### PR TITLE
fix: improve grid navigation wraparound and notification UX

### DIFF
--- a/src/app/grid_nav.zig
+++ b/src/app/grid_nav.zig
@@ -168,6 +168,20 @@ pub fn navigateGrid(
         }
     }
 
+    if (direction == .left and is_wrapping and new_session < sessions.len and !sessions[new_session].spawned) {
+        var col_idx: usize = grid_cols;
+        while (col_idx > 0) {
+            col_idx -= 1;
+            const candidate = new_row * grid_cols + col_idx;
+            if (candidate >= sessions.len) continue;
+            if (sessions[candidate].spawned) {
+                new_col = col_idx;
+                new_session = candidate;
+                break;
+            }
+        }
+    }
+
     if (new_session != current_session) {
         if (anim_state.mode == .Full) {
             try sessions[new_session].ensureSpawnedWithLoop(loop);

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -1267,6 +1267,9 @@ pub fn run() !void {
                         std.debug.print("Expanding session: {d}\n", .{clicked_session});
                     } else if (focused.spawned and !focused.dead and !input_keys.isModifierKey(key)) {
                         session_interaction_component.resetScrollIfNeeded(anim_state.focused_session);
+                        if (anim_state.mode == .Grid) {
+                            session_interaction_component.setAttention(anim_state.focused_session, false);
+                        }
                         try input_keys.handleKeyInput(focused, key, mod);
                     }
                 },

--- a/src/render/renderer.zig
+++ b/src/render/renderer.zig
@@ -660,11 +660,11 @@ fn renderSessionOverlays(
         primitives.drawThickBorder(renderer, rect, ATTENTION_THICKNESS, color);
 
         const tint_color = switch (view.status) {
-            .awaiting_approval => c.SDL_Color{ .r = yellow.r, .g = yellow.g, .b = yellow.b, .a = 25 },
+            .awaiting_approval => c.SDL_Color{ .r = yellow.r, .g = yellow.g, .b = yellow.b, .a = 55 },
             .done => blk: {
-                break :blk c.SDL_Color{ .r = done_green.r, .g = done_green.g, .b = done_green.b, .a = 35 };
+                break :blk c.SDL_Color{ .r = done_green.r, .g = done_green.g, .b = done_green.b, .a = 55 };
             },
-            else => c.SDL_Color{ .r = yellow.r, .g = yellow.g, .b = yellow.b, .a = 25 },
+            else => c.SDL_Color{ .r = yellow.r, .g = yellow.g, .b = yellow.b, .a = 55 },
         };
         _ = c.SDL_SetRenderDrawBlendMode(renderer, c.SDL_BLENDMODE_BLEND);
         _ = c.SDL_SetRenderDrawColor(renderer, tint_color.r, tint_color.g, tint_color.b, tint_color.a);


### PR DESCRIPTION
## Summary

- Fix Cmd+left wraparound to land on rightmost spawned terminal
- Clear notification highlighting on any key press (not just text input)
- Increase notification tint visibility

## Solution

**Grid navigation wraparound** (`src/app/grid_nav.zig`): When pressing Cmd+left from the leftmost column (column 0), the navigation now searches backward from the last column to find the rightmost spawned terminal, rather than unconditionally landing on the last cell which might be empty.

**Notification clearing on key press** (`src/app/runtime.zig`): Previously, only `SDL_EVENT_TEXT_INPUT` events cleared the notification attention flag. Keys like Enter, Tab, and arrow keys only generate `SDL_EVENT_KEY_DOWN` events (no TEXT_INPUT), so they didn't clear the highlighting. Now any key forwarded to the terminal in Grid mode clears the attention.

**Notification tint visibility** (`src/render/renderer.zig`): Increased the alpha value of the notification overlay tint from 25/35 to 55, making the yellow (awaiting approval / running) and green (done) highlights more visible while still being subtle enough not to obscure terminal content.