### PR TITLE
Bump zwanzig linter to v0.9.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "toml-0.3.0-bV14Bd-EAQBKoXhpYft303BtA2vgLNlxntUCIWgRUl46",
         },
         .zwanzig = .{
-            .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.8.0.tar.gz",
-            .hash = "zwanzig-0.8.0-oiXZlms3FQDGrGJGFGOO-bMF7OkxG4nFhiK6-ajHsJTb",
+            .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.9.0.tar.gz",
+            .hash = "zwanzig-0.9.0-oiXZltweFgBEE08jR3yJNtrtPhnZB32Jcu9Xwiv2wP-D",
         },
     },
     .paths = .{


### PR DESCRIPTION
## Summary

Bumps the zwanzig linter dependency from v0.8.0 to v0.9.0, picking up the latest rule improvements and fixes.

## Test plan

- [x] `zig build` succeeds
- [x] `zig build test` passes
- [x] `just lint` passes with the new version (64 files, 19 rules, no issues)