### PR TITLE
Stop ghostty from mis-reading architect release tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,9 @@ jobs:
     env:
       ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/architect/.zig-cache
       ZIG_LOCAL_CACHE_DIR: ${{ github.workspace }}/architect/.zig-cache/local
+      # Prevent ghostty (dependency) from reading the repository git tag of Architect
+      # and thinking it is its own release tag.
+      GIT_CEILING_DIRECTORIES: ${{ github.workspace }}/architect/.zig-cache
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary\n- set GIT_CEILING_DIRECTORIES during release build so ghostty's Git detection cannot see the Architect tag\n- avoids ghostty panicking on tagged releases when used as a dependency\n\n## Testing\n- Not run (CI-only workflow change)