### PR TITLE
Simplify Homebrew formula - remove pre-fetch complexity

### DIFF
--- a/Formula/architect.rb
+++ b/Formula/architect.rb
@@ -9,19 +9,9 @@ class Architect < Formula
   depends_on "zig" => :build
   depends_on "sdl3"
   depends_on "sdl3_ttf"
-
-  resource "ghostty" do
-    url "https://github.com/ghostty-org/ghostty/archive/f705b9f46a4083d8053cfa254898c164af46ff34.tar.gz"
-    sha256 "a3588866217e11940a89a4e383955aa97b0dc9ebfd3a8b2fb92107e3fbf69276"
-  end
+  depends_on xcode: :build
 
   def install
-    ENV["ZIG_GLOBAL_CACHE_DIR"] = buildpath/"zig-cache"
-
-    system "zig", "fetch",
-           "--global-cache-dir", ENV["ZIG_GLOBAL_CACHE_DIR"],
-           resource("ghostty").cached_download
-
     system "zig", "build",
            "-Doptimize=ReleaseFast",
            "--prefix", prefix


### PR DESCRIPTION
## Problem
The formula was failing during build with SDK detection errors when trying to pre-fetch and cache the Ghostty dependency.

## Root Cause
The complex pre-fetch approach was unnecessary - Zig's package manager can handle fetching dependencies during build, and Homebrew allows network access in the build phase as long as checksums in `build.zig.zon` are verified.

## Solution
- Remove the `resource "ghostty"` block
- Remove manual `zig fetch` pre-seeding
- Remove `ZIG_GLOBAL_CACHE_DIR` override
- Add `depends_on xcode: :build` to ensure SDK is available
- Let Zig package manager fetch Ghostty naturally from `build.zig.zon`

## Benefits
- Simpler, cleaner formula
- Follows standard Zig/Homebrew patterns
- Avoids SDK detection issues
- Easier to maintain - formula auto-updates only need to change version/SHA256 of main project

## Testing
This should resolve the SDK detection error and allow successful installation.