### PR TITLE
Add visual toast notifications for hotkey feedback

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -135,7 +135,7 @@ const ToastNotification = struct {
             return 255;
         }
         const fade_progress = @as(f32, @floatFromInt(elapsed - NOTIFICATION_FADE_START_MS)) /
-                             @as(f32, @floatFromInt(NOTIFICATION_DURATION_MS - NOTIFICATION_FADE_START_MS));
+            @as(f32, @floatFromInt(NOTIFICATION_DURATION_MS - NOTIFICATION_FADE_START_MS));
         const eased_progress = fade_progress * fade_progress * (3.0 - 2.0 * fade_progress);
         const alpha = 255.0 * (1.0 - eased_progress);
         return @intFromFloat(@max(0, @min(255, alpha)));
@@ -503,7 +503,7 @@ pub fn main() !void {
 
                         var notification_buf: [64]u8 = undefined;
                         const hotkey = if (direction == .increase) "⌘⇧+" else "⌘⇧-";
-                        const notification_msg = std.fmt.bufPrint(&notification_buf, "{s}  Font size: {d}pt", .{hotkey, font_size}) catch "Font size changed";
+                        const notification_msg = std.fmt.bufPrint(&notification_buf, "{s}  Font size: {d}pt", .{ hotkey, font_size }) catch "Font size changed";
                         toast_notification.show(notification_msg, now);
                     } else if (isSwitchTerminalShortcut(key, mod)) |is_next| {
                         if (anim_state.mode == .Full) {
@@ -521,7 +521,7 @@ pub fn main() !void {
 
                             var notification_buf: [64]u8 = undefined;
                             const hotkey = if (is_next) "⌘⇧]" else "⌘⇧[";
-                            const notification_msg = std.fmt.bufPrint(&notification_buf, "{s}  Terminal {d}", .{hotkey, new_session}) catch "Terminal switched";
+                            const notification_msg = std.fmt.bufPrint(&notification_buf, "{s}  Terminal {d}", .{ hotkey, new_session }) catch "Terminal switched";
                             toast_notification.show(notification_msg, now);
                         }
                     } else if (key == c.SDLK_ESCAPE and anim_state.mode == .Full) {


### PR DESCRIPTION
This PR adds a toast notification system that provides visual feedback when users press hotkeys.

## Changes

- **Toast Notification System**: New `ToastNotification` struct with automatic fade-out animation (2.5s total: 1.5s visible, 1s fade)
- **Visual Design**: Large centered text (fixed 36pt) at top of window with semi-transparent dark background and blue border
- **Font Size Notifications**: Shows "⌘⇧+  Font size: XXpt" or "⌘⇧-  Font size: XXpt" when adjusting font
- **Terminal Switching Notifications**: Shows "⌘⇧]  Terminal X" or "⌘⇧[  Terminal X" when switching terminals
- **Increased Font Size Limit**: Maximum font size raised from 32pt to 96pt

## Implementation Details

The notification system:
- Uses smooth alpha-based fade transition with cubic easing
- Renders on top of all terminal content using SDL3 text rendering
- Shows feedback even when font size limits are reached (so users know they've hit the max/min)
- Displays Mac keyboard symbols (⌘ for Command, ⇧ for Shift) alongside the action

## Testing

- Build and tests pass successfully
- Notifications appear for all hotkey actions and fade smoothly