### PR TITLE
fix: use correct Homebrew install syntax

### DIFF
--- a/Formula/architect.rb
+++ b/Formula/architect.rb
@@ -66,7 +66,7 @@ class Architect < Formula
       </plist>
     EOS
 
-    install buildpath/"zig-out/bin/architect", macos/"architect"
+    macos.install buildpath/"zig-out/bin/architect"
 
     resources.install "assets/macos/#{app_name}.icns"
   end


### PR DESCRIPTION
## Summary

Fixes the Homebrew formula installation error:
```
ArgumentError: wrong number of arguments (given 2, expected 0)
```

## Solution

The previous code incorrectly used `install source, destination` as a standalone function. The correct Homebrew pattern is `destination.install source` where `install` is called on the destination Pathname.

Changed from:
```ruby
install buildpath/"zig-out/bin/architect", macos/"architect"
```

To:
```ruby
macos.install buildpath/"zig-out/bin/architect"
```

This matches the pattern already used in the same formula at line 71:
```ruby
resources.install "assets/macos/#{app_name}.icns"
```

## Test plan

- [ ] `brew install --build-from-source forketyfork/architect/architect` completes successfully