### PR TITLE
Show first-run onboarding hint in terminal and persist its state

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ architect hook claude
 architect hook codex
 architect hook gemini
 ```
+On first launch, Architect shows a faint terminal hint with the core shortcuts (Cmd+N/W/Enter) and the `architect hook` setup command.
 
 ## Configuration
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,6 +54,7 @@ Architect is a terminal multiplexer displaying interactive sessions in a grid wi
 - Attention borders (pulsing yellow for awaiting approval, solid green for done)
 - CWD bar with marquee scrolling for long paths
 - Scrollback indicator strip
+- First-run onboarding hint text rendered inside the terminal view (dimmed)
 
 **UiRoot (src/ui/)** is the registry for UI overlay components and session interaction state:
 - Dispatches events topmost-first (by z-index)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,6 +193,7 @@ Auto-managed runtime state. Do not edit manually unless troubleshooting.
 
 ```toml
 font_size = 14
+onboarding_shown = true
 
 [window]
 width = 1440
@@ -212,6 +213,7 @@ terminals = [
 | Field | Description |
 |-------|-------------|
 | `font_size` | Current font size (adjusted with `Cmd++`/`Cmd+-`) |
+| `onboarding_shown` | Whether the first-run onboarding hint has been displayed |
 | `[window]` | Last window position and dimensions |
 | `terminals` | Working directories for each terminal (ordered by session index) |
 

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -372,6 +372,13 @@ pub fn run() !void {
     };
     defer persistence.deinit(allocator);
     persistence.font_size = std.math.clamp(persistence.font_size, min_font_size, max_font_size);
+    const show_onboarding = !persistence.onboarding_shown;
+    if (show_onboarding) {
+        persistence.onboarding_shown = true;
+        persistence.save(allocator) catch |err| {
+            log.warn("Failed to save onboarding state: {}", .{err});
+        };
+    }
 
     const theme = colors_mod.Theme.fromConfig(config.theme);
 
@@ -1834,6 +1841,7 @@ pub fn run() !void {
                 &theme,
                 config.grid.font_scale,
                 &grid,
+                show_onboarding,
             ) catch |err| {
                 log.err("render failed: {}", .{err});
                 return err;


### PR DESCRIPTION
### Motivation
- Provide a gentle, in-terminal onboarding hint on first run so users discover core shortcuts and the `architect` hook command. 
- Persist whether the hint has already been shown so it only appears once per installation.

### Description
- Add an `onboarding_shown` flag to `Persistence` and include it in TOML load/save semantics (`src/config.zig`).
- On startup, compute `show_onboarding = !persistence.onboarding_shown`, mark the flag true and save immediately when the hint will be shown (`src/app/runtime.zig`).
- Thread `show_onboarding` into the renderer and render a dim, in-terminal hint (slot 0, focused and alive) with the lines describing `Cmd+N`, `Cmd+W`, `Cmd+Enter` and `architect hook ...` (`src/render/renderer.zig`).
- Update documentation to mention the onboarding hint and the new persistence field (`README.md`, `docs/configuration.md`, `docs/architecture.md`) and add a persistence round-trip expectation to tests in `src/config.zig`.

### Testing
- Attempted `zig build` and `zig build test`, but `zig` was not available in the environment so builds/tests could not be executed (command not found).
- Attempted `just lint` and `zig fmt` but the required tools were not installed so lint/format checks could not be run (command not found).
- Source changes were committed locally and basic repository status checks were performed; unit tests touching `Persistence` were updated but not run due to the missing `zig` toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697918f1a48c83328c5870bd9ecb6c3e)