### PR TITLE
Add animated help button with keyboard shortcuts overlay

### DIFF
--- a/src/render/renderer.zig
+++ b/src/render/renderer.zig
@@ -11,6 +11,7 @@ const SessionState = session_state.SessionState;
 const Rect = app_state.Rect;
 const AnimationState = app_state.AnimationState;
 const ToastNotification = app_state.ToastNotification;
+const HelpButtonAnimation = app_state.HelpButtonAnimation;
 
 const FONT_PATH: [*:0]const u8 = "/System/Library/Fonts/SFNSMono.ttf";
 const NOTIFICATION_FONT_SIZE: c_int = 36;
@@ -525,6 +526,143 @@ pub fn renderToastNotification(
     };
 
     _ = c.SDL_RenderTexture(renderer, texture, null, &dest_rect);
+}
+
+pub fn renderHelpButton(
+    renderer: *c.SDL_Renderer,
+    help_button: *const HelpButtonAnimation,
+    current_time: i64,
+    window_width: c_int,
+    window_height: c_int,
+) void {
+    const rect = help_button.getRect(current_time, window_width, window_height);
+    const radius: c_int = 8;
+
+    _ = c.SDL_SetRenderDrawBlendMode(renderer, c.SDL_BLENDMODE_BLEND);
+    _ = c.SDL_SetRenderDrawColor(renderer, 40, 40, 50, 220);
+    const bg_rect = c.SDL_FRect{
+        .x = @floatFromInt(rect.x),
+        .y = @floatFromInt(rect.y),
+        .w = @floatFromInt(rect.w),
+        .h = @floatFromInt(rect.h),
+    };
+    _ = c.SDL_RenderFillRect(renderer, &bg_rect);
+
+    _ = c.SDL_SetRenderDrawColor(renderer, 100, 150, 255, 255);
+    drawRoundedBorder(renderer, rect, radius);
+
+    if (help_button.state == .Closed or help_button.state == .Collapsing or help_button.state == .Expanding) {
+        const font_size = @max(16, @min(32, @divFloor(rect.h * 3, 4)));
+        const question_font = c.TTF_OpenFont(FONT_PATH, @floatFromInt(font_size)) orelse return;
+        defer c.TTF_CloseFont(question_font);
+
+        const question_mark: [2]u8 = .{ '?', 0 };
+        const fg_color = c.SDL_Color{ .r = 200, .g = 200, .b = 200, .a = 255 };
+        const surface = c.TTF_RenderText_Blended(question_font, &question_mark, 1, fg_color) orelse return;
+        defer c.SDL_DestroySurface(surface);
+
+        const texture = c.SDL_CreateTextureFromSurface(renderer, surface) orelse return;
+        defer c.SDL_DestroyTexture(texture);
+
+        var text_width_f: f32 = 0;
+        var text_height_f: f32 = 0;
+        _ = c.SDL_GetTextureSize(texture, &text_width_f, &text_height_f);
+
+        const text_x = rect.x + @divFloor(rect.w - @as(c_int, @intFromFloat(text_width_f)), 2);
+        const text_y = rect.y + @divFloor(rect.h - @as(c_int, @intFromFloat(text_height_f)), 2);
+
+        const dest_rect = c.SDL_FRect{
+            .x = @floatFromInt(text_x),
+            .y = @floatFromInt(text_y),
+            .w = text_width_f,
+            .h = text_height_f,
+        };
+        _ = c.SDL_RenderTexture(renderer, texture, null, &dest_rect);
+    } else if (help_button.state == .Open) {
+        const title_font_size: c_int = 20;
+        const key_font_size: c_int = 16;
+        const padding: c_int = 20;
+        const line_height: c_int = 28;
+        var y_offset: c_int = rect.y + padding;
+
+        const title_font = c.TTF_OpenFont(FONT_PATH, @floatFromInt(title_font_size)) orelse return;
+        defer c.TTF_CloseFont(title_font);
+
+        const key_font = c.TTF_OpenFont(FONT_PATH, @floatFromInt(key_font_size)) orelse return;
+        defer c.TTF_CloseFont(key_font);
+
+        const title_text = "Keyboard Shortcuts";
+        const title_color = c.SDL_Color{ .r = 200, .g = 200, .b = 200, .a = 255 };
+        const title_surface = c.TTF_RenderText_Blended(title_font, title_text, title_text.len, title_color) orelse return;
+        defer c.SDL_DestroySurface(title_surface);
+
+        const title_texture = c.SDL_CreateTextureFromSurface(renderer, title_surface) orelse return;
+        defer c.SDL_DestroyTexture(title_texture);
+
+        var title_width_f: f32 = 0;
+        var title_height_f: f32 = 0;
+        _ = c.SDL_GetTextureSize(title_texture, &title_width_f, &title_height_f);
+
+        const title_x = rect.x + @divFloor(rect.w - @as(c_int, @intFromFloat(title_width_f)), 2);
+        _ = c.SDL_RenderTexture(renderer, title_texture, null, &c.SDL_FRect{
+            .x = @floatFromInt(title_x),
+            .y = @floatFromInt(y_offset),
+            .w = title_width_f,
+            .h = title_height_f,
+        });
+
+        y_offset += @as(c_int, @intFromFloat(title_height_f)) + line_height;
+
+        const shortcuts = [_]struct { key: []const u8, desc: []const u8 }{
+            .{ .key = "Click terminal", .desc = "Expand to full screen" },
+            .{ .key = "ESC (hold)", .desc = "Collapse to grid view" },
+            .{ .key = "⌘⇧[ / ⌘⇧]", .desc = "Switch terminals" },
+            .{ .key = "⌘↑/↓/←/→", .desc = "Navigate grid" },
+            .{ .key = "⌘⇧+ / ⌘⇧-", .desc = "Adjust font size" },
+            .{ .key = "Mouse wheel", .desc = "Scroll history" },
+        };
+
+        const key_color = c.SDL_Color{ .r = 120, .g = 170, .b = 255, .a = 255 };
+        const desc_color = c.SDL_Color{ .r = 180, .g = 180, .b = 180, .a = 255 };
+
+        for (shortcuts) |shortcut| {
+            const key_surface = c.TTF_RenderText_Blended(key_font, shortcut.key.ptr, shortcut.key.len, key_color) orelse continue;
+            defer c.SDL_DestroySurface(key_surface);
+
+            const key_texture = c.SDL_CreateTextureFromSurface(renderer, key_surface) orelse continue;
+            defer c.SDL_DestroyTexture(key_texture);
+
+            var key_width_f: f32 = 0;
+            var key_height_f: f32 = 0;
+            _ = c.SDL_GetTextureSize(key_texture, &key_width_f, &key_height_f);
+
+            _ = c.SDL_RenderTexture(renderer, key_texture, null, &c.SDL_FRect{
+                .x = @floatFromInt(rect.x + padding),
+                .y = @floatFromInt(y_offset),
+                .w = key_width_f,
+                .h = key_height_f,
+            });
+
+            const desc_surface = c.TTF_RenderText_Blended(key_font, shortcut.desc.ptr, shortcut.desc.len, desc_color) orelse continue;
+            defer c.SDL_DestroySurface(desc_surface);
+
+            const desc_texture = c.SDL_CreateTextureFromSurface(renderer, desc_surface) orelse continue;
+            defer c.SDL_DestroyTexture(desc_texture);
+
+            var desc_width_f: f32 = 0;
+            var desc_height_f: f32 = 0;
+            _ = c.SDL_GetTextureSize(desc_texture, &desc_width_f, &desc_height_f);
+
+            _ = c.SDL_RenderTexture(renderer, desc_texture, null, &c.SDL_FRect{
+                .x = @floatFromInt(rect.x + rect.w - padding - @as(c_int, @intFromFloat(desc_width_f))),
+                .y = @floatFromInt(y_offset),
+                .w = desc_width_f,
+                .h = desc_height_f,
+            });
+
+            y_offset += line_height;
+        }
+    }
 }
 
 fn getCellColor(color: ghostty_vt.Style.Color, default: c.SDL_Color) c.SDL_Color {


### PR DESCRIPTION
## Summary
- Adds an animated help button in the top right corner with a "?" icon
- Expands into a 400x400px overlay displaying all keyboard shortcuts when clicked
- Closes when clicking outside the overlay or clicking the button again
- Uses smooth cubic ease-in-out animation (200ms)

## Changes
- **app_state.zig**: Added `HelpButtonState` enum and `HelpButtonAnimation` struct with animation logic
- **renderer.zig**: Added `renderHelpButton()` function that renders the button and overlay with hotkey information
- **main.zig**: Added mouse click handling for button interaction and animation state management

## Visual Behavior
1. Small rounded square (40x40px) with "?" in top right corner
2. Click to expand - shows "?" during animation
3. Fully expanded (400x400px) - displays keyboard shortcuts:
   - Click terminal → Expand to full screen
   - ESC (hold) → Collapse to grid view
   - ⌘⇧[ / ⌘⇧] → Switch terminals
   - ⌘↑/↓/←/→ → Navigate grid
   - ⌘⇧+ / ⌘⇧- → Adjust font size
   - Mouse wheel → Scroll history
4. Click anywhere outside or on button to collapse

## Test Plan
- [x] Build passes: `zig build`
- [x] Tests pass: `zig build test`
- [x] Code formatted: `zig fmt src/`
- [x] Button appears in top right corner
- [x] Click button opens overlay with animation
- [x] Click outside closes overlay
- [x] Text only appears after expansion completes