### PR TITLE
fix(render): handle emoji with variation selectors correctly

### DIFF
--- a/src/font.zig
+++ b/src/font.zig
@@ -126,7 +126,7 @@ pub const Font = struct {
     }
 
     fn shouldBaselineAlign(fallback: Fallback, cluster: []const u21) bool {
-        if (fallback == .emoji) return cluster.len == 1;
+        if (fallback == .emoji) return true;
         if (fallback != .primary) return true;
         if (cluster.len != 1) return false;
         return isSymbolLike(cluster[0]);
@@ -464,7 +464,7 @@ pub const Font = struct {
         var dest_x = base_x + (avail_w - dest_w) * 0.5;
         var dest_y = base_y + (avail_h - dest_h) * 0.5;
 
-        if (align_baseline and cluster.len == 1) {
+        if (align_baseline) {
             if (glyphMetrics(metrics_font, cluster[0])) |glyph| {
                 const glyph_h = glyph.max_y - glyph.min_y;
                 const glyph_center_x = (glyph.min_x + glyph.max_x) * 0.5;

--- a/src/render/renderer.zig
+++ b/src/render/renderer.zig
@@ -384,7 +384,7 @@ fn renderSessionContent(
                 .{ .active = .{ .x = @intCast(col), .y = @intCast(row) } }) orelse continue;
 
             const cell = list_cell.cell;
-            const cp: u21 = if (cell.content_tag == .codepoint) cell.content.codepoint else 0;
+            const cp: u21 = if (cell.content_tag == .codepoint or cell.content_tag == .codepoint_grapheme) cell.content.codepoint else 0;
             const glyph_width_cells: c_int = switch (cell.wide) {
                 .wide => 2,
                 else => 1,

--- a/src/session/state.zig
+++ b/src/session/state.zig
@@ -136,6 +136,7 @@ pub const SessionState = struct {
             .cols = self.pty_size.ws_col,
             .rows = self.pty_size.ws_row,
             .max_scrollback = 10_000_000,
+            .default_modes = .{ .grapheme_cluster = true },
         });
         errdefer terminal.deinit(self.allocator);
 


### PR DESCRIPTION
Closes #221

## Summary

Text-default emoji that rely on VS16 (U+FE0F) for emoji presentation were invisible in Architect. Three independent problems combined to produce the bug:

1. **Renderer skipped grapheme cells** -- the content tag check only matched `.codepoint`, so any cell carrying extra grapheme data (`.codepoint_grapheme`) was treated as codepoint 0 and never rendered.
2. **Grapheme cluster mode was off** -- without mode 2027, ghostty-vt handled VS16 as a zero-width attachment instead of promoting the cell from narrow to wide. Ghostty itself enables this mode by default via `grapheme-width-method = unicode`; Architect now does the same.
3. **Baseline alignment skipped multi-codepoint clusters** -- single-codepoint emoji got baseline-aligned while VS16 emoji (two codepoints) were vertically centered, causing a visible height mismatch on the same line.

## Test plan

- [x] Run `printf '🌤️🎞️🗣️🖼️🎛️😊😃\n'` in Architect and confirm all emoji render at the same size and vertical alignment
- [x] Verify regular emoji (😊😃👍🔥) still render correctly
- [x] Verify combining characters (e.g. `printf 'e\u0301 n\u0303\n'`) render correctly