### PR TITLE
Fix Homebrew formula audit issues

### DIFF
--- a/Formula/architect.rb
+++ b/Formula/architect.rb
@@ -7,9 +7,9 @@ class Architect < Formula
 
   depends_on "pkg-config" => :build
   depends_on "zig" => :build
+  depends_on xcode: :build
   depends_on "sdl3"
   depends_on "sdl3_ttf"
-  depends_on xcode: :build
 
   def install
     system "zig", "build",
@@ -18,6 +18,6 @@ class Architect < Formula
   end
 
   test do
-    assert_predicate bin/"architect", :exist?
+    assert_path_exists bin/"architect"
   end
 end


### PR DESCRIPTION
## Audit Findings

Running `brew audit --strict --online forketyfork/architect/architect` revealed 2 style issues:

1. **Dependency ordering**: xcode dependency should come before runtime dependencies
2. **Test assertion**: Should use `assert_path_exists` instead of `assert_predicate`

## Changes

- Moved `depends_on xcode: :build` to line 10 (before sdl3)
- Changed test from `assert_predicate bin/"architect", :exist?` to `assert_path_exists bin/"architect"`

## Verification

After these changes, `brew audit --strict` passes without warnings.