### PR TITLE
Improve CI stability for Zig downloads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           for i in 1 2 3; do
             nix develop --command just setup && break
+            if [ $i -eq 3 ]; then exit 1; fi
             sleep 5
           done
         working-directory: architect
@@ -52,6 +53,7 @@ jobs:
         run: |
           for i in 1 2 3; do
             nix develop --command just build && break
+            if [ $i -eq 3 ]; then exit 1; fi
             sleep 5
           done
         working-directory: architect
@@ -60,6 +62,7 @@ jobs:
         run: |
           for i in 1 2 3; do
             nix develop --command just test && break
+            if [ $i -eq 3 ]; then exit 1; fi
             sleep 5
           done
         working-directory: architect
@@ -68,6 +71,7 @@ jobs:
         run: |
           for i in 1 2 3; do
             nix develop --command just lint && break
+            if [ $i -eq 3 ]; then exit 1; fi
             sleep 5
           done
         working-directory: architect

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,6 +62,7 @@ jobs:
         run: |
           for i in 1 2 3; do
             nix develop --command just setup && break
+            if [ $i -eq 3 ]; then exit 1; fi
             sleep 5
           done
         working-directory: architect
@@ -70,6 +71,7 @@ jobs:
         run: |
           for i in 1 2 3; do
             nix develop --command zig build -Doptimize=ReleaseFast && break
+            if [ $i -eq 3 ]; then exit 1; fi
             sleep 5
           done
         working-directory: architect


### PR DESCRIPTION
## Summary\n- align Zig global/local cache to a workspace path so prefetch and build share cache\n- cache Zig package downloads via actions/cache keyed by build.zig.zon and platform\n- add simple three-try retries around prefetch and build steps to smooth over transient network errors\n\n## Testing\n- XDG_CACHE_HOME=/Users/sergei.petunin/dev/github/forketyfork/architect/.cache nix develop --command just ci *(fails: ghostty build expects tagged release version when building locally)*