### PR TITLE
Fix edge clipping and add dead-session restart UX in terminal grid

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -384,8 +384,7 @@ pub fn main() !void {
                     const mouse_y: c_int = @intFromFloat(event.button.y);
 
                     const help_rect = help_button.getRect(now, window_width, window_height);
-                    const clicked_help = mouse_x >= help_rect.x and mouse_x < help_rect.x + help_rect.w and
-                        mouse_y >= help_rect.y and mouse_y < help_rect.y + help_rect.h;
+                    const clicked_help = renderer_mod.isPointInRect(mouse_x, mouse_y, help_rect);
 
                     if (clicked_help) {
                         if (help_button.state == .Closed) {
@@ -413,8 +412,7 @@ pub fn main() !void {
                         var clicked_restart = false;
                         if (sessions[clicked_session].dead) {
                             const restart_rect = renderer_mod.getRestartButtonRect(cell_rect);
-                            clicked_restart = mouse_x >= restart_rect.x and mouse_x < restart_rect.x + restart_rect.w and
-                                mouse_y >= restart_rect.y and mouse_y < restart_rect.y + restart_rect.h;
+                            clicked_restart = renderer_mod.isPointInRect(mouse_x, mouse_y, restart_rect);
                         }
 
                         if (clicked_restart) {

--- a/src/session/state.zig
+++ b/src/session/state.zig
@@ -27,6 +27,9 @@ pub const SessionState = struct {
     cache_texture: ?*c.SDL_Texture = null,
     cache_w: c_int = 0,
     cache_h: c_int = 0,
+    restart_button_texture: ?*c.SDL_Texture = null,
+    restart_button_w: c_int = 0,
+    restart_button_h: c_int = 0,
     spawned: bool = false,
     dead: bool = false,
     shell_path: []const u8,
@@ -113,6 +116,9 @@ pub const SessionState = struct {
         if (self.cache_texture) |tex| {
             c.SDL_DestroyTexture(tex);
         }
+        if (self.restart_button_texture) |tex| {
+            c.SDL_DestroyTexture(tex);
+        }
         if (self.spawned) {
             if (self.stream) |*stream| {
                 stream.deinit();
@@ -149,6 +155,10 @@ pub const SessionState = struct {
             if (result > 0) {
                 self.dead = true;
                 self.dirty = true;
+                if (self.restart_button_texture) |tex| {
+                    c.SDL_DestroyTexture(tex);
+                    self.restart_button_texture = null;
+                }
                 log.info("session {d} process exited", .{self.id});
             }
         }
@@ -170,6 +180,11 @@ pub const SessionState = struct {
                 shell.deinit();
                 self.shell = null;
             }
+        }
+
+        if (self.restart_button_texture) |tex| {
+            c.SDL_DestroyTexture(tex);
+            self.restart_button_texture = null;
         }
 
         self.spawned = false;


### PR DESCRIPTION
## Summary
- ensure terminal size calculations subtract render padding so the last row/column remains visible at all font sizes
- keep PTY pixel hints consistent with drawable area during init and resize
- allow rendering of partially visible glyphs/cursor at edges; hide cursor for dead sessions and show a "[Process completed]" banner
- add "Restart" button overlay for dead sessions and handle restart clicks; track session liveness with checkAlive/dead flag and restart helper
- guard input paths against dead sessions to avoid writes after exit

## Testing
- zig build
- zig build test