### PR TITLE
chore(deps): bump zwanzig to v0.5.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "toml-0.3.0-bV14Bd-EAQBKoXhpYft303BtA2vgLNlxntUCIWgRUl46",
         },
         .zwanzig = .{
-            .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.5.0.tar.gz",
-            .hash = "zwanzig-0.5.0-oiXZlifaEgAB_FuYpnxVSSZdPmnv_mOxRugoTeDFlhNk",
+            .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.5.1.tar.gz",
+            .hash = "zwanzig-0.5.1-oiXZlnTIEgDfDuLVtMQqlNsP5LIB74dhRqGGAr6lyGVo",
         },
     },
     .paths = .{


### PR DESCRIPTION
## Summary

Updates the zwanzig dependency from v0.5.0 to v0.5.1.

## Changes

- Updated dependency URL in `build.zig.zon` to point to v0.5.1 release
- Updated package hash to match the new version

## Test plan

- [x] `zig build` passes
- [x] `zig build test` passes
- [x] `just lint` passes
