### PR TITLE
Add first-launch onboarding message

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,6 +193,7 @@ Auto-managed runtime state. Do not edit manually unless troubleshooting.
 
 ```toml
 font_size = 14
+onboarding_shown = true
 
 [window]
 width = 1440
@@ -212,6 +213,7 @@ terminals = [
 | Field | Description |
 |-------|-------------|
 | `font_size` | Current font size (adjusted with `Cmd++`/`Cmd+-`) |
+| `onboarding_shown` | Whether the first-launch onboarding message has been displayed |
 | `[window]` | Last window position and dimensions |
 | `terminals` | Working directories for each terminal (ordered by session index) |
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -236,11 +236,13 @@ pub const Persistence = struct {
     window: WindowConfig = .{},
     font_size: c_int = 14,
     terminal_paths: std.ArrayListUnmanaged([]const u8) = .{},
+    onboarding_shown: bool = false,
 
     const TomlPersistenceV2 = struct {
         window: WindowConfig = .{},
         font_size: c_int = 14,
         terminals: ?[]const []const u8 = null,
+        onboarding_shown: bool = false,
     };
 
     const TomlPersistenceV1 = struct {
@@ -283,6 +285,7 @@ pub const Persistence = struct {
             defer result.deinit();
             persistence.window = result.value.window;
             persistence.font_size = result.value.font_size;
+            persistence.onboarding_shown = result.value.onboarding_shown;
 
             if (result.value.terminals) |paths| {
                 for (paths) |path| {
@@ -339,6 +342,7 @@ pub const Persistence = struct {
     pub fn serializeToWriter(self: Persistence, writer: anytype) !void {
         // Write font_size first (top-level scalar)
         try writer.print("font_size = {d}\n", .{self.font_size});
+        try writer.print("onboarding_shown = {}\n", .{self.onboarding_shown});
 
         // Write terminals array before any sections
         if (self.terminal_paths.items.len > 0) {


### PR DESCRIPTION
Display a brief welcome message in grey text on first launch, explaining:
- Cmd+N/W for terminal management
- Cmd+Enter for focus toggle
- Hold Escape to interrupt agents
- architect hook command for AI agent integration

The message is shown once and tracked via onboarding_shown in persistence.toml.

https://claude.ai/code/session_013AMHvCsisuoq8T8BroZKs4