### PR TITLE
fix: correct paths-filter pattern for markdown files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           filters: |
             code:
               - '**'
-              - '!*.md'
+              - '!**/*.md'
               - '!docs/**'
 
   build-matrix:


### PR DESCRIPTION
## Summary
- Fixed CI paths-filter glob pattern to correctly skip builds for documentation-only changes

## Problem
Documentation-only PRs (like PR #159 which only edited README.md) were triggering full CI builds. Investigation showed the `dorny/paths-filter` action was incorrectly detecting `code = true` for markdown file changes.

The root cause: the exclusion pattern `!*.md` wasn't working as expected due to picomatch glob behavior—it wasn't matching root-level markdown files like `README.md`.

## Solution
Changed the exclusion pattern from `!*.md` to `!**/*.md`, which correctly matches markdown files at any path level in the repository.

## Test plan
- [ ] Verify this PR's `changes` job outputs `Filter code = true` (since it modifies a YAML file)
- [ ] Create a test PR that only modifies a markdown file and verify `Filter code = false` and build-matrix jobs are skipped