### PR TITLE
Answer OSC default color queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Architect solves this with a grid view that keeps all your agents visible, with 
 - Per-cell cwd bar in grid view with reserved space so terminal content stays visible
 - Scrollback with trackpad/wheel support and an auto-hiding draggable scrollbar in terminal views
 - OSC 8 hyperlink support (Cmd+Click to open)
-- Replies to OSC 10/11 default color queries so Codex and similar CLIs do not stall on startup probes
+- Replies to OSC 4/10/11 color queries using the live terminal palette/default colors so Codex and similar CLIs do not stall on startup probes
 - Kitty keyboard protocol for enhanced key handling
 - Persistent window state and font size across sessions
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Architect solves this with a grid view that keeps all your agents visible, with 
 - Per-cell cwd bar in grid view with reserved space so terminal content stays visible
 - Scrollback with trackpad/wheel support and an auto-hiding draggable scrollbar in terminal views
 - OSC 8 hyperlink support (Cmd+Click to open)
+- Replies to OSC 10/11 default color queries so Codex and similar CLIs do not stall on startup probes
 - Kitty keyboard protocol for enhanced key handling
 - Persistent window state and font size across sessions
 

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -1075,7 +1075,7 @@ pub fn run() !void {
 
     // Initialize all session slots
     for (0..grid_layout.max_terminals) |i| {
-        sessions_storage[i] = try SessionState.init(allocator, i, shell_path, size, notify_sock);
+        sessions_storage[i] = try SessionState.init(allocator, i, shell_path, size, notify_sock, theme);
         sessions[i] = &sessions_storage[i];
         init_count += 1;
     }

--- a/src/render/renderer.zig
+++ b/src/render/renderer.zig
@@ -336,10 +336,15 @@ fn renderSessionContent(
     };
 
     const base_bg = c.SDL_Color{ .r = theme.background.r, .g = theme.background.g, .b = theme.background.b, .a = 255 };
+    const base_fg = c.SDL_Color{ .r = theme.foreground.r, .g = theme.foreground.g, .b = theme.foreground.b, .a = 255 };
     const session_bg_color = if (terminal.colors.background.get()) |rgb|
         c.SDL_Color{ .r = rgb.r, .g = rgb.g, .b = rgb.b, .a = 255 }
     else
         base_bg;
+    const session_fg_color = if (terminal.colors.foreground.get()) |rgb|
+        c.SDL_Color{ .r = rgb.r, .g = rgb.g, .b = rgb.b, .a = 255 }
+    else
+        base_fg;
 
     _ = c.SDL_SetRenderDrawColor(renderer, session_bg_color.r, session_bg_color.g, session_bg_color.b, session_bg_color.a);
     const bg_rect = c.SDL_FRect{
@@ -376,7 +381,6 @@ fn renderSessionContent(
     const visible_cols: usize = @min(@as(usize, term_cols), max_cols_fit);
     const visible_rows: usize = @min(@as(usize, term_rows), max_rows_fit);
 
-    const default_fg = c.SDL_Color{ .r = theme.foreground.r, .g = theme.foreground.g, .b = theme.foreground.b, .a = 255 };
     const active_selection = screen.selection;
 
     var row: usize = 0;
@@ -422,7 +426,7 @@ fn renderSessionContent(
             const on_cursor = should_render_cursor and cursor_col == col and cursor_row == row;
 
             const style = list_cell.style();
-            var fg_color = getCellColor(style.fg_color, default_fg, theme);
+            var fg_color = getCellColor(style.fg_color, session_fg_color, &terminal.colors.palette.current);
             var bg_color = if (style.bg(list_cell.cell, &terminal.colors.palette.current)) |rgb|
                 c.SDL_Color{ .r = rgb.r, .g = rgb.g, .b = rgb.b, .a = 255 }
             else
@@ -960,10 +964,22 @@ fn applyTvOverlay(renderer: *c.SDL_Renderer, rect: Rect, is_focused: bool, theme
     primitives.drawRoundedBorder(renderer, rect, radius);
 }
 
-fn getCellColor(color: ghostty_vt.Style.Color, default: c.SDL_Color, theme: *const colors.Theme) c.SDL_Color {
+fn getCellColor(
+    color: ghostty_vt.Style.Color,
+    default: c.SDL_Color,
+    palette: *const ghostty_vt.color.Palette,
+) c.SDL_Color {
     return switch (color) {
         .none => default,
-        .palette => |idx| colors.get256ColorWithTheme(idx, theme),
+        .palette => |idx| {
+            const rgb = palette[idx];
+            return c.SDL_Color{
+                .r = rgb.r,
+                .g = rgb.g,
+                .b = rgb.b,
+                .a = 255,
+            };
+        },
         .rgb => |rgb| c.SDL_Color{
             .r = rgb.r,
             .g = rgb.g,
@@ -971,6 +987,22 @@ fn getCellColor(color: ghostty_vt.Style.Color, default: c.SDL_Color, theme: *con
             .a = 255,
         },
     };
+}
+
+test "getCellColor uses the live terminal palette for indexed colors" {
+    var palette = ghostty_vt.color.default;
+    palette[17] = .{ .r = 0x12, .g = 0x34, .b = 0x56 };
+
+    const color = getCellColor(
+        .{ .palette = 17 },
+        .{ .r = 0xaa, .g = 0xbb, .b = 0xcc, .a = 255 },
+        &palette,
+    );
+
+    try std.testing.expectEqual(@as(u8, 0x12), color.r);
+    try std.testing.expectEqual(@as(u8, 0x34), color.g);
+    try std.testing.expectEqual(@as(u8, 0x56), color.b);
+    try std.testing.expectEqual(@as(u8, 255), color.a);
 }
 
 fn flushRun(

--- a/src/session/state.zig
+++ b/src/session/state.zig
@@ -5,6 +5,7 @@ const xev = @import("xev");
 const ghostty_vt = @import("ghostty-vt");
 const shell_mod = @import("../shell.zig");
 const pty_mod = @import("../pty.zig");
+const colors_mod = @import("../colors.zig");
 const fs = std.fs;
 const cwd_mod = if (builtin.os.tag == .macos) @import("../cwd.zig") else struct {};
 const vt_stream = @import("../vt_stream.zig");
@@ -90,6 +91,7 @@ pub const SessionState = struct {
     session_id_z: [session_id_buf_len:0]u8,
     notify_sock_z: [:0]const u8,
     allocator: std.mem.Allocator,
+    theme: colors_mod.Theme,
     cwd_path: ?[]const u8 = null,
     /// Subslice of cwd_path pointing to the basename. Always points within cwd_path's memory.
     /// When cwd_path is freed, this becomes invalid and must not be used.
@@ -158,6 +160,7 @@ pub const SessionState = struct {
         shell_path: []const u8,
         size: pty_mod.winsize,
         notify_sock: [:0]const u8,
+        theme: colors_mod.Theme,
     ) InitError!SessionState {
         const session_id_buf = [_:0]u8{0} ** session_id_buf_len;
 
@@ -174,6 +177,7 @@ pub const SessionState = struct {
             .session_id_z = session_id_buf,
             .notify_sock_z = notify_sock,
             .allocator = allocator,
+            .theme = theme,
         };
     }
 
@@ -209,6 +213,7 @@ pub const SessionState = struct {
             .rows = self.pty_size.ws_row,
             .max_scrollback = 10_000_000,
             .default_modes = .{ .grapheme_cluster = true },
+            .colors = terminalColorsFromTheme(self.theme),
         });
         errdefer terminal.deinit(self.allocator);
 
@@ -720,6 +725,32 @@ pub const SessionState = struct {
     }
 };
 
+fn terminalColorsFromTheme(theme: colors_mod.Theme) ghostty_vt.Terminal.Colors {
+    var palette = ghostty_vt.color.default;
+    for (theme.palette, 0..) |entry, idx| {
+        palette[idx] = .{
+            .r = entry.r,
+            .g = entry.g,
+            .b = entry.b,
+        };
+    }
+
+    return .{
+        .background = .init(.{
+            .r = theme.background.r,
+            .g = theme.background.g,
+            .b = theme.background.b,
+        }),
+        .foreground = .init(.{
+            .r = theme.foreground.r,
+            .g = theme.foreground.g,
+            .b = theme.foreground.b,
+        }),
+        .cursor = .unset,
+        .palette = .init(palette),
+    };
+}
+
 /// Returns the AgentKind for a given PID by inspecting its process name via sysctl.
 /// Falls back to KERN_PROCARGS2 for Node.js wrappers.
 fn detectAgentByPid(pid: posix.pid_t) ?AgentKind {
@@ -829,6 +860,7 @@ pub const MakeNonBlockingError = posix.FcntlError;
 test "SessionState assigns incrementing ids" {
     const allocator = std.testing.allocator;
     next_session_id.store(0, .seq_cst);
+    const theme = colors_mod.Theme.default();
 
     const size = pty_mod.winsize{
         .ws_row = 24,
@@ -838,13 +870,13 @@ test "SessionState assigns incrementing ids" {
     };
     const notify_sock: [:0]const u8 = "sock";
 
-    var first = try SessionState.init(allocator, 0, "/bin/zsh", size, notify_sock);
+    var first = try SessionState.init(allocator, 0, "/bin/zsh", size, notify_sock, theme);
     defer first.deinit(allocator);
     first.assignNewSessionId();
     try std.testing.expectEqual(@as(usize, 0), first.id);
     try std.testing.expectEqualStrings("0", std.mem.sliceTo(first.session_id_z[0..], 0));
 
-    var second = try SessionState.init(allocator, 1, "/bin/zsh", size, notify_sock);
+    var second = try SessionState.init(allocator, 1, "/bin/zsh", size, notify_sock, theme);
     defer second.deinit(allocator);
     second.assignNewSessionId();
     try std.testing.expectEqual(@as(usize, 1), second.id);
@@ -853,6 +885,7 @@ test "SessionState assigns incrementing ids" {
 
 test "despawn keeps active wait context alive until callback reclaims it" {
     const allocator = std.testing.allocator;
+    const theme = colors_mod.Theme.default();
     const size = pty_mod.winsize{
         .ws_row = 24,
         .ws_col = 80,
@@ -861,7 +894,7 @@ test "despawn keeps active wait context alive until callback reclaims it" {
     };
     const notify_sock: [:0]const u8 = "sock";
 
-    var session = try SessionState.init(allocator, 0, "/bin/zsh", size, notify_sock);
+    var session = try SessionState.init(allocator, 0, "/bin/zsh", size, notify_sock, theme);
     defer session.deinit(allocator);
 
     const wait_ctx = try allocator.create(SessionState.WaitContext);
@@ -886,6 +919,7 @@ test "despawn keeps active wait context alive until callback reclaims it" {
 
 test "resetForRespawn clears agent metadata" {
     const allocator = std.testing.allocator;
+    const theme = colors_mod.Theme.default();
     const size = pty_mod.winsize{
         .ws_row = 24,
         .ws_col = 80,
@@ -894,7 +928,7 @@ test "resetForRespawn clears agent metadata" {
     };
     const notify_sock: [:0]const u8 = "sock";
 
-    var session = try SessionState.init(allocator, 0, "/bin/zsh", size, notify_sock);
+    var session = try SessionState.init(allocator, 0, "/bin/zsh", size, notify_sock, theme);
     defer session.deinit(allocator);
 
     session.agent_kind = .codex;

--- a/src/vt_stream.zig
+++ b/src/vt_stream.zig
@@ -5,7 +5,7 @@ const shell_mod = @import("shell.zig");
 const log = std.log.scoped(.vt_stream);
 
 const ReadonlyHandler = @typeInfo(@TypeOf(ghostty_vt.Terminal.vtHandler)).@"fn".return_type.?;
-const ColorOperation = ghostty_vt.StreamAction.Value(.color_operation);
+const color_operation_value = ghostty_vt.StreamAction.Value(.color_operation);
 
 /// Stream handler that keeps terminal state in sync (via the built-in
 /// readonly handler) but also answers basic device-status queries so
@@ -121,13 +121,18 @@ pub const Handler = struct {
         _ = try self.shell.write(resp);
     }
 
-    fn handleColorOperation(self: *Handler, op: ColorOperation) !void {
+    fn handleColorOperation(self: *Handler, op: color_operation_value) !void {
         var it = op.requests.constIterator(0);
         while (it.next()) |request| {
             switch (request.*) {
                 .set => |set| self.applyColorSet(set.target, set.color),
                 .reset => |target| self.applyColorReset(target),
-                .reset_palette => self.terminal.colors.palette.resetAll(),
+                .reset_palette => {
+                    if (self.terminal.colors.palette.mask.count() > 0) {
+                        self.terminal.flags.dirty.palette = true;
+                    }
+                    self.terminal.colors.palette.resetAll();
+                },
                 .query => |target| {
                     const color = self.colorForQuery(target) orelse continue;
                     var buf: [64]u8 = undefined;
@@ -145,7 +150,10 @@ pub const Handler = struct {
         color: ghostty_vt.color.RGB,
     ) void {
         switch (target) {
-            .palette => |index| self.terminal.colors.palette.set(index, color),
+            .palette => |index| {
+                self.terminal.flags.dirty.palette = true;
+                self.terminal.colors.palette.set(index, color);
+            },
             .dynamic => |dynamic| switch (dynamic) {
                 .foreground => self.terminal.colors.foreground.set(color),
                 .background => self.terminal.colors.background.set(color),
@@ -158,7 +166,10 @@ pub const Handler = struct {
 
     fn applyColorReset(self: *Handler, target: ghostty_vt.osc.color.Target) void {
         switch (target) {
-            .palette => |index| self.terminal.colors.palette.reset(index),
+            .palette => |index| {
+                self.terminal.flags.dirty.palette = true;
+                self.terminal.colors.palette.reset(index);
+            },
             .dynamic => |dynamic| switch (dynamic) {
                 .foreground => self.terminal.colors.foreground.reset(),
                 .background => self.terminal.colors.background.reset(),
@@ -284,6 +295,46 @@ test "stream answers OSC 10 and OSC 11 color queries" {
     try stream.nextSlice("\x1b]11;?\x1b\\");
     const bg_len = try std.posix.read(pipe_fds[0], &buf);
     try std.testing.expectEqualSlices(u8, "\x1b]11;rgb:1212/3434/5656\x1b\\", buf[0..bg_len]);
+}
+
+test "stream answers OSC 4 palette queries with the current terminal palette" {
+    const allocator = std.testing.allocator;
+
+    var palette = ghostty_vt.color.default;
+    palette[17] = .{ .r = 0x12, .g = 0x34, .b = 0x56 };
+
+    var terminal = try ghostty_vt.Terminal.init(allocator, .{
+        .cols = 80,
+        .rows = 24,
+        .colors = .{
+            .background = .init(.{ .r = 0x12, .g = 0x34, .b = 0x56 }),
+            .foreground = .init(.{ .r = 0xab, .g = 0xcd, .b = 0xef }),
+            .cursor = .unset,
+            .palette = .init(palette),
+        },
+    });
+    defer terminal.deinit(allocator);
+
+    const pipe_fds = try std.posix.pipe();
+    defer std.posix.close(pipe_fds[0]);
+    defer std.posix.close(pipe_fds[1]);
+
+    var shell = shell_mod.Shell{
+        .pty = .{
+            .master = pipe_fds[1],
+            .slave = pipe_fds[0],
+        },
+        .child_pid = 0,
+    };
+
+    var stream = initStream(allocator, &terminal, &shell);
+    defer stream.deinit();
+
+    var buf: [128]u8 = undefined;
+
+    try stream.nextSlice("\x1b]4;17;?\x07");
+    const len = try std.posix.read(pipe_fds[0], &buf);
+    try std.testing.expectEqualSlices(u8, "\x1b]4;17;rgb:1212/3434/5656\x07", buf[0..len]);
 }
 
 pub const StreamType = ghostty_vt.Stream(Handler);

--- a/src/vt_stream.zig
+++ b/src/vt_stream.zig
@@ -5,6 +5,7 @@ const shell_mod = @import("shell.zig");
 const log = std.log.scoped(.vt_stream);
 
 const ReadonlyHandler = @typeInfo(@TypeOf(ghostty_vt.Terminal.vtHandler)).@"fn".return_type.?;
+const ColorOperation = ghostty_vt.StreamAction.Value(.color_operation);
 
 /// Stream handler that keeps terminal state in sync (via the built-in
 /// readonly handler) but also answers basic device-status queries so
@@ -36,6 +37,7 @@ pub const Handler = struct {
             .device_attributes => try self.handleDeviceAttributes(value),
             .device_status => try self.handleDeviceStatus(value.request),
             .kitty_keyboard_query => try self.handleKittyKeyboardQuery(),
+            .color_operation => try self.handleColorOperation(value),
             .kitty_keyboard_push => {
                 log.debug("kitty_keyboard_push: flags={d}", .{value.flags.int()});
                 try self.readonly.vt(action, value);
@@ -118,11 +120,100 @@ pub const Handler = struct {
         const resp = try formatKittyQueryResponse(&buf, flags.int());
         _ = try self.shell.write(resp);
     }
+
+    fn handleColorOperation(self: *Handler, op: ColorOperation) !void {
+        var it = op.requests.constIterator(0);
+        while (it.next()) |request| {
+            switch (request.*) {
+                .set => |set| self.applyColorSet(set.target, set.color),
+                .reset => |target| self.applyColorReset(target),
+                .reset_palette => self.terminal.colors.palette.resetAll(),
+                .query => |target| {
+                    const color = self.colorForQuery(target) orelse continue;
+                    var buf: [64]u8 = undefined;
+                    const resp = try formatOscColorQueryResponse(&buf, target, color, op.terminator);
+                    _ = try self.shell.write(resp);
+                },
+                .reset_special => {},
+            }
+        }
+    }
+
+    fn applyColorSet(
+        self: *Handler,
+        target: ghostty_vt.osc.color.Target,
+        color: ghostty_vt.color.RGB,
+    ) void {
+        switch (target) {
+            .palette => |index| self.terminal.colors.palette.set(index, color),
+            .dynamic => |dynamic| switch (dynamic) {
+                .foreground => self.terminal.colors.foreground.set(color),
+                .background => self.terminal.colors.background.set(color),
+                .cursor => self.terminal.colors.cursor.set(color),
+                else => {},
+            },
+            .special => {},
+        }
+    }
+
+    fn applyColorReset(self: *Handler, target: ghostty_vt.osc.color.Target) void {
+        switch (target) {
+            .palette => |index| self.terminal.colors.palette.reset(index),
+            .dynamic => |dynamic| switch (dynamic) {
+                .foreground => self.terminal.colors.foreground.reset(),
+                .background => self.terminal.colors.background.reset(),
+                .cursor => self.terminal.colors.cursor.reset(),
+                else => {},
+            },
+            .special => {},
+        }
+    }
+
+    fn colorForQuery(
+        self: *Handler,
+        target: ghostty_vt.osc.color.Target,
+    ) ?ghostty_vt.color.RGB {
+        return switch (target) {
+            .palette => |index| self.terminal.colors.palette.current[index],
+            .dynamic => |dynamic| switch (dynamic) {
+                .foreground => self.terminal.colors.foreground.get(),
+                .background => self.terminal.colors.background.get(),
+                .cursor => self.terminal.colors.cursor.get() orelse self.terminal.colors.foreground.get(),
+                else => null,
+            },
+            .special => null,
+        };
+    }
 };
 
 /// Format kitty keyboard query response. Exposed for testing.
 fn formatKittyQueryResponse(buf: []u8, flags: u5) error{NoSpaceLeft}![]u8 {
     return std.fmt.bufPrint(buf, "\x1b[?{d}u", .{flags});
+}
+
+fn formatOscColorQueryResponse(
+    buf: []u8,
+    target: ghostty_vt.osc.color.Target,
+    color: ghostty_vt.color.RGB,
+    terminator: ghostty_vt.osc.Terminator,
+) error{NoSpaceLeft}![]u8 {
+    const red = @as(u16, color.r) * 257;
+    const green = @as(u16, color.g) * 257;
+    const blue = @as(u16, color.b) * 257;
+
+    return switch (target) {
+        .palette => |index| std.fmt.bufPrint(
+            buf,
+            "\x1b]4;{d};rgb:{x:0>4}/{x:0>4}/{x:0>4}{s}",
+            .{ index, red, green, blue, terminator.string() },
+        ),
+        .dynamic => |dynamic| std.fmt.bufPrint(
+            buf,
+            "\x1b]{d};rgb:{x:0>4}/{x:0>4}/{x:0>4}{s}",
+            .{ @intFromEnum(dynamic), red, green, blue, terminator.string() },
+        ),
+        .special => unreachable,
+    };
 }
 
 test "formatKittyQueryResponse - disabled (flags=0)" {
@@ -141,6 +232,58 @@ test "formatKittyQueryResponse - all flags (flags=31)" {
     var buf: [16]u8 = undefined;
     const resp = try formatKittyQueryResponse(&buf, 31);
     try std.testing.expectEqualSlices(u8, "\x1b[?31u", resp);
+}
+
+test "formatOscColorQueryResponse formats dynamic queries with the input terminator" {
+    var buf: [64]u8 = undefined;
+    const resp = try formatOscColorQueryResponse(
+        &buf,
+        .{ .dynamic = .foreground },
+        .{ .r = 0xab, .g = 0xcd, .b = 0xef },
+        .bel,
+    );
+    try std.testing.expectEqualSlices(u8, "\x1b]10;rgb:abab/cdcd/efef\x07", resp);
+}
+
+test "stream answers OSC 10 and OSC 11 color queries" {
+    const allocator = std.testing.allocator;
+
+    var terminal = try ghostty_vt.Terminal.init(allocator, .{
+        .cols = 80,
+        .rows = 24,
+        .colors = .{
+            .background = .init(.{ .r = 0x12, .g = 0x34, .b = 0x56 }),
+            .foreground = .init(.{ .r = 0xab, .g = 0xcd, .b = 0xef }),
+            .cursor = .unset,
+            .palette = .default,
+        },
+    });
+    defer terminal.deinit(allocator);
+
+    const pipe_fds = try std.posix.pipe();
+    defer std.posix.close(pipe_fds[0]);
+    defer std.posix.close(pipe_fds[1]);
+
+    var shell = shell_mod.Shell{
+        .pty = .{
+            .master = pipe_fds[1],
+            .slave = pipe_fds[0],
+        },
+        .child_pid = 0,
+    };
+
+    var stream = initStream(allocator, &terminal, &shell);
+    defer stream.deinit();
+
+    var buf: [128]u8 = undefined;
+
+    try stream.nextSlice("\x1b]10;?\x07");
+    const fg_len = try std.posix.read(pipe_fds[0], &buf);
+    try std.testing.expectEqualSlices(u8, "\x1b]10;rgb:abab/cdcd/efef\x07", buf[0..fg_len]);
+
+    try stream.nextSlice("\x1b]11;?\x1b\\");
+    const bg_len = try std.posix.read(pipe_fds[0], &buf);
+    try std.testing.expectEqualSlices(u8, "\x1b]11;rgb:1212/3434/5656\x1b\\", buf[0..bg_len]);
 }
 
 pub const StreamType = ghostty_vt.Stream(Handler);


### PR DESCRIPTION
## Solution

Codex sends OSC 10/11 probes when it starts. Architect already parsed those sequences through `ghostty-vt`, but our VT wrapper only answered device-status and kitty-keyboard queries, so the probe timed out and startup stalled for about two seconds.

This change seeds each session's `ghostty-vt` terminal with Architect's configured theme colors, then handles OSC color operations in the VT stream. Supported set/reset operations still update terminal state, and OSC 10/11 queries now get xterm-style replies using the caller's terminator.

Issue linkage: No project issue exists yet. Linkage will be added during mandatory cleanup.

## Test plan

- [ ] Launch Architect and start Codex in a fresh terminal. Confirm the CLI comes up without the previous noticeable ~2 second pause.
- [ ] In Architect, run the probe below and confirm it prints immediate `]10;rgb:` and `]11;rgb:` replies that match the configured foreground/background colors.

```bash
python3 - <<'PY'
import os
import select
import termios
import tty
import time

with open('/dev/tty', 'rb+', buffering=0) as t:
    fd = t.fileno()
    old = termios.tcgetattr(fd)
    tty.setraw(fd)
    try:
        os.write(fd, b'\x1b]10;?\a\x1b]11;?\a')
        deadline = time.time() + 1
        data = b''
        while time.time() < deadline:
            ready, _, _ = select.select([fd], [], [], 0.1)
            if not ready:
                continue
            data += os.read(fd, 1024)
            if data.count(b'\x1b]') >= 2:
                break
    finally:
        termios.tcsetattr(fd, termios.TCSADRAIN, old)

print(repr(data))
PY
```
