### PR TITLE
fix: send SS3 arrow key sequences in application cursor mode

### DIFF
--- a/src/app/input_keys.zig
+++ b/src/app/input_keys.zig
@@ -14,13 +14,18 @@ pub fn isModifierKey(key: c.SDL_Keycode) bool {
 pub fn handleKeyInput(focused: *SessionState, key: c.SDL_Keycode, mod: c.SDL_Keymod) !void {
     if (key == c.SDLK_ESCAPE) return;
 
+    const cursor_keys = if (focused.terminal) |*terminal|
+        terminal.modes.get(.cursor_keys)
+    else
+        false;
+
     const kitty_enabled = if (focused.terminal) |*terminal|
         terminal.screens.active.kitty_keyboard.current().int() != 0
     else
         false;
 
     var buf: [16]u8 = undefined;
-    const n = input.encodeKeyWithMod(key, mod, kitty_enabled, &buf);
+    const n = input.encodeKeyWithMod(key, mod, cursor_keys, kitty_enabled, &buf);
     if (n > 0) {
         try focused.sendInput(buf[0..n]);
     }


### PR DESCRIPTION
## Summary

Arrow keys in newsboat (and other ncurses applications) were not working correctly:
- Up arrow triggered "mark all read" (the 'A' key action) instead of moving up
- Down arrow did nothing

## Root Cause

Architect was always sending CSI sequences (`\x1b[A`, `\x1b[B`, etc.) for arrow keys, regardless of the terminal's cursor keys mode. However, ncurses-based applications like newsboat enable **DECCKM** (application cursor keys mode) via `smkx`, and expect SS3 sequences (`\x1bOA`, `\x1bOB`, etc.) in this mode.

The xterm-256color terminfo defines arrow keys as SS3 sequences:
- `kcuu1=\EOA` (up)
- `kcud1=\EOB` (down)
- etc.

When newsboat received `\x1b[A` instead of `\x1bOA`, ncurses couldn't recognize it as KEY_UP and passed through the raw 'A' character, triggering the wrong action.

## Solution

- Added `cursor_keys` parameter to `encodeKeyWithMod()` in `src/input/mapper.zig`
- When `cursor_keys` is true (DECCKM mode enabled), arrow keys now send SS3 sequences
- Updated `handleKeyInput()` in `src/app/input_keys.zig` to query `terminal.modes.get(.cursor_keys)` and pass it to the encoder
- Added tests for both normal mode and application mode arrow key encoding

## Test Plan

- [x] `zig build` passes
- [x] `zig build test` passes
- [x] `just lint` passes
- [x] Manual test: verify arrow keys work in newsboat
- [x] Manual test: verify arrow keys still work in shell (bash/zsh)
