### PR TITLE
chore: bump ghostty-vt pin

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .ghostty = .{
-            .url = "https://github.com/ghostty-org/ghostty/archive/f705b9f46a4083d8053cfa254898c164af46ff34.tar.gz",
-            .hash = "122022d77cfd6d901de978a2667797a18d82f7ce2fd6c40d4028d6db603499dc9679",
+            .url = "https://github.com/ghostty-org/ghostty/archive/01ea3744c59af4d973e96c5cce2fe8d4aa485e59.tar.gz",
+            .hash = "ghostty-1.3.0-dev-5UdBCztHSQTgA1VZa_mg8qFdLnXQJc3gWhsAgO6ZMybK",
         },
         .libxev = .{
             .url = "https://deps.files.ghostty.org/libxev-34fa50878aec6e5fa8f532867001ab3c36fae23e.tar.gz",

--- a/docs/ghostty-vt-notes.md
+++ b/docs/ghostty-vt-notes.md
@@ -44,8 +44,8 @@ In `build.zig.zon` (URL + hash; tarball fetched automatically):
 ```zig
 .dependencies = .{
     .ghostty = .{
-        .url = "https://github.com/ghostty-org/ghostty/archive/f705b9f46a4083d8053cfa254898c164af46ff34.tar.gz",
-        .hash = "122022d77cfd6d901de978a2667797a18d82f7ce2fd6c40d4028d6db603499dc9679",
+        .url = "https://github.com/ghostty-org/ghostty/archive/01ea3744c59af4d973e96c5cce2fe8d4aa485e59.tar.gz",
+        .hash = "ghostty-1.3.0-dev-5UdBCztHSQTgA1VZa_mg8qFdLnXQJc3gWhsAgO6ZMybK",
     },
 },
 ```

--- a/src/session/state.zig
+++ b/src/session/state.zig
@@ -252,6 +252,7 @@ pub const SessionState = struct {
         HyperlinkSetOutOfMemory,
         NeedsRehash,
         OutOfMemory,
+        OutOfSpace,
         StringAllocOutOfMemory,
         StyleSetNeedsRehash,
         StyleSetOutOfMemory,


### PR DESCRIPTION
 Issue: Upgrade ghostty-vt dependency to the latest upstream commit.
 Solution: Updated the ghostty tarball URL/hash and docs to match the new pin.
 Solution: Added OutOfSpace to ProcessOutputError to match the updated stream error set.