### PR TITLE
Remove multiline paste confirmation and enable immediate paste

### DIFF
--- a/src/font_paths.zig
+++ b/src/font_paths.zig
@@ -53,7 +53,7 @@ pub const FontPaths = struct {
         }
 
         if (builtin.os.tag == .macos) {
-            paths.symbol_fallback = try allocator.dupeZ(u8, "/System/Library/Fonts/SFNSMono.ttf");
+            paths.symbol_fallback = try allocator.dupeZ(u8, "/System/Library/Fonts/Supplemental/Arial Unicode.ttf");
             paths.emoji_fallback = try allocator.dupeZ(u8, "/System/Library/Fonts/Apple Color Emoji.ttc");
         } else {
             paths.symbol_fallback = null;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1116,11 +1116,6 @@ fn pasteClipboardIntoSession(
         return;
     }
 
-    if (!ghostty_vt.input.isSafePaste(clip)) {
-        ui.showToast("Clipboard blocked (unsafe paste)", now);
-        return;
-    }
-
     const opts = ghostty_vt.input.PasteOptions.fromTerminal(&terminal);
     const clip_buf = try allocator.dupe(u8, clip);
     defer allocator.free(clip_buf);

--- a/src/ui/components/toast.zig
+++ b/src/ui/components/toast.zig
@@ -12,6 +12,8 @@ pub const ToastComponent = struct {
     message_len: usize = 0,
 
     font: ?*c.TTF_Font = null,
+    symbol_fallback: ?*c.TTF_Font = null,
+    emoji_fallback: ?*c.TTF_Font = null,
     texture: ?*c.SDL_Texture = null,
     tex_w: c_int = 0,
     tex_h: c_int = 0,
@@ -51,6 +53,14 @@ pub const ToastComponent = struct {
         if (self.texture) |tex| {
             c.SDL_DestroyTexture(tex);
             self.texture = null;
+        }
+        if (self.emoji_fallback) |f| {
+            c.TTF_CloseFont(f);
+            self.emoji_fallback = null;
+        }
+        if (self.symbol_fallback) |f| {
+            c.TTF_CloseFont(f);
+            self.symbol_fallback = null;
         }
         if (self.font) |f| {
             c.TTF_CloseFont(f);
@@ -124,6 +134,26 @@ pub const ToastComponent = struct {
         if (self.font == null) {
             self.font = c.TTF_OpenFont(font_path.ptr, @floatFromInt(NOTIFICATION_FONT_SIZE));
             if (self.font == null) return error.FontUnavailable;
+
+            if (assets.symbol_fallback_path) |symbol_path| {
+                self.symbol_fallback = c.TTF_OpenFont(symbol_path.ptr, @floatFromInt(NOTIFICATION_FONT_SIZE));
+                if (self.symbol_fallback) |s| {
+                    if (!c.TTF_AddFallbackFont(self.font.?, s)) {
+                        c.TTF_CloseFont(s);
+                        self.symbol_fallback = null;
+                    }
+                }
+            }
+
+            if (assets.emoji_fallback_path) |emoji_path| {
+                self.emoji_fallback = c.TTF_OpenFont(emoji_path.ptr, @floatFromInt(NOTIFICATION_FONT_SIZE));
+                if (self.emoji_fallback) |e| {
+                    if (!c.TTF_AddFallbackFont(self.font.?, e)) {
+                        c.TTF_CloseFont(e);
+                        self.emoji_fallback = null;
+                    }
+                }
+            }
         }
         const toast_font = self.font.?;
 


### PR DESCRIPTION
## Summary
- Removes all multiline paste confirmation logic to enable immediate pasting
- Removes `isSafePaste` check that was blocking multiline clipboard content
- Removes pending paste UI state, keyboard handlers, and visual overlays
- Updates toast component with symbol/emoji fallback font support
- Changes macOS symbol fallback font to Arial Unicode

## Context
Previously, multiline clipboard content triggered a confirmation flow requiring the user to press Enter to submit or Esc to cancel. This change removes that confirmation entirely, allowing all clipboard content to paste immediately without any blocking or safety checks.

## Changes
- **src/main.zig**: Removed pending paste keyboard handlers (Enter/Esc), removed `isSafePaste` check, removed `commitPendingPaste` and `cancelPendingPaste` functions
- **src/session/state.zig**: Removed `pending_paste` field and its cleanup from `deinit()`
- **src/render/renderer.zig**: Removed pulsing blue border overlay for pending paste state
- **src/ui/components/toast.zig**: Added symbol and emoji fallback font support
- **src/font_paths.zig**: Updated macOS symbol fallback font path to Arial Unicode

## Test plan
- [x] Build succeeds (`zig build`)
- [x] Tests pass (`zig build test`)
- [ ] Manual test: Copy multiline text and paste with Cmd+V - should paste immediately
- [ ] Manual test: Copy single-line text and paste - should work as before
- [ ] Manual test: Verify toast notifications appear correctly with fallback fonts