### PR TITLE
grid selection tint priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ zig fmt src/
 
 ## AI Assistant Integration
 
-Architect integrates with AI coding assistants through a Unix domain socket protocol. Grid tiles automatically highlight when an assistant is waiting for approval (pulsing yellow border) or has completed a task (solid green border).
+Architect integrates with AI coding assistants through a Unix domain socket protocol. In grid view the selected tile gets a subtle blue tint; if a notification is active, the yellow/green highlight takes priority over the selection tint. Waiting-for-approval shows a pulsing yellow border, and completion shows a solid green border.
 
 ### Socket Protocol
 


### PR DESCRIPTION
## Summary
- keep grid selection border visible alongside attention highlights
- deepen done-state green tint to separate it from yellow
- document grid highlight priority in README

## Solution
Thickened grid selection borders to match attention width and always render a blue border (inset when attention is present) so focus remains visible even when yellow/green highlights are active. Adjusted the done-state tint to a deeper green while preserving the pulsing yellow for awaiting approval, and documented the grid highlight priority for users.

## Testing
- zig build
- zig build test
