### PR TITLE
fix: add Shift+Tab and Shift+Enter escape sequences for Claude Code

### DIFF
--- a/src/input/mapper.zig
+++ b/src/input/mapper.zig
@@ -145,9 +145,9 @@ pub fn encodeKeyWithMod(key: c.SDL_Keycode, mod: c.SDL_Keymod, buf: []u8) usize 
                 break :blk 3;
             },
             c.SDLK_RETURN => blk: {
-                // Shift+Enter: send carriage return (fallback until protocol negotiation)
-                buf[0] = '\r';
-                break :blk 1;
+                // Shift+Enter: send CSI u encoding (ESC [ 13 ; 2 u)
+                @memcpy(buf[0..7], "\x1b[13;2u");
+                break :blk 7;
             },
             else => 0,
         };


### PR DESCRIPTION
Previously, the terminal would send plain Tab (\t) and Enter (\r) regardless
of the Shift modifier, breaking applications like Claude Code that rely on
these key combinations (Shift+Tab for mode switching, Shift+Enter for
multiline input).

Now:
- Shift+Tab sends CSI Z (\x1b[Z) - standard backtab sequence
- Shift+Enter sends CSI u (\x1b[13;2u) - kitty keyboard protocol encoding