### PR TITLE
Add visible cursor block and enhanced keyboard navigation

### DIFF
--- a/src/c.zig
+++ b/src/c.zig
@@ -66,6 +66,7 @@ pub const SDLK_RIGHTBRACKET = c_import.SDLK_RIGHTBRACKET;
 pub const SDL_KMOD_CTRL = c_import.SDL_KMOD_CTRL;
 pub const SDL_KMOD_SHIFT = c_import.SDL_KMOD_SHIFT;
 pub const SDL_KMOD_GUI = c_import.SDL_KMOD_GUI;
+pub const SDL_KMOD_ALT = c_import.SDL_KMOD_ALT;
 pub const SDL_PIXELFORMAT_RGBA8888 = c_import.SDL_PIXELFORMAT_RGBA8888;
 pub const SDL_TEXTUREACCESS_TARGET = c_import.SDL_TEXTUREACCESS_TARGET;
 


### PR DESCRIPTION
## Summary

This PR adds a visible cursor block to terminals and implements comprehensive keyboard shortcuts for efficient text editing, matching standard macOS/readline behavior.

## Changes

### 1. Visible Cursor Block
- Renders a light gray block cursor at the current cursor position
- Only displayed when terminal is focused and viewing live content (not scrolled)
- Properly scaled for both grid view (1/3 scale) and full-screen view
- Uses ghostty-vt's `screen.cursor` for accurate positioning

### 2. Enhanced Keyboard Navigation
Implemented the following shortcuts using standard readline control sequences:

**Cursor Movement:**
- `Alt+Left` / `Alt+Right`: Move word-by-word (ESC+b/f)
- `Cmd+Left` / `Cmd+Right`: Jump to beginning/end of line (Ctrl+A/E)

**Deletion:**
- `Alt+Backspace`: Delete previous word (Ctrl+W)
- `Cmd+Backspace`: Delete from cursor to line start (Ctrl+U)

### 3. Technical Implementation
- Modified `encodeKeyWithMod()` to handle GUI and Alt modifiers
- Added `SDL_KMOD_ALT` binding to `c.zig`
- All shortcuts work with bash, zsh, and other readline-compatible shells
- Comprehensive test coverage for all new keyboard shortcuts

## Testing
- ✅ All existing tests pass
- ✅ New tests added for all keyboard shortcuts
- ✅ Build successful with no warnings
- ✅ Cursor renders correctly in both grid and full-screen modes

## Original Request
> I can't see the cursor block in the terminal. Please add it. Then add the ability to move cursor word-by-word with Alt+Left/Right and to the beginning/end of the line with Cmd+Left/Right. Finally, add Cmd+Backspace to delete the line and Alt+Backspace to delete the word.