### PR TITLE
keep grid border during expand/collapse

### DIFF
--- a/src/render/renderer.zig
+++ b/src/render/renderer.zig
@@ -200,7 +200,7 @@ pub fn render(
 
             const apply_effects = anim_scale < 0.999;
             const entry = render_cache.entry(anim_state.focused_session);
-            try renderSession(renderer, sessions[anim_state.focused_session], &views[anim_state.focused_session], entry, animating_rect, anim_scale, true, apply_effects, font, term_cols, term_rows, current_time, false, theme);
+            try renderSession(renderer, sessions[anim_state.focused_session], &views[anim_state.focused_session], entry, animating_rect, anim_scale, true, apply_effects, font, term_cols, term_rows, current_time, true, theme);
         },
         .GridResizing => {
             // Render session contents first so borders draw on top.


### PR DESCRIPTION
Solution:\n- Render the focused session overlays in grid mode during expand/collapse so the grid border draws throughout the animation.\n- Keeps the focused terminal border visible during transitions (notably in 2x2 grids where the focused cell quickly occludes the others).