### PR TITLE
chore(deps): bump zwanzig to v0.5.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "toml-0.3.0-bV14Bd-EAQBKoXhpYft303BtA2vgLNlxntUCIWgRUl46",
         },
         .zwanzig = .{
-            .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.4.0.tar.gz",
-            .hash = "zwanzig-0.4.0-oiXZlh-WEgAX1c_4KkZinBAxMRVxW_P4Qan2C6s70pt6",
+            .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.5.0.tar.gz",
+            .hash = "zwanzig-0.5.0-oiXZlifaEgAB_FuYpnxVSSZdPmnv_mOxRugoTeDFlhNk",
         },
     },
     .paths = .{


### PR DESCRIPTION
## Summary

- Bumps zwanzig dependency from v0.4.0 to v0.5.0
- Refactors mouse scroll forwarding logic in `SessionInteractionComponent`

## Changes

**Dependency update:**
Updated zwanzig to the latest version (v0.5.0) in `build.zig.zon`.

**Session interaction refactor:**
Cleaned up the mouse scroll forwarding logic by hoisting the terminal lookup and using a `forwarded` flag for clearer control flow instead of nested else branches.

## Test plan

- [x] `zig build` passes
- [x] `zig build test` passes
- [x] `just lint` passes (60 files analyzed, no issues)
