### PR TITLE
trackpad scroll precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See [Setup](#setup) section below for building from source.
   - Type in the focused terminal
   - Visual feedback indicator appears briefly when hotkeys are pressed
 - **Keyboard Navigation**: Move the grid focus with ⌘↑/↓/←/→ and open the on-screen shortcut overlay via the ? pill in the top-right corner
-- **Scrollback in Place**: Hover any terminal and use the mouse wheel to scroll history; typing snaps back to live output and a yellow strip in grid view shows when you're scrolled (10 MB per terminal, matching Ghostty's default)
+- **Scrollback in Place**: Hover any terminal and use the mouse wheel or a trackpad to scroll history; small high-precision gestures accumulate via SDL's integer wheel deltas, typing snaps back to live output, and a yellow strip in grid view shows when you're scrolled (10 MB per terminal, matching Ghostty's default)
 - **High-Quality Rendering**: SDL_ttf font rendering with SFNSMono (default system monospace font on macOS), glyph caching, vsync-aligned presentation (renders at display refresh rate), and cached grid tiles to reduce redraw work
 - **Persistent State**: Automatically saves and restores window position/size and font size; user configuration is read-only and edited via Cmd+,
 - **Font Size Adjustment**: Use Cmd+Plus/Minus (8–96px) to adjust font size (saved automatically)

--- a/src/main.zig
+++ b/src/main.zig
@@ -888,8 +888,12 @@ pub fn main() !void {
                     );
 
                     if (hovered_session) |session_idx| {
-                        const raw_delta = scaled_event.wheel.y;
-                        const scroll_delta = -@as(isize, @intFromFloat(raw_delta * @as(f32, @floatFromInt(SCROLL_LINES_PER_TICK))));
+                        const ticks_per_notch: isize = SCROLL_LINES_PER_TICK;
+                        const wheel_ticks: isize = if (scaled_event.wheel.integer_y != 0)
+                            @as(isize, @intCast(scaled_event.wheel.integer_y)) * ticks_per_notch
+                        else
+                            @as(isize, @intFromFloat(scaled_event.wheel.y * @as(f32, @floatFromInt(SCROLL_LINES_PER_TICK))));
+                        const scroll_delta = -wheel_ticks;
                         if (scroll_delta != 0) {
                             scrollSession(&sessions[session_idx], scroll_delta, now);
                             // If the wheel event originates from a touch/trackpad


### PR DESCRIPTION
## Summary
- Restore trackpad scroll sensitivity after SDL 3.4 migration by consuming wheel integer ticks.
- Maintain scroll line scaling and inertia behavior; document trackpad scrolling support.

## Solution
- Use SDL MouseWheelEvent.integer_y (added in 3.2.12) to accumulate high-precision deltas and convert to line scrolls.
- Apply lines-per-tick multiplier and sign flip for terminal scroll direction; fallback to float deltas when integer_y is zero.
- Update README scrollback description to mention trackpad/high-precision gestures.
