### PR TITLE
fix: remove double-free bugs in openUrl

### DIFF
--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -34,10 +34,7 @@ pub fn openUrl(_: std.mem.Allocator, url: []const u8) OpenError!void {
     errdefer thread_allocator.destroy(ctx);
 
     ctx.allocator = thread_allocator;
-    ctx.url = thread_allocator.dupe(u8, url) catch {
-        thread_allocator.destroy(ctx);
-        return error.OutOfMemory;
-    };
+    ctx.url = thread_allocator.dupe(u8, url) catch return error.OutOfMemory;
     errdefer thread_allocator.free(ctx.url);
 
     ctx.argv = switch (builtin.os.tag) {
@@ -48,7 +45,6 @@ pub fn openUrl(_: std.mem.Allocator, url: []const u8) OpenError!void {
     };
 
     const thread = std.Thread.spawn(.{}, openUrlThread, .{ctx}) catch |err| {
-        ctx.deinit();
         return switch (err) {
             error.OutOfMemory => error.OutOfMemory,
             else => error.SpawnFailed,


### PR DESCRIPTION
## Summary

Fixes double-free bugs in `openUrl` identified by a reviewer on PR #191.

## Problem

The `openUrl` function had two double-free bugs:

1. When `dupe` failed, manual `destroy(ctx)` was called before returning the error, but the `errdefer` on line 34 would also trigger on error return
2. When `Thread.spawn` failed, `ctx.deinit()` freed both url and ctx, then returning an error triggered both `errdefer` statements

## Solution

Remove the manual cleanup calls in catch blocks. The `errdefer` mechanism exists precisely for this purpose — to ensure cleanup happens exactly once when returning an error. Let `errdefer` do its job.

## Test plan

- [x] `zig build` passes
- [x] `zig build test` passes
