### PR TITLE
fix(diff-overlay): scale down oversized emoji glyphs to fit row height

### DIFF
--- a/src/ui/components/diff_overlay.zig
+++ b/src/ui/components/diff_overlay.zig
@@ -2025,12 +2025,18 @@ pub const DiffOverlayComponent = struct {
                         const max_width = rect.w - used - padding;
                         if (max_width <= 0) continue;
                         if (render_w > max_width) {
+                            // Convert max_width from destination space back to source texture space.
+                            // render_w may be smaller than segment.w when height scaling was applied,
+                            // so a plain pixel count would clip a tiny sliver of the original texture.
+                            const src_clip_w: c_int = @max(1, @as(c_int, @intFromFloat(
+                                @as(f32, @floatFromInt(max_width)) * @as(f32, @floatFromInt(segment.w)) / @as(f32, @floatFromInt(render_w)),
+                            )));
                             render_w = max_width;
                             clip_src = c.SDL_FRect{
                                 .x = 0,
                                 .y = 0,
-                                .w = @floatFromInt(render_w),
-                                .h = @floatFromInt(render_h),
+                                .w = @floatFromInt(src_clip_w),
+                                .h = @floatFromInt(segment.h),
                             };
                             src_ptr = &clip_src;
                         }


### PR DESCRIPTION
When a diff line contains an emoji, Apple Color Emoji on macOS produces a surface several times taller than the monospace row height. The segment texture was drawn at its natural height with no upper bound, so the emoji overflowed its row and obscured adjacent lines.

`renderDiffContent` in `diff_overlay.zig` now scales both dimensions down proportionally when a segment texture exceeds `row_height`. SDL scales the texture to the destination rect, so no source-rect clipping is needed for height. The width-clip guard was also fixed to compare against the post-scale `render_w` rather than the raw `segment.w`. `story_overlay` and `reader_overlay` already handle this via their `fitTextureHeight` helper and are not affected.

Closes #230

## Test plan

- Open a diff that contains an emoji on an added/removed/context line (e.g. `+ State: 🟢 good progress`)
- Verify the emoji is sized consistently with surrounding text and does not overflow into adjacent rows
