### PR TITLE
feat(mcp): add session spawning helper

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Bundle libraries and package
         run: |
           chmod +x scripts/bundle-macos.sh
-          ./scripts/bundle-macos.sh zig-out/bin/architect release
+          ./scripts/bundle-macos.sh zig-out/bin/architect release zig-out/bin/architect-mcp
           cd release
           tar -czf architect-macos-${{ matrix.arch }}.tar.gz Architect.app
         working-directory: architect

--- a/Formula/architect.rb
+++ b/Formula/architect.rb
@@ -67,6 +67,8 @@ class Architect < Formula
     EOS
 
     macos.install buildpath/"zig-out/bin/architect"
+    macos.install buildpath/"zig-out/bin/architect-mcp"
+    bin.install_symlink macos/"architect-mcp" => "architect-mcp"
 
     resources.install "assets/macos/#{app_name}.icns"
   end
@@ -81,10 +83,18 @@ class Architect < Formula
 
       Launch with:
         open -a Architect
+
+      MCP helper command:
+        architect-mcp
+
+      MCP helper app-bundle path:
+        #{prefix}/Architect.app/Contents/MacOS/architect-mcp
     EOS
   end
 
   test do
     assert_path_exists prefix/"Architect.app/Contents/MacOS/architect"
+    assert_path_exists prefix/"Architect.app/Contents/MacOS/architect-mcp"
+    assert_path_exists bin/"architect-mcp"
   end
 end

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Architect solves this with a grid view that keeps all your agents visible, with 
 - **Recent folders** (⌘O) — quickly `cd` into recently visited directories with instant search filtering (start typing to narrow the list), substring highlighting, arrow key navigation, and ⌘1–⌘9 quick selection
 - **Diff review comments** — click diff lines in the ⌘D overlay to leave inline comments with multiline wrapping, then send them all to a running agent (or start one) with the "Send to agent" button
 - **Story viewer** — run `architect story <filename>` to open a scrollable overlay that renders PR story files with prose text and diff-colored code blocks
+- **MCP session spawning** — run `architect-mcp` from an MCP client to ask the running Architect app to create a terminal session in a requested working directory
 - **Reader mode** (⌘R) — open a centered markdown reader for the selected terminal's history (works in full view and grid) with live updates, bottom pinning, incremental search (⌘F, Enter/Shift+Enter), markdown tables with inline cell styling (bold/italic/code/links/strikethrough), task checkboxes (emoji), clickable links, shared draggable scrollbar, and left-to-right gradient separators before command prompts (OSC 133 + fallback heuristics)
 
 ### Terminal Essentials
@@ -76,7 +77,7 @@ open Architect.app
 
 * These GitHub release archives are ad-hoc signed so macOS can launch them locally, but they are not Developer ID signed or notarized.
 * Clear the quarantine attribute before first launch, or macOS may block the app.
-* The archive contains `Architect.app`. You can launch it with `open Architect.app` or run `./Architect.app/Contents/MacOS/architect` from the terminal. Keep the bundle contents intact.
+* The archive contains `Architect.app`. You can launch it with `open Architect.app` or run `./Architect.app/Contents/MacOS/architect` from the terminal. The MCP helper is bundled at `./Architect.app/Contents/MacOS/architect-mcp`. Keep the bundle contents intact.
 * Not sure which architecture? Run `uname -m` - if it shows `arm64`, use the ARM64 version; if it shows `x86_64`, use the Intel version.
 
 ### Homebrew (macOS)
@@ -96,6 +97,9 @@ brew install architect
 
 # Copy the app to your Applications folder
 cp -r $(brew --prefix)/Cellar/architect/*/Architect.app /Applications/
+
+# MCP clients can use the helper on PATH
+architect-mcp
 ```
 
 Or install directly without tapping:
@@ -112,6 +116,8 @@ nix develop
 just build
 ```
 
+Source builds install both executables under `zig-out/bin/`: `architect` and `architect-mcp`.
+
 ## Hooks
 
 To add hooks for Claude Code, Codex or Gemini, use the `architect` command available in the terminal:
@@ -119,6 +125,31 @@ To add hooks for Claude Code, Codex or Gemini, use the `architect` command avail
 architect hook claude
 architect hook codex
 architect hook gemini
+```
+
+## MCP
+
+`architect-mcp` is a stdio MCP server for local clients. It exposes one tool, `spawn_session`, which forwards the request to the running Architect app. It does not launch Architect by itself.
+
+`spawn_session` arguments:
+```json
+{
+  "cwd": "/absolute/path/to/worktree",
+  "command": "codex",
+  "display_name": "Issue 291"
+}
+```
+
+`cwd` is required. `command` and `display_name` are optional. On success, the tool returns structured content with `status`, `session_id`, and `slot_index`. If Architect is not running, the grid is full, `cwd` is invalid, or spawning fails, the tool returns an MCP tool error with a stable `code` and `message`.
+
+For release downloads, use:
+```bash
+./Architect.app/Contents/MacOS/architect-mcp
+```
+
+For Homebrew installs, `architect-mcp` is also symlinked onto `PATH`; the app-bundle fallback is:
+```bash
+$(brew --prefix)/Cellar/architect/$(brew list --versions architect | awk '{print $2}')/Architect.app/Contents/MacOS/architect-mcp
 ```
 
 ## Configuration
@@ -142,7 +173,7 @@ Common settings include font family, theme colors, grid font scale, and logging 
 
 ## Documentation
 
-* [`docs/ai-integration.md`](docs/ai-integration.md): set up Claude Code, Codex, and Gemini CLI hooks for status notifications (includes `architect notify`, `architect hook ...`, and timestamped backups).
+* [`docs/ai-integration.md`](docs/ai-integration.md): set up Claude Code, Codex, and Gemini CLI hooks for status notifications, plus the `architect-mcp` `spawn_session` interface.
 * [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md): architecture overview and system boundaries.
 * [`docs/configuration.md`](docs/configuration.md): detailed configuration reference for `config.toml` and `persistence.toml`.
 * [`docs/development.md`](docs/development.md): build, test, and release process.

--- a/build.zig
+++ b/build.zig
@@ -17,6 +17,17 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    const mcp_mod = b.createModule(.{
+        .root_source_file = b.path("src/mcp/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const control_mod = b.createModule(.{
+        .root_source_file = b.path("src/app/control.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    mcp_mod.addImport("control", control_mod);
     const assets_mod = b.createModule(.{
         .root_source_file = b.path("assets/terminfo.zig"),
         .target = target,
@@ -52,10 +63,15 @@ pub fn build(b: *std.Build) void {
         .name = "architect",
         .root_module = exe_mod,
     });
+    const mcp_exe = b.addExecutable(.{
+        .name = "architect-mcp",
+        .root_module = mcp_mod,
+    });
 
     exe.linkSystemLibrary("SDL3");
     exe.linkSystemLibrary("SDL3_ttf");
     exe.linkLibC();
+    mcp_exe.linkLibC();
 
     if (target.result.os.tag == .macos) {
         exe.linkSystemLibrary("proc");
@@ -81,6 +97,7 @@ pub fn build(b: *std.Build) void {
     }
 
     b.installArtifact(exe);
+    b.installArtifact(mcp_exe);
 
     const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
@@ -95,11 +112,17 @@ pub fn build(b: *std.Build) void {
     const exe_unit_tests = b.addTest(.{
         .root_module = exe_mod,
     });
+    const mcp_unit_tests = b.addTest(.{
+        .root_module = mcp_mod,
+    });
+    mcp_unit_tests.linkLibC();
 
     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
+    const run_mcp_unit_tests = b.addRunArtifact(mcp_unit_tests);
 
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_exe_unit_tests.step);
+    test_step.dependOn(&run_mcp_unit_tests.step);
 
     // Lint step using zwanzig
     if (b.lazyDependency("zwanzig", .{

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -320,7 +320,7 @@ src/mcp/main.zig
     | validates spawn_session arguments
     v
 app/control.zig
-    | scans per-instance discovery files in ${XDG_RUNTIME_DIR:-$TMPDIR:-/tmp}
+    | scans per-instance discovery files in XDG_RUNTIME_DIR or stable per-user runtime dir
     | connects to architect_control_<pid>.sock
     v
 Control socket listener thread in the running app
@@ -377,7 +377,7 @@ Rotate: rename active file to architect-<UTC timestamp>.log and continue in new 
 | persistence.toml | `~/.config/architect/persistence.toml` | Runtime state (window pos, font size, terminal cwds, agent session IDs) |
 | architect.log + archives | `~/Library/Logs/Architect/` | Structured application logs with size-based rotation (10 MiB active-file threshold) |
 | diff_comments.json | `<repo>/.architect/diff_comments.json` | Per-repo inline diff review comments (unsent) |
-| architect_control_<uid>_<pid>.json | `${XDG_RUNTIME_DIR:-$TMPDIR:-/tmp}` | Per-instance discovery file pointing `architect-mcp` at a running app's local control socket |
+| architect_control_<uid>_<pid>.json | `XDG_RUNTIME_DIR`, or `~/Library/Caches/Architect/runtime` on macOS / `~/.cache/architect/runtime` elsewhere | Per-instance discovery file pointing `architect-mcp` at a running app's local control socket |
 
 ### Exit Points
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## System Overview
 
-Architect is a **single-process, layered desktop application** built in Zig that functions as a grid-based terminal multiplexer optimized for multi-agent AI coding workflows. It follows a five-layer architecture: a thin entrypoint delegates to an application runtime that owns the frame loop, platform abstraction (SDL3), session management (PTY + ghostty-vt terminal emulation), scene rendering, and a component-based UI overlay system. The UI and terminal loop run on the main thread; background threads are used only for bounded auxiliary work (notification socket listener and quit-time agent-teardown worker). The frame loop uses a wakeable wait model: active work continues at the normal frame cadence, while idle frames block in SDL until either a wake-worthy event arrives or the next idle deadline expires. The application uses an action-queue pattern for UI-to-app mutations, epoch-based cache invalidation for efficient rendering, and a vtable-based component registry for extensible UI overlays. Renderer cache entries are reused for both grid tiles and the steady-state full-screen terminal view; overlays remain live unless an effect needs them baked into the cached texture.
+Architect is a **single-process, layered desktop application** built in Zig that functions as a grid-based terminal multiplexer optimized for multi-agent AI coding workflows. It follows a five-layer architecture: a thin entrypoint delegates to an application runtime that owns the frame loop, platform abstraction (SDL3), session management (PTY + ghostty-vt terminal emulation), scene rendering, and a component-based UI overlay system. The UI and terminal loop run on the main thread; background threads are used only for bounded auxiliary work (notification socket listener, local control socket listener, and quit-time agent-teardown worker). The frame loop uses a wakeable wait model: active work continues at the normal frame cadence, while idle frames block in SDL until either a wake-worthy event arrives or the next idle deadline expires. The application uses an action-queue pattern for UI-to-app mutations, request queues for external socket inputs, epoch-based cache invalidation for efficient rendering, and a vtable-based component registry for extensible UI overlays. Renderer cache entries are reused for both grid tiles and the steady-state full-screen terminal view; overlays remain live unless an effect needs them baked into the cached texture.
 
 ## Component Diagram
 
@@ -10,10 +10,12 @@ Architect is a **single-process, layered desktop application** built in Zig that
 graph TD
     subgraph Entrypoint
         MAIN["main.zig"]
+        MCP["mcp/main.zig<br/><i>architect-mcp stdio MCP helper</i>"]
     end
 
     subgraph Application Layer
         RT["app/runtime.zig<br/><i>Frame loop, lifetime, config, session spawning</i>"]
+        CTRL["app/control.zig<br/><i>Local control socket, spawn request schema</i>"]
         APP_MODS["app_state, layout, ui_host,<br/>grid_nav, grid_layout, input_keys,<br/>input_text, terminal_actions, worktree"]
     end
 
@@ -46,13 +48,16 @@ graph TD
     end
 
     MAIN --> RT
+    MCP --> CTRL
     RT --> APP_MODS
+    RT --> CTRL
     RT --> SDL
     RT --> SS
     RT --> REN
     RT --> UR
     SS --> SESSION_MODS
     SN -.->|"thread-safe queue"| RT
+    CTRL -.->|"thread-safe queue"| RT
     REN --> FONT
     REN --> GFX
     UR --> UI_CORE
@@ -84,7 +89,7 @@ Platform    Session    Rendering    UI Overlay
 **Invariants:**
 - Session, Rendering, and UI Overlay layers never import from each other directly. All cross-layer communication flows through the Application layer or shared types.
 - UI components communicate with the application exclusively via the `UiAction` queue (never direct state mutation).
-- Background threads are intentionally limited to two cases: the notification socket listener (`session/notify.zig`) and a quit-time agent-teardown worker in `app/runtime.zig`. Both communicate completion/state back to the main thread through thread-safe primitives. The notification listener also posts a custom SDL wake event after queueing a notification so the idle frame loop breaks out of `SDL_WaitEventTimeout(...)` promptly.
+- Background threads are intentionally limited to three cases: the notification socket listener (`session/notify.zig`), the local control socket listener (`app/control.zig`), and a quit-time agent-teardown worker in `app/runtime.zig`. They communicate completion/state back to the main thread through thread-safe primitives. The notification and control listeners also post a custom SDL wake event after queueing work so the idle frame loop breaks out of `SDL_WaitEventTimeout(...)` promptly.
 - Shutdown order is UI-first for teardown dependencies: `UiRoot.deinit()` runs before session teardown so components that reference sessions are released while session memory is still valid.
 - Runtime uses a one-shot teardown guard around UI cleanup so mixed `errdefer`/`defer` error unwind paths cannot deinitialize `UiRoot` twice.
 - Runtime persistence is updated during the frame loop when runtime state changes (cwd changes, terminal spawn/despawn, window move/resize, font size changes), and finalization is explicit at the end of `app/runtime.zig`: final save and deinit `Persistence` before deferred subsystem teardown begins.
@@ -101,7 +106,7 @@ These patterns are mandatory for all new code. They are derived from the archite
 
 2. **Render invalidation uses epoch comparison.** When terminal content changes, increment `render_epoch` on the `SessionState`. The renderer checks whether `presented_epoch` no longer matches `render_epoch` to know whether a session needs to be redrawn this frame, and cached session textures refresh when their stored epoch no longer matches the session epoch. This applies to both grid tiles and the steady-state full-screen terminal view. Never force a full re-render. (See ADR-004.)
 
-3. **Blocking I/O goes on a background thread with a thread-safe queue.** The frame loop must never block. Any new external I/O source must follow the notification socket pattern: background thread + queue + main-loop drain. (See ADR-009.)
+3. **Blocking I/O goes on a background thread with a thread-safe queue.** The frame loop must never block. Any new external I/O source must follow the notification/control socket pattern: background thread + queue + main-loop drain. (See ADR-009.)
 
 4. **Config vs. persistence separation.** User-editable preferences go in `config.toml`. Auto-managed runtime state (window position, recent folders, terminal cwds) goes in `persistence.toml`. Never mix them. (See ADR-010.)
 
@@ -120,7 +125,8 @@ These patterns are mandatory for all new code. They are derived from the archite
 | Add a new persisted runtime value   | `config.zig` (persistence section) + `persistence.toml` docs |
 | Add cross-layer shared types        | Shared Utilities (`geom.zig`, `colors.zig`, etc.) |
 | Add a new UiAction                  | `ui/types.zig` (tagged union) + handler in `app/runtime.zig` |
-| Add external tool integration       | `session/notify.zig` (extend notification protocol) |
+| Add notification-only external tool integration | `session/notify.zig` (extend notification protocol) |
+| Add external control of app state   | `app/control.zig` + a runtime drain handler in `app/runtime.zig` |
 
 ## Data Flow
 
@@ -303,6 +309,35 @@ Story notifications  -> StoryOverlay opens with file content
 Renderer draws attention border / story overlay
 ```
 
+### External MCP Spawn Path
+
+```
+MCP client
+    | launches architect-mcp over stdio
+    v
+src/mcp/main.zig
+    | JSON-RPC initialize/tools/list/tools/call
+    | validates spawn_session arguments
+    v
+app/control.zig
+    | reads discovery file in ${XDG_RUNTIME_DIR:-$TMPDIR:-/tmp}
+    | connects to architect_control_<pid>.sock
+    v
+Control socket listener thread in the running app
+    | parses request and queues PendingSpawn
+    | posts SDL wake event
+    v
+app/runtime.zig main loop
+    | validates cwd, chooses or expands a grid slot
+    | calls SessionState.ensureSpawnedWithDir()
+    | queues optional command into pending_write
+    v
+Control response
+    | status + session_id + slot_index, or stable error code
+    v
+architect-mcp MCP tool result
+```
+
 ### Logging Path
 
 ```
@@ -328,6 +363,7 @@ Rotate: rename active file to architect-<UTC timestamp>.log and continue in new 
 | SDL event queue | Keyboard, mouse, window events | Primary user interaction |
 | PTY read | Shell process stdout/stderr | Terminal content updates |
 | Unix domain socket | External AI tools | Status notifications (JSON) |
+| Unix domain socket | `architect-mcp` | Local `spawn_session` control requests |
 | Config files | `~/.config/architect/` | Startup configuration and persistence |
 
 ### Storage
@@ -341,6 +377,7 @@ Rotate: rename active file to architect-<UTC timestamp>.log and continue in new 
 | persistence.toml | `~/.config/architect/persistence.toml` | Runtime state (window pos, font size, terminal cwds, agent session IDs) |
 | architect.log + archives | `~/Library/Logs/Architect/` | Structured application logs with size-based rotation (10 MiB active-file threshold) |
 | diff_comments.json | `<repo>/.architect/diff_comments.json` | Per-repo inline diff review comments (unsent) |
+| architect_control.json | `${XDG_RUNTIME_DIR:-$TMPDIR:-/tmp}` | Discovery file pointing `architect-mcp` at the running app's local control socket |
 
 ### Exit Points
 
@@ -357,7 +394,9 @@ Rotate: rename active file to architect-<UTC timestamp>.log and continue in new 
 | Module | Responsibility | Public API (key functions/types) | Dependencies |
 |--------|---------------|----------------------------------|--------------|
 | `main.zig` | Thin entrypoint + global logging hook registration | `main()`, `std_options.logFn` | `app/runtime`, `logging` |
+| `mcp/main.zig` | Separate `architect-mcp` stdio MCP server. Handles JSON-RPC lifecycle methods and exposes the single `spawn_session` tool. | `main()`, `run()` | `app/control` module import, std |
 | `app/runtime.zig` | Application lifetime, frame loop, session spawning, config persistence, logging lifecycle/view-transition markers | `run()`, frame loop internals | `platform/sdl`, `session/state`, `render/renderer`, `ui/root`, `config`, `logging`, all `app/*` modules |
+| `app/control.zig` | Local control channel shared by the app and `architect-mcp`: spawn request schema, discovery file, Unix socket listener, request queue, and response serialization | `SpawnRequest`, `SpawnResponse`, `SpawnQueue`, `startControlThread()`, `connectAndSendSpawnRequest()` | std (socket, thread, JSON) |
 | `app/terminal_history.zig` | Extract focused terminal scrollback + viewport text, strip ANSI escape sequences, convert OSC 133 prompt markers into reader-friendly prompt marker lines, and extract agent session IDs from PTY output for resumption | `extractSessionText()`, `extractTerminalText()`, `stripAnsiAlloc()`, `extractAgentSessionId()`, `buildResumeCommand()` | `session/state`, `ghostty-vt`, std |
 | `app/*` (app_state, layout, ui_host, grid_nav, grid_layout, input_keys, input_text, terminal_actions, worktree) | Application logic decomposed by concern: state enums, grid sizing, UI snapshot building, navigation, input encoding, clipboard, worktree commands (with configurable external directory and post-create init) | `ViewMode`, `AnimationState`, `SessionStatus`, `buildUiHost()`, `applyTerminalResize()`, `encodeKey()`, `paste()`, `clear()`, `resolveWorktreeDir()` | `geom`, `anim/easing`, `ui/types`, `ui/session_view_state`, `colors`, `input/mapper`, `session/state`, `c` |
 | `platform/sdl.zig` | SDL3 initialization, window management, HiDPI | `init()`, `createWindow()`, `createRenderer()` | `c` |
@@ -386,8 +425,8 @@ Rotate: rename active file to architect-<UTC timestamp>.log and continue in new 
 
 ### ADR-001: Five-Layer Single-Thread Architecture
 
-- **Decision:** Organize the application into five layers (entrypoint, platform, session, rendering, UI overlay) running on a single main thread with only the notification socket on a background thread.
-- **Context:** A terminal multiplexer needs tight control over frame timing, event ordering, and GPU resource management. Multi-threaded rendering introduces synchronization complexity without clear benefit for a UI-bound application. The notification socket is the only I/O that must not block the frame loop.
+- **Decision:** Organize the application into five layers (entrypoint, platform, session, rendering, UI overlay) running on a single main thread with bounded background threads only for blocking external I/O and quit-time agent teardown.
+- **Context:** A terminal multiplexer needs tight control over frame timing, event ordering, and GPU resource management. Multi-threaded rendering introduces synchronization complexity without clear benefit for a UI-bound application. Notification and control sockets are isolated on listener threads because their accept/read paths must not block the frame loop.
 - **Alternatives considered:**
   - *Multi-threaded rendering* -- rejected because SDL3 renderers are not thread-safe, and the complexity of synchronizing terminal state across threads outweighs the marginal throughput gain.
   - *Async I/O everywhere* -- rejected because the frame loop is inherently synchronous (poll, update, render, present), and async patterns add indirection without improving latency for a 60 FPS UI.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -320,7 +320,7 @@ src/mcp/main.zig
     | validates spawn_session arguments
     v
 app/control.zig
-    | reads discovery file in ${XDG_RUNTIME_DIR:-$TMPDIR:-/tmp}
+    | scans per-instance discovery files in ${XDG_RUNTIME_DIR:-$TMPDIR:-/tmp}
     | connects to architect_control_<pid>.sock
     v
 Control socket listener thread in the running app
@@ -377,7 +377,7 @@ Rotate: rename active file to architect-<UTC timestamp>.log and continue in new 
 | persistence.toml | `~/.config/architect/persistence.toml` | Runtime state (window pos, font size, terminal cwds, agent session IDs) |
 | architect.log + archives | `~/Library/Logs/Architect/` | Structured application logs with size-based rotation (10 MiB active-file threshold) |
 | diff_comments.json | `<repo>/.architect/diff_comments.json` | Per-repo inline diff review comments (unsent) |
-| architect_control.json | `${XDG_RUNTIME_DIR:-$TMPDIR:-/tmp}` | Discovery file pointing `architect-mcp` at the running app's local control socket |
+| architect_control_<uid>_<pid>.json | `${XDG_RUNTIME_DIR:-$TMPDIR:-/tmp}` | Per-instance discovery file pointing `architect-mcp` at a running app's local control socket |
 
 ### Exit Points
 

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -21,7 +21,7 @@ Examples:
 
 `architect-mcp` is launched by an MCP client as a stdio server. It exposes exactly one tool, `spawn_session`, and forwards each call to the running Architect app through a local Unix-domain control socket. The helper is not a daemon and does not launch the GUI app if Architect is not already running.
 
-The running app writes a per-instance discovery file named `architect_control_<uid>_<pid>.json` under `${XDG_RUNTIME_DIR:-$TMPDIR:-/tmp}` and logs that full path together with the socket path. When several Architect instances are running, `architect-mcp` tries the newest reachable discovery entry.
+The running app writes a per-instance discovery file named `architect_control_<uid>_<pid>.json` under `XDG_RUNTIME_DIR` when that is set. Otherwise it uses a stable per-user runtime directory: `~/Library/Caches/Architect/runtime` on macOS, or `~/.cache/architect/runtime` on other platforms. The app logs the full discovery file path together with the socket path. When several Architect instances are running, `architect-mcp` tries the newest reachable discovery entry.
 
 Helper paths:
 

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -2,6 +2,8 @@
 
 Architect exposes a Unix domain socket to let external tools (Claude Code, Codex, Gemini CLI, etc.) signal UI states.
 
+Architect also ships `architect-mcp`, a separate stdio MCP helper that lets local MCP clients ask the running app to create new terminal sessions.
+
 ## Socket Protocol
 
 - Socket: `${XDG_RUNTIME_DIR:-/tmp}/architect_notify_<pid>.sock`
@@ -14,6 +16,68 @@ Examples:
 {"session": 0, "state": "awaiting_approval"}
 {"session": 0, "state": "done"}
 ```
+
+## MCP `spawn_session`
+
+`architect-mcp` is launched by an MCP client as a stdio server. It exposes exactly one tool, `spawn_session`, and forwards each call to the running Architect app through a local Unix-domain control socket. The helper is not a daemon and does not launch the GUI app if Architect is not already running.
+
+Helper paths:
+
+- Source builds: `zig-out/bin/architect-mcp`
+- Release app bundle: `Architect.app/Contents/MacOS/architect-mcp`
+- Homebrew: `architect-mcp` on `PATH`, with the app-bundle path under `$(brew --prefix)/Cellar/architect/<version>/Architect.app/Contents/MacOS/architect-mcp` as a fallback
+
+Input schema:
+
+```json
+{
+  "type": "object",
+  "required": ["cwd"],
+  "additionalProperties": false,
+  "properties": {
+    "cwd": {
+      "type": "string",
+      "description": "Absolute working directory for the new terminal session."
+    },
+    "command": {
+      "type": "string",
+      "description": "Optional command text queued into the new shell. Architect appends a newline when needed."
+    },
+    "display_name": {
+      "type": "string",
+      "description": "Optional display label reserved for clients and future Architect UI."
+    }
+  }
+}
+```
+
+Example tool arguments:
+
+```json
+{
+  "cwd": "/Users/me/dev/project",
+  "command": "codex",
+  "display_name": "Project task"
+}
+```
+
+Successful calls return MCP structured content like:
+
+```json
+{
+  "status": "spawned",
+  "session_id": 12,
+  "slot_index": 3
+}
+```
+
+Tool errors use stable codes:
+
+- `invalid_request`: the MCP arguments do not match the schema
+- `app_not_running`: no running Architect app accepted the local control request
+- `full_grid`: every Architect terminal slot is already in use
+- `invalid_cwd`: `cwd` is not an absolute existing directory
+- `spawn_failed`: Architect accepted the request but could not create or initialize the terminal session
 
 ## Built-in Command (inside Architect terminals)
 

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -21,6 +21,8 @@ Examples:
 
 `architect-mcp` is launched by an MCP client as a stdio server. It exposes exactly one tool, `spawn_session`, and forwards each call to the running Architect app through a local Unix-domain control socket. The helper is not a daemon and does not launch the GUI app if Architect is not already running.
 
+The running app writes a per-instance discovery file named `architect_control_<uid>_<pid>.json` under `${XDG_RUNTIME_DIR:-$TMPDIR:-/tmp}` and logs that full path together with the socket path. When several Architect instances are running, `architect-mcp` tries the newest reachable discovery entry.
+
 Helper paths:
 
 - Source builds: `zig-out/bin/architect-mcp`

--- a/docs/development.md
+++ b/docs/development.md
@@ -100,3 +100,5 @@ The release workflow packages ad-hoc-signed app bundles with local `codesign --s
 Each release includes:
 - `architect-macos-arm64.tar.gz` - Apple Silicon
 - `architect-macos-x86_64.tar.gz` - Intel
+
+Each archive contains `Architect.app` with both `Contents/MacOS/architect` and the stdio MCP helper `Contents/MacOS/architect-mcp`.

--- a/scripts/bundle-macos.sh
+++ b/scripts/bundle-macos.sh
@@ -2,12 +2,13 @@
 set -euo pipefail
 
 if [[ $# -lt 2 ]]; then
-    echo "Usage: $0 <executable> <output-dir> [--debug] [--unsigned]"
+    echo "Usage: $0 <executable> <output-dir> [architect-mcp-executable] [--debug] [--unsigned]"
     exit 1
 fi
 
 EXECUTABLE="$1"
 OUTPUT_DIR="$2"
+MCP_EXECUTABLE=""
 DEBUG_MODE=false
 SIGN_APP=true
 
@@ -20,11 +21,19 @@ for arg in "${@:3}"; do
             SIGN_APP=false
             ;;
         *)
-            echo "Unknown flag: $arg"
-            exit 1
+            if [[ -z "$MCP_EXECUTABLE" ]]; then
+                MCP_EXECUTABLE="$arg"
+            else
+                echo "Unknown flag: $arg"
+                exit 1
+            fi
             ;;
     esac
 done
+
+if [[ -z "$MCP_EXECUTABLE" ]]; then
+    MCP_EXECUTABLE="$(dirname "$EXECUTABLE")/architect-mcp"
+fi
 
 APP_NAME="Architect"
 APP_DIR="$OUTPUT_DIR/${APP_NAME}.app"
@@ -46,6 +55,12 @@ if [[ "$SIGN_APP" == true ]]; then
 fi
 
 echo "Bundling macOS application: $EXECUTABLE -> $APP_DIR"
+echo "Including MCP helper: $MCP_EXECUTABLE"
+
+if [[ ! -f "$MCP_EXECUTABLE" ]]; then
+    echo "Error: architect-mcp executable not found: $MCP_EXECUTABLE"
+    exit 1
+fi
 
 rm -rf "$APP_DIR"
 mkdir -p "$LIB_DIR" "$RESOURCES_DIR" "$SHARE_DIR"
@@ -109,6 +124,8 @@ fi
 # Copy the binary as the main executable (dylibs use @executable_path/lib/)
 cp "$EXECUTABLE" "$MACOS_DIR/architect"
 chmod +x "$MACOS_DIR/architect"
+cp "$MCP_EXECUTABLE" "$MACOS_DIR/architect-mcp"
+chmod +x "$MACOS_DIR/architect-mcp"
 
 seen_list=""
 queue=""
@@ -201,6 +218,7 @@ if [[ "$skip_lib_patching" != true ]]; then
         [[ -z "$original" ]] && continue
         name=$(basename "$original")
         install_name_tool -change "$original" "@executable_path/lib/$name" "$MACOS_DIR/architect" || true
+        install_name_tool -change "$original" "@executable_path/lib/$name" "$MACOS_DIR/architect-mcp" || true
     done <<< "$seen_list"
 
     echo ""
@@ -208,6 +226,10 @@ if [[ "$skip_lib_patching" != true ]]; then
     if otool -L "$MACOS_DIR/architect" | grep -q '/nix/store'; then
         echo "Warning: Nix store references remain in architect binary"
         otool -L "$MACOS_DIR/architect" | grep '/nix/store'
+    fi
+    if otool -L "$MACOS_DIR/architect-mcp" | grep -q '/nix/store'; then
+        echo "Warning: Nix store references remain in architect-mcp binary"
+        otool -L "$MACOS_DIR/architect-mcp" | grep '/nix/store'
     fi
 
     remaining=0
@@ -244,6 +266,9 @@ if [[ "$SIGN_APP" == true ]]; then
     echo "Signing architect..."
     codesign --force --sign - --entitlements "$ENTITLEMENTS" "$MACOS_DIR/architect"
 
+    echo "Signing architect-mcp..."
+    codesign --force --sign - --entitlements "$ENTITLEMENTS" "$MACOS_DIR/architect-mcp"
+
     echo "Signing ${APP_NAME}.app..."
     codesign --force --sign - --entitlements "$ENTITLEMENTS" "$APP_DIR"
 
@@ -252,6 +277,7 @@ else
     echo ""
     echo "Removing embedded signatures (--unsigned)..."
     remove_signature_if_present "$MACOS_DIR/architect"
+    remove_signature_if_present "$MACOS_DIR/architect-mcp"
     shopt -s nullglob
     for lib in "$LIB_DIR"/*.dylib; do
         remove_signature_if_present "$lib"

--- a/src/app/control.zig
+++ b/src/app/control.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const posix = std.posix;
 const atomic = std.atomic;
 
@@ -243,23 +244,66 @@ fn duplicateValidatedString(
 }
 
 pub fn getControlSocketPath(allocator: std.mem.Allocator) ![:0]u8 {
-    const base = runtimeDir();
+    var base = try controlRuntimeDirAlloc(allocator);
+    defer base.deinit(allocator);
+    try ensureControlRuntimeDir(base);
+
     const pid = std.c.getpid();
     const socket_name = try std.fmt.allocPrint(allocator, "architect_control_{d}.sock", .{pid});
     defer allocator.free(socket_name);
-    return try std.fs.path.joinZ(allocator, &.{ base, socket_name });
+    return try std.fs.path.joinZ(allocator, &.{ base.path, socket_name });
 }
 
 pub fn getControlDiscoveryPath(allocator: std.mem.Allocator) ![]u8 {
+    var base = try controlRuntimeDirAlloc(allocator);
+    defer base.deinit(allocator);
+    try ensureControlRuntimeDir(base);
+
     const file_name = try controlDiscoveryFileNameAlloc(allocator);
     defer allocator.free(file_name);
-    return try std.fs.path.join(allocator, &.{ runtimeDir(), file_name });
+    return try std.fs.path.join(allocator, &.{ base.path, file_name });
 }
 
-fn runtimeDir() []const u8 {
-    return std.posix.getenv("XDG_RUNTIME_DIR") orelse
-        std.posix.getenv("TMPDIR") orelse
-        "/tmp";
+const ControlRuntimeDir = struct {
+    path: []u8,
+    managed: bool,
+
+    fn deinit(self: *ControlRuntimeDir, allocator: std.mem.Allocator) void {
+        allocator.free(self.path);
+        self.* = undefined;
+    }
+};
+
+fn controlRuntimeDirAlloc(allocator: std.mem.Allocator) !ControlRuntimeDir {
+    if (std.posix.getenv("XDG_RUNTIME_DIR")) |runtime_dir| {
+        return .{
+            .path = try allocator.dupe(u8, runtime_dir),
+            .managed = false,
+        };
+    }
+
+    return .{
+        .path = try fallbackControlRuntimeDirAlloc(allocator),
+        .managed = true,
+    };
+}
+
+fn fallbackControlRuntimeDirAlloc(allocator: std.mem.Allocator) ![]u8 {
+    if (std.posix.getenv("HOME")) |home| {
+        if (builtin.os.tag == .macos) {
+            return try std.fs.path.join(allocator, &.{ home, "Library", "Caches", "Architect", "runtime" });
+        }
+        return try std.fs.path.join(allocator, &.{ home, ".cache", "architect", "runtime" });
+    }
+
+    return try std.fmt.allocPrint(allocator, "/tmp/architect-{d}", .{posix.getuid()});
+}
+
+fn ensureControlRuntimeDir(runtime_dir: ControlRuntimeDir) !void {
+    if (!runtime_dir.managed) return;
+
+    try std.fs.cwd().makePath(runtime_dir.path);
+    try posix.fchmodat(posix.AT.FDCWD, runtime_dir.path, 0o700, 0);
 }
 
 fn controlDiscoveryFileNameAlloc(allocator: std.mem.Allocator) ![]u8 {
@@ -716,7 +760,10 @@ fn discoverControlCandidates(allocator: std.mem.Allocator) !std.ArrayListUnmanag
         candidates.deinit(allocator);
     }
 
-    var dir = std.fs.openDirAbsolute(runtimeDir(), .{ .iterate = true }) catch |err| switch (err) {
+    var runtime_dir = try controlRuntimeDirAlloc(allocator);
+    defer runtime_dir.deinit(allocator);
+
+    var dir = std.fs.openDirAbsolute(runtime_dir.path, .{ .iterate = true }) catch |err| switch (err) {
         error.FileNotFound => return candidates,
         else => return err,
     };
@@ -905,6 +952,16 @@ test "control discovery file names are scoped to the current user and process" {
     try std.testing.expect(isOwnControlDiscoveryFileName(file_name, prefix));
     try std.testing.expect(!isOwnControlDiscoveryFileName("architect_control.json", prefix));
     try std.testing.expect(!isOwnControlDiscoveryFileName("not_architect_control_1_2.json", prefix));
+}
+
+test "fallback control runtime directory does not use TMPDIR" {
+    const allocator = std.testing.allocator;
+
+    const path = try fallbackControlRuntimeDirAlloc(allocator);
+    defer allocator.free(path);
+
+    try std.testing.expect(std.mem.indexOf(u8, path, "architect") != null);
+    try std.testing.expect(std.mem.indexOf(u8, path, "nix-shell.") == null);
 }
 
 test "newestDiscoveryCandidateIndex picks the highest mtime" {

--- a/src/app/control.zig
+++ b/src/app/control.zig
@@ -1,0 +1,736 @@
+const std = @import("std");
+const posix = std.posix;
+const atomic = std.atomic;
+
+const log = std.log.scoped(.control);
+
+pub const max_message_bytes: usize = 64 * 1024;
+const max_cwd_bytes: usize = 4096;
+const max_command_bytes: usize = 16 * 1024;
+const discovery_file_name = "architect_control.json";
+
+pub const SpawnErrorCode = enum {
+    invalid_request,
+    app_not_running,
+    full_grid,
+    invalid_cwd,
+    spawn_failed,
+
+    pub fn jsonString(self: SpawnErrorCode) []const u8 {
+        return switch (self) {
+            .invalid_request => "invalid_request",
+            .app_not_running => "app_not_running",
+            .full_grid => "full_grid",
+            .invalid_cwd => "invalid_cwd",
+            .spawn_failed => "spawn_failed",
+        };
+    }
+
+    pub fn fromString(value: []const u8) ?SpawnErrorCode {
+        if (std.mem.eql(u8, value, "invalid_request")) return .invalid_request;
+        if (std.mem.eql(u8, value, "app_not_running")) return .app_not_running;
+        if (std.mem.eql(u8, value, "full_grid")) return .full_grid;
+        if (std.mem.eql(u8, value, "invalid_cwd")) return .invalid_cwd;
+        if (std.mem.eql(u8, value, "spawn_failed")) return .spawn_failed;
+        return null;
+    }
+};
+
+pub const SpawnRequest = struct {
+    cwd: []const u8,
+    command: ?[]const u8 = null,
+    display_name: ?[]const u8 = null,
+
+    pub fn deinit(self: *SpawnRequest, allocator: std.mem.Allocator) void {
+        allocator.free(self.cwd);
+        if (self.command) |command| allocator.free(command);
+        if (self.display_name) |display_name| allocator.free(display_name);
+        self.* = undefined;
+    }
+};
+
+pub const SpawnSuccess = struct {
+    session_id: usize,
+    slot_index: usize,
+};
+
+pub const SpawnFailure = struct {
+    code: SpawnErrorCode,
+    message: []const u8,
+};
+
+pub const SpawnResponse = union(enum) {
+    success: SpawnSuccess,
+    failure: SpawnFailure,
+};
+
+pub const OwnedSpawnResponse = struct {
+    response: SpawnResponse,
+    owned_message: ?[]const u8 = null,
+
+    pub fn deinit(self: *OwnedSpawnResponse, allocator: std.mem.Allocator) void {
+        if (self.owned_message) |message| {
+            allocator.free(message);
+            self.owned_message = null;
+        }
+    }
+};
+
+pub const RuntimeWake = struct {
+    context: ?*anyopaque,
+    callback: *const fn (?*anyopaque) void,
+
+    pub fn notify(self: RuntimeWake) void {
+        self.callback(self.context);
+    }
+};
+
+pub const SpawnCompletion = struct {
+    mutex: std.Thread.Mutex = .{},
+    condition: std.Thread.Condition = .{},
+    completed: bool = false,
+    response: SpawnResponse = undefined,
+
+    pub fn complete(self: *SpawnCompletion, response: SpawnResponse) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        self.response = response;
+        self.completed = true;
+        self.condition.signal();
+    }
+
+    pub fn wait(self: *SpawnCompletion) SpawnResponse {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        while (!self.completed) {
+            self.condition.wait(&self.mutex);
+        }
+        return self.response;
+    }
+};
+
+pub const PendingSpawn = struct {
+    request: SpawnRequest,
+    completion: *SpawnCompletion,
+};
+
+pub const SpawnQueue = struct {
+    mutex: std.Thread.Mutex = .{},
+    items: std.ArrayListUnmanaged(PendingSpawn) = .empty,
+
+    pub fn deinit(self: *SpawnQueue, allocator: std.mem.Allocator) void {
+        self.items.deinit(allocator);
+    }
+
+    pub fn push(self: *SpawnQueue, allocator: std.mem.Allocator, item: PendingSpawn) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        try self.items.append(allocator, item);
+    }
+
+    pub fn drainAll(self: *SpawnQueue) std.ArrayListUnmanaged(PendingSpawn) {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const items = self.items;
+        self.items = .empty;
+        return items;
+    }
+};
+
+pub const ParseSpawnRequestError = error{
+    ExpectedObject,
+    MissingCwd,
+    InvalidCwd,
+    InvalidCommand,
+    InvalidDisplayName,
+    UnknownField,
+    OutOfMemory,
+};
+
+pub fn parseSpawnRequestFromValue(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+) ParseSpawnRequestError!SpawnRequest {
+    if (value != .object) return error.ExpectedObject;
+    const object = value.object;
+
+    var request = SpawnRequest{
+        .cwd = undefined,
+    };
+    var have_cwd = false;
+    var have_command = false;
+    var have_display_name = false;
+    errdefer {
+        if (have_cwd) allocator.free(request.cwd);
+        if (request.command) |command| allocator.free(command);
+        if (request.display_name) |display_name| allocator.free(display_name);
+    }
+
+    var iter = object.iterator();
+    while (iter.next()) |entry| {
+        const key = entry.key_ptr.*;
+        const field_value = entry.value_ptr.*;
+
+        if (std.mem.eql(u8, key, "cwd")) {
+            if (have_cwd) return error.InvalidCwd;
+            if (field_value != .string) return error.InvalidCwd;
+            request.cwd = duplicateValidatedString(allocator, field_value.string, max_cwd_bytes, true) catch |err| switch (err) {
+                error.EmptyString, error.StringTooLong, error.NulByte => return error.InvalidCwd,
+                error.OutOfMemory => return error.OutOfMemory,
+            };
+            have_cwd = true;
+            continue;
+        }
+
+        if (std.mem.eql(u8, key, "command")) {
+            if (have_command) return error.InvalidCommand;
+            have_command = true;
+            if (field_value == .null) {
+                request.command = null;
+                continue;
+            }
+            if (field_value != .string) return error.InvalidCommand;
+            request.command = duplicateValidatedString(allocator, field_value.string, max_command_bytes, true) catch |err| switch (err) {
+                error.EmptyString, error.StringTooLong, error.NulByte => return error.InvalidCommand,
+                error.OutOfMemory => return error.OutOfMemory,
+            };
+            continue;
+        }
+
+        if (std.mem.eql(u8, key, "display_name")) {
+            if (have_display_name) return error.InvalidDisplayName;
+            have_display_name = true;
+            if (field_value == .null) {
+                request.display_name = null;
+                continue;
+            }
+            if (field_value != .string) return error.InvalidDisplayName;
+            request.display_name = duplicateValidatedString(allocator, field_value.string, 512, true) catch |err| switch (err) {
+                error.EmptyString, error.StringTooLong, error.NulByte => return error.InvalidDisplayName,
+                error.OutOfMemory => return error.OutOfMemory,
+            };
+            continue;
+        }
+
+        return error.UnknownField;
+    }
+
+    if (!have_cwd) return error.MissingCwd;
+    return request;
+}
+
+const DuplicateStringError = error{
+    EmptyString,
+    StringTooLong,
+    NulByte,
+    OutOfMemory,
+};
+
+fn duplicateValidatedString(
+    allocator: std.mem.Allocator,
+    value: []const u8,
+    max_len: usize,
+    reject_empty: bool,
+) DuplicateStringError![]const u8 {
+    if (reject_empty and value.len == 0) return error.EmptyString;
+    if (value.len > max_len) return error.StringTooLong;
+    if (std.mem.indexOfScalar(u8, value, 0) != null) return error.NulByte;
+    return try allocator.dupe(u8, value);
+}
+
+pub fn getControlSocketPath(allocator: std.mem.Allocator) ![:0]u8 {
+    const base = runtimeDir();
+    const pid = std.c.getpid();
+    const socket_name = try std.fmt.allocPrint(allocator, "architect_control_{d}.sock", .{pid});
+    defer allocator.free(socket_name);
+    return try std.fs.path.joinZ(allocator, &.{ base, socket_name });
+}
+
+pub fn getControlDiscoveryPath(allocator: std.mem.Allocator) ![]u8 {
+    return try std.fs.path.join(allocator, &.{ runtimeDir(), discovery_file_name });
+}
+
+fn runtimeDir() []const u8 {
+    return std.posix.getenv("XDG_RUNTIME_DIR") orelse
+        std.posix.getenv("TMPDIR") orelse
+        "/tmp";
+}
+
+const ControlContext = struct {
+    allocator: std.mem.Allocator,
+    socket_path: [:0]const u8,
+    discovery_path: []const u8,
+    queue: *SpawnQueue,
+    stop: *atomic.Value(bool),
+    runtime_wake: ?RuntimeWake,
+};
+
+pub fn startControlThread(
+    allocator: std.mem.Allocator,
+    socket_path: [:0]const u8,
+    discovery_path: []const u8,
+    queue: *SpawnQueue,
+    stop: *atomic.Value(bool),
+    runtime_wake: ?RuntimeWake,
+) std.Thread.SpawnError!std.Thread {
+    _ = std.posix.unlink(socket_path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => log.warn("failed to unlink control socket: {}", .{err}),
+    };
+
+    const ctx = ControlContext{
+        .allocator = allocator,
+        .socket_path = socket_path,
+        .discovery_path = discovery_path,
+        .queue = queue,
+        .stop = stop,
+        .runtime_wake = runtime_wake,
+    };
+    return try std.Thread.spawn(.{}, controlThreadMain, .{ctx});
+}
+
+pub fn cleanupControlFiles(socket_path: [:0]const u8, discovery_path: []const u8) void {
+    _ = std.posix.unlink(socket_path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => log.warn("failed to unlink control socket during cleanup: {}", .{err}),
+    };
+    std.fs.deleteFileAbsolute(discovery_path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => log.warn("failed to delete control discovery file: {}", .{err}),
+    };
+}
+
+pub fn failPending(
+    queue: *SpawnQueue,
+    allocator: std.mem.Allocator,
+    code: SpawnErrorCode,
+    message: []const u8,
+) void {
+    var pending = queue.drainAll();
+    defer pending.deinit(allocator);
+    for (pending.items) |*item| {
+        item.completion.complete(.{ .failure = .{ .code = code, .message = message } });
+        item.request.deinit(allocator);
+    }
+}
+
+fn controlThreadMain(ctx: ControlContext) !void {
+    const addr = try std.net.Address.initUnix(ctx.socket_path);
+    const fd = try posix.socket(posix.AF.UNIX, posix.SOCK.STREAM, 0);
+    defer posix.close(fd);
+
+    try posix.bind(fd, &addr.any, addr.getOsSockLen());
+    try posix.listen(fd, 16);
+
+    const sock_path = std.mem.sliceTo(ctx.socket_path, 0);
+    std.posix.fchmodat(posix.AT.FDCWD, sock_path, 0o600, 0) catch |err| {
+        log.warn("failed to chmod control socket: {}", .{err});
+    };
+    writeDiscoveryFile(ctx.allocator, ctx.discovery_path, sock_path) catch |err| {
+        log.warn("failed to write control discovery file: {}", .{err});
+    };
+
+    const flags = posix.fcntl(fd, posix.F.GETFL, 0) catch |err| blk: {
+        log.warn("failed to get control socket flags: {}", .{err});
+        break :blk null;
+    };
+    if (flags) |f| {
+        var o_flags: posix.O = @bitCast(@as(u32, @intCast(f)));
+        o_flags.NONBLOCK = true;
+        if (posix.fcntl(fd, posix.F.SETFL, @as(u32, @bitCast(o_flags)))) |_| {} else |err| {
+            log.warn("failed to set control socket non-blocking: {}", .{err});
+        }
+    }
+
+    while (!ctx.stop.load(.seq_cst)) {
+        const conn_fd = posix.accept(fd, null, null, 0) catch |err| switch (err) {
+            error.WouldBlock => {
+                std.Thread.sleep(std.time.ns_per_ms * 10);
+                continue;
+            },
+            else => {
+                log.debug("control accept error: {}", .{err});
+                continue;
+            },
+        };
+        handleControlConnection(ctx.allocator, conn_fd, ctx.queue, ctx.runtime_wake);
+        posix.close(conn_fd);
+    }
+}
+
+fn handleControlConnection(
+    allocator: std.mem.Allocator,
+    conn_fd: posix.fd_t,
+    queue: *SpawnQueue,
+    runtime_wake: ?RuntimeWake,
+) void {
+    const bytes = readLineFromFd(allocator, conn_fd, max_message_bytes) catch |err| {
+        log.debug("failed to read control request: {}", .{err});
+        writeControlResponse(conn_fd, .{ .failure = .{
+            .code = .invalid_request,
+            .message = "invalid control request",
+        } }) catch |write_err| {
+            log.debug("failed to write invalid control request response: {}", .{write_err});
+        };
+        return;
+    };
+    defer allocator.free(bytes);
+
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, bytes, .{}) catch {
+        writeControlResponse(conn_fd, .{ .failure = .{
+            .code = .invalid_request,
+            .message = "request is not valid JSON",
+        } }) catch |write_err| {
+            log.debug("failed to write invalid JSON control response: {}", .{write_err});
+        };
+        return;
+    };
+    defer parsed.deinit();
+
+    var request = parseSpawnRequestFromValue(allocator, parsed.value) catch |err| {
+        writeControlResponse(conn_fd, .{ .failure = .{
+            .code = .invalid_request,
+            .message = parseErrorMessage(err),
+        } }) catch |write_err| {
+            log.debug("failed to write invalid spawn request response: {}", .{write_err});
+        };
+        return;
+    };
+    errdefer request.deinit(allocator);
+
+    var completion = SpawnCompletion{};
+    queue.push(allocator, .{
+        .request = request,
+        .completion = &completion,
+    }) catch |err| {
+        log.warn("failed to queue control request: {}", .{err});
+        request.deinit(allocator);
+        writeControlResponse(conn_fd, .{ .failure = .{
+            .code = .spawn_failed,
+            .message = "failed to queue spawn request",
+        } }) catch |write_err| {
+            log.debug("failed to write queue failure response: {}", .{write_err});
+        };
+        return;
+    };
+
+    if (runtime_wake) |waker| {
+        waker.notify();
+    }
+
+    const response = completion.wait();
+    writeControlResponse(conn_fd, response) catch |err| {
+        log.debug("failed to write control response: {}", .{err});
+    };
+}
+
+pub fn parseErrorMessage(err: ParseSpawnRequestError) []const u8 {
+    return switch (err) {
+        error.ExpectedObject => "spawn_session arguments must be an object",
+        error.MissingCwd => "cwd is required",
+        error.InvalidCwd => "cwd must be a non-empty string",
+        error.InvalidCommand => "command must be a non-empty string when provided",
+        error.InvalidDisplayName => "display_name must be a non-empty string when provided",
+        error.UnknownField => "spawn_session contains an unsupported field",
+        error.OutOfMemory => "out of memory while parsing spawn_session arguments",
+    };
+}
+
+fn writeDiscoveryFile(allocator: std.mem.Allocator, path: []const u8, socket_path: []const u8) !void {
+    const payload = try discoveryPayloadAlloc(allocator, socket_path);
+    defer allocator.free(payload);
+
+    const file = try std.fs.createFileAbsolute(path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(payload);
+}
+
+fn discoveryPayloadAlloc(allocator: std.mem.Allocator, socket_path: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    defer out.deinit();
+    var json: std.json.Stringify = .{ .writer = &out.writer };
+
+    try json.beginObject();
+    try json.objectField("pid");
+    try json.write(std.c.getpid());
+    try json.objectField("socket_path");
+    try json.write(socket_path);
+    try json.endObject();
+    try out.writer.writeByte('\n');
+
+    return try allocator.dupe(u8, out.written());
+}
+
+fn readLineFromFd(allocator: std.mem.Allocator, fd: posix.fd_t, max_bytes: usize) ![]u8 {
+    var buffer: std.ArrayList(u8) = .empty;
+    errdefer buffer.deinit(allocator);
+
+    var tmp: [512]u8 = undefined;
+    while (true) {
+        const n = try posix.read(fd, &tmp);
+        if (n == 0) break;
+
+        for (tmp[0..n]) |byte| {
+            if (byte == '\n') {
+                return try buffer.toOwnedSlice(allocator);
+            }
+            if (byte == '\r') continue;
+            if (buffer.items.len >= max_bytes) return error.MessageTooLarge;
+            try buffer.append(allocator, byte);
+        }
+    }
+
+    if (buffer.items.len == 0) return error.EndOfStream;
+    return try buffer.toOwnedSlice(allocator);
+}
+
+fn writeAllFd(fd: posix.fd_t, bytes: []const u8) !void {
+    var written: usize = 0;
+    while (written < bytes.len) {
+        const n = try posix.write(fd, bytes[written..]);
+        if (n == 0) return error.WriteFailed;
+        written += n;
+    }
+}
+
+fn writeControlResponse(fd: posix.fd_t, response: SpawnResponse) !void {
+    var buffer: [512]u8 = undefined;
+    var fbs = std.heap.FixedBufferAllocator.init(&buffer);
+    const allocator = fbs.allocator();
+    const payload = try controlResponseAlloc(allocator, response);
+    try writeAllFd(fd, payload);
+}
+
+pub fn controlRequestAlloc(allocator: std.mem.Allocator, request: SpawnRequest) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    defer out.deinit();
+    var json: std.json.Stringify = .{ .writer = &out.writer };
+
+    try json.beginObject();
+    try json.objectField("cwd");
+    try json.write(request.cwd);
+    if (request.command) |command| {
+        try json.objectField("command");
+        try json.write(command);
+    }
+    if (request.display_name) |display_name| {
+        try json.objectField("display_name");
+        try json.write(display_name);
+    }
+    try json.endObject();
+    try out.writer.writeByte('\n');
+
+    return try allocator.dupe(u8, out.written());
+}
+
+pub fn controlResponseAlloc(allocator: std.mem.Allocator, response: SpawnResponse) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    defer out.deinit();
+    var json: std.json.Stringify = .{ .writer = &out.writer };
+
+    try json.beginObject();
+    switch (response) {
+        .success => |success| {
+            try json.objectField("ok");
+            try json.write(true);
+            try json.objectField("session_id");
+            try json.write(success.session_id);
+            try json.objectField("slot_index");
+            try json.write(success.slot_index);
+        },
+        .failure => |failure| {
+            try json.objectField("ok");
+            try json.write(false);
+            try json.objectField("code");
+            try json.write(failure.code.jsonString());
+            try json.objectField("message");
+            try json.write(failure.message);
+        },
+    }
+    try json.endObject();
+    try out.writer.writeByte('\n');
+
+    return try allocator.dupe(u8, out.written());
+}
+
+pub fn connectAndSendSpawnRequest(
+    allocator: std.mem.Allocator,
+    request: SpawnRequest,
+) !OwnedSpawnResponse {
+    const discovery_path = try getControlDiscoveryPath(allocator);
+    defer allocator.free(discovery_path);
+
+    const discovery_file = std.fs.openFileAbsolute(discovery_path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return staticFailure(.app_not_running, "Architect is not running"),
+        else => return err,
+    };
+    defer discovery_file.close();
+
+    const discovery = try discovery_file.readToEndAlloc(allocator, max_message_bytes);
+    defer allocator.free(discovery);
+
+    const socket_path = parseDiscoverySocketPath(allocator, discovery) catch {
+        return staticFailure(.app_not_running, "Architect control discovery file is invalid");
+    };
+    defer allocator.free(socket_path);
+
+    const fd = posix.socket(posix.AF.UNIX, posix.SOCK.STREAM, 0) catch |err| switch (err) {
+        else => return err,
+    };
+    defer posix.close(fd);
+
+    const addr = std.net.Address.initUnix(socket_path) catch {
+        return staticFailure(.app_not_running, "Architect control socket path is invalid");
+    };
+    posix.connect(fd, &addr.any, addr.getOsSockLen()) catch {
+        return staticFailure(.app_not_running, "Architect is not accepting control requests");
+    };
+
+    const payload = try controlRequestAlloc(allocator, request);
+    defer allocator.free(payload);
+    try writeAllFd(fd, payload);
+
+    const response_bytes = try readLineFromFd(allocator, fd, max_message_bytes);
+    defer allocator.free(response_bytes);
+    return try parseControlResponse(allocator, response_bytes);
+}
+
+fn staticFailure(code: SpawnErrorCode, message: []const u8) OwnedSpawnResponse {
+    return .{
+        .response = .{ .failure = .{ .code = code, .message = message } },
+    };
+}
+
+fn parseDiscoverySocketPath(allocator: std.mem.Allocator, bytes: []const u8) ![]const u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, bytes, .{});
+    defer parsed.deinit();
+
+    if (parsed.value != .object) return error.InvalidDiscovery;
+    const socket_value = parsed.value.object.get("socket_path") orelse return error.InvalidDiscovery;
+    if (socket_value != .string or socket_value.string.len == 0) return error.InvalidDiscovery;
+    return try allocator.dupe(u8, socket_value.string);
+}
+
+fn parseControlResponse(allocator: std.mem.Allocator, bytes: []const u8) !OwnedSpawnResponse {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, bytes, .{});
+    defer parsed.deinit();
+
+    if (parsed.value != .object) return error.InvalidControlResponse;
+    const object = parsed.value.object;
+    const ok_value = object.get("ok") orelse return error.InvalidControlResponse;
+    if (ok_value != .bool) return error.InvalidControlResponse;
+
+    if (ok_value.bool) {
+        const session_id_value = object.get("session_id") orelse return error.InvalidControlResponse;
+        const slot_index_value = object.get("slot_index") orelse return error.InvalidControlResponse;
+        if (session_id_value != .integer or slot_index_value != .integer) return error.InvalidControlResponse;
+        if (session_id_value.integer < 0 or slot_index_value.integer < 0) return error.InvalidControlResponse;
+        return .{ .response = .{ .success = .{
+            .session_id = @intCast(session_id_value.integer),
+            .slot_index = @intCast(slot_index_value.integer),
+        } } };
+    }
+
+    const code_value = object.get("code") orelse return error.InvalidControlResponse;
+    const message_value = object.get("message") orelse return error.InvalidControlResponse;
+    if (code_value != .string or message_value != .string) return error.InvalidControlResponse;
+    const code = SpawnErrorCode.fromString(code_value.string) orelse return error.InvalidControlResponse;
+    const message = try allocator.dupe(u8, message_value.string);
+    return .{
+        .response = .{ .failure = .{ .code = code, .message = message } },
+        .owned_message = message,
+    };
+}
+
+test "parseSpawnRequestFromValue accepts cwd with optional metadata" {
+    const allocator = std.testing.allocator;
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, "{\"cwd\":\"/tmp\",\"command\":\"pwd\",\"display_name\":\"Task\"}", .{});
+    defer parsed.deinit();
+
+    var request = try parseSpawnRequestFromValue(allocator, parsed.value);
+    defer request.deinit(allocator);
+
+    try std.testing.expectEqualStrings("/tmp", request.cwd);
+    try std.testing.expectEqualStrings("pwd", request.command.?);
+    try std.testing.expectEqualStrings("Task", request.display_name.?);
+}
+
+test "parseSpawnRequestFromValue rejects invalid shapes" {
+    const allocator = std.testing.allocator;
+
+    const cases = [_][]const u8{
+        "{}",
+        "{\"cwd\":\"\"}",
+        "{\"cwd\":7}",
+        "{\"cwd\":\"/tmp\",\"command\":\"\"}",
+        "{\"cwd\":\"/tmp\",\"extra\":true}",
+    };
+
+    for (cases) |case| {
+        var parsed = try std.json.parseFromSlice(std.json.Value, allocator, case, .{});
+        defer parsed.deinit();
+        if (parseSpawnRequestFromValue(allocator, parsed.value)) |*request| {
+            request.deinit(allocator);
+            try std.testing.expect(false);
+        } else |_| {}
+    }
+}
+
+test "control response round-trips success and failure" {
+    const allocator = std.testing.allocator;
+
+    const success_payload = try controlResponseAlloc(allocator, .{ .success = .{
+        .session_id = 42,
+        .slot_index = 3,
+    } });
+    defer allocator.free(success_payload);
+
+    var success = try parseControlResponse(allocator, success_payload);
+    defer success.deinit(allocator);
+    switch (success.response) {
+        .success => |result| {
+            try std.testing.expectEqual(@as(usize, 42), result.session_id);
+            try std.testing.expectEqual(@as(usize, 3), result.slot_index);
+        },
+        .failure => try std.testing.expect(false),
+    }
+
+    const failure_payload = try controlResponseAlloc(allocator, .{ .failure = .{
+        .code = .full_grid,
+        .message = "all terminals are in use",
+    } });
+    defer allocator.free(failure_payload);
+
+    var failure = try parseControlResponse(allocator, failure_payload);
+    defer failure.deinit(allocator);
+    switch (failure.response) {
+        .failure => |result| {
+            try std.testing.expectEqual(SpawnErrorCode.full_grid, result.code);
+            try std.testing.expectEqualStrings("all terminals are in use", result.message);
+        },
+        .success => try std.testing.expect(false),
+    }
+}
+
+test "SpawnQueue drains queued requests" {
+    const allocator = std.testing.allocator;
+    var queue = SpawnQueue{};
+    defer queue.deinit(allocator);
+
+    var completion = SpawnCompletion{};
+    try queue.push(allocator, .{
+        .request = .{ .cwd = try allocator.dupe(u8, "/tmp") },
+        .completion = &completion,
+    });
+
+    var pending = queue.drainAll();
+    defer pending.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 1), pending.items.len);
+    pending.items[0].request.deinit(allocator);
+
+    var empty = queue.drainAll();
+    defer empty.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 0), empty.items.len);
+}

--- a/src/app/control.zig
+++ b/src/app/control.zig
@@ -7,7 +7,9 @@ const log = std.log.scoped(.control);
 pub const max_message_bytes: usize = 64 * 1024;
 const max_cwd_bytes: usize = 4096;
 const max_command_bytes: usize = 16 * 1024;
-const discovery_file_name = "architect_control.json";
+const discovery_file_prefix = "architect_control_";
+const discovery_file_suffix = ".json";
+const control_request_read_timeout_ms: i64 = 2000;
 
 pub const SpawnErrorCode = enum {
     invalid_request,
@@ -249,13 +251,31 @@ pub fn getControlSocketPath(allocator: std.mem.Allocator) ![:0]u8 {
 }
 
 pub fn getControlDiscoveryPath(allocator: std.mem.Allocator) ![]u8 {
-    return try std.fs.path.join(allocator, &.{ runtimeDir(), discovery_file_name });
+    const file_name = try controlDiscoveryFileNameAlloc(allocator);
+    defer allocator.free(file_name);
+    return try std.fs.path.join(allocator, &.{ runtimeDir(), file_name });
 }
 
 fn runtimeDir() []const u8 {
     return std.posix.getenv("XDG_RUNTIME_DIR") orelse
         std.posix.getenv("TMPDIR") orelse
         "/tmp";
+}
+
+fn controlDiscoveryFileNameAlloc(allocator: std.mem.Allocator) ![]u8 {
+    return try std.fmt.allocPrint(
+        allocator,
+        "{s}{d}_{d}{s}",
+        .{ discovery_file_prefix, posix.getuid(), std.c.getpid(), discovery_file_suffix },
+    );
+}
+
+fn controlDiscoveryFilePrefixAlloc(allocator: std.mem.Allocator) ![]u8 {
+    return try std.fmt.allocPrint(allocator, "{s}{d}_", .{ discovery_file_prefix, posix.getuid() });
+}
+
+fn isOwnControlDiscoveryFileName(file_name: []const u8, prefix: []const u8) bool {
+    return std.mem.startsWith(u8, file_name, prefix) and std.mem.endsWith(u8, file_name, discovery_file_suffix);
 }
 
 const ControlContext = struct {
@@ -332,17 +352,7 @@ fn controlThreadMain(ctx: ControlContext) !void {
         log.warn("failed to write control discovery file: {}", .{err});
     };
 
-    const flags = posix.fcntl(fd, posix.F.GETFL, 0) catch |err| blk: {
-        log.warn("failed to get control socket flags: {}", .{err});
-        break :blk null;
-    };
-    if (flags) |f| {
-        var o_flags: posix.O = @bitCast(@as(u32, @intCast(f)));
-        o_flags.NONBLOCK = true;
-        if (posix.fcntl(fd, posix.F.SETFL, @as(u32, @bitCast(o_flags)))) |_| {} else |err| {
-            log.warn("failed to set control socket non-blocking: {}", .{err});
-        }
-    }
+    setFdNonBlocking(fd, "control socket");
 
     while (!ctx.stop.load(.seq_cst)) {
         const conn_fd = posix.accept(fd, null, null, 0) catch |err| switch (err) {
@@ -355,8 +365,22 @@ fn controlThreadMain(ctx: ControlContext) !void {
                 continue;
             },
         };
+        setFdNonBlocking(conn_fd, "control connection");
         handleControlConnection(ctx.allocator, conn_fd, ctx.queue, ctx.runtime_wake);
         posix.close(conn_fd);
+    }
+}
+
+fn setFdNonBlocking(fd: posix.fd_t, context: []const u8) void {
+    const flags = posix.fcntl(fd, posix.F.GETFL, 0) catch |err| {
+        log.warn("failed to get {s} flags: {}", .{ context, err });
+        return;
+    };
+
+    var o_flags: posix.O = @bitCast(@as(u32, @intCast(flags)));
+    o_flags.NONBLOCK = true;
+    if (posix.fcntl(fd, posix.F.SETFL, @as(u32, @bitCast(o_flags)))) |_| {} else |err| {
+        log.warn("failed to set {s} non-blocking: {}", .{ context, err });
     }
 }
 
@@ -366,7 +390,7 @@ fn handleControlConnection(
     queue: *SpawnQueue,
     runtime_wake: ?RuntimeWake,
 ) void {
-    const bytes = readLineFromFd(allocator, conn_fd, max_message_bytes) catch |err| {
+    const bytes = readLineFromFdWithTimeout(allocator, conn_fd, max_message_bytes, control_request_read_timeout_ms) catch |err| {
         log.debug("failed to read control request: {}", .{err});
         writeControlResponse(conn_fd, .{ .failure = .{
             .code = .invalid_request,
@@ -442,9 +466,42 @@ fn writeDiscoveryFile(allocator: std.mem.Allocator, path: []const u8, socket_pat
     const payload = try discoveryPayloadAlloc(allocator, socket_path);
     defer allocator.free(payload);
 
-    const file = try std.fs.createFileAbsolute(path, .{ .truncate = true });
-    defer file.close();
+    const dir_path = std.fs.path.dirname(path) orelse return error.InvalidDiscoveryPath;
+    const base_name = std.fs.path.basename(path);
+
+    var dir = try std.fs.openDirAbsolute(dir_path, .{});
+    defer dir.close();
+
+    const temp_name = try std.fmt.allocPrint(
+        allocator,
+        ".{s}.{x}.tmp",
+        .{ base_name, std.crypto.random.int(u64) },
+    );
+    defer allocator.free(temp_name);
+
+    var file = try dir.createFile(temp_name, .{
+        .exclusive = true,
+        .mode = 0o600,
+    });
+    var file_open = true;
+    errdefer if (file_open) file.close();
+    errdefer deleteTempDiscoveryFile(&dir, temp_name);
+
+    try posix.fchmod(file.handle, 0o600);
     try file.writeAll(payload);
+    try file.sync();
+    file.close();
+    file_open = false;
+
+    try dir.rename(temp_name, base_name);
+    log.info("wrote control discovery file {s} for socket {s}", .{ path, socket_path });
+}
+
+fn deleteTempDiscoveryFile(dir: *std.fs.Dir, temp_name: []const u8) void {
+    dir.deleteFile(temp_name) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => log.warn("failed to delete temporary control discovery file {s}: {}", .{ temp_name, err }),
+    };
 }
 
 fn discoveryPayloadAlloc(allocator: std.mem.Allocator, socket_path: []const u8) ![]u8 {
@@ -464,12 +521,40 @@ fn discoveryPayloadAlloc(allocator: std.mem.Allocator, socket_path: []const u8) 
 }
 
 fn readLineFromFd(allocator: std.mem.Allocator, fd: posix.fd_t, max_bytes: usize) ![]u8 {
+    return try readLineFromFdWithTimeout(allocator, fd, max_bytes, null);
+}
+
+fn readLineFromFdWithTimeout(
+    allocator: std.mem.Allocator,
+    fd: posix.fd_t,
+    max_bytes: usize,
+    timeout_ms: ?i64,
+) ![]u8 {
     var buffer: std.ArrayList(u8) = .empty;
     errdefer buffer.deinit(allocator);
 
+    const deadline_ms = if (timeout_ms) |ms| std.time.milliTimestamp() + ms else null;
     var tmp: [512]u8 = undefined;
     while (true) {
-        const n = try posix.read(fd, &tmp);
+        if (deadline_ms) |deadline| {
+            const now = std.time.milliTimestamp();
+            if (now >= deadline) return error.TimedOut;
+
+            const remaining_ms = deadline - now;
+            const poll_timeout: i32 = @intCast(@min(remaining_ms, std.math.maxInt(i32)));
+            var fds = [_]posix.pollfd{.{
+                .fd = fd,
+                .events = posix.POLL.IN,
+                .revents = 0,
+            }};
+            const ready = try posix.poll(&fds, poll_timeout);
+            if (ready == 0) return error.TimedOut;
+        }
+
+        const n = posix.read(fd, &tmp) catch |err| switch (err) {
+            error.WouldBlock => continue,
+            else => return err,
+        };
         if (n == 0) break;
 
         for (tmp[0..n]) |byte| {
@@ -559,42 +644,136 @@ pub fn connectAndSendSpawnRequest(
     allocator: std.mem.Allocator,
     request: SpawnRequest,
 ) !OwnedSpawnResponse {
-    const discovery_path = try getControlDiscoveryPath(allocator);
-    defer allocator.free(discovery_path);
-
-    const discovery_file = std.fs.openFileAbsolute(discovery_path, .{}) catch |err| switch (err) {
-        error.FileNotFound => return staticFailure(.app_not_running, "Architect is not running"),
+    var connection = connectToNewestControlSocket(allocator) catch |err| switch (err) {
+        error.NoControlDiscoveryFile => return staticFailure(.app_not_running, "Architect is not running"),
+        error.NoLiveControlSocket => return staticFailure(.app_not_running, "Architect is not accepting control requests"),
         else => return err,
     };
-    defer discovery_file.close();
-
-    const discovery = try discovery_file.readToEndAlloc(allocator, max_message_bytes);
-    defer allocator.free(discovery);
-
-    const socket_path = parseDiscoverySocketPath(allocator, discovery) catch {
-        return staticFailure(.app_not_running, "Architect control discovery file is invalid");
-    };
-    defer allocator.free(socket_path);
-
-    const fd = posix.socket(posix.AF.UNIX, posix.SOCK.STREAM, 0) catch |err| switch (err) {
-        else => return err,
-    };
-    defer posix.close(fd);
-
-    const addr = std.net.Address.initUnix(socket_path) catch {
-        return staticFailure(.app_not_running, "Architect control socket path is invalid");
-    };
-    posix.connect(fd, &addr.any, addr.getOsSockLen()) catch {
-        return staticFailure(.app_not_running, "Architect is not accepting control requests");
-    };
+    defer connection.deinit(allocator);
 
     const payload = try controlRequestAlloc(allocator, request);
     defer allocator.free(payload);
-    try writeAllFd(fd, payload);
+    try writeAllFd(connection.fd, payload);
 
-    const response_bytes = try readLineFromFd(allocator, fd, max_message_bytes);
+    const response_bytes = try readLineFromFd(allocator, connection.fd, max_message_bytes);
     defer allocator.free(response_bytes);
     return try parseControlResponse(allocator, response_bytes);
+}
+
+const ControlConnection = struct {
+    fd: posix.fd_t,
+    socket_path: []const u8,
+
+    fn deinit(self: *ControlConnection, allocator: std.mem.Allocator) void {
+        posix.close(self.fd);
+        allocator.free(self.socket_path);
+        self.* = undefined;
+    }
+};
+
+const DiscoveryCandidate = struct {
+    socket_path: []const u8,
+    mtime: i128,
+
+    fn deinit(self: *DiscoveryCandidate, allocator: std.mem.Allocator) void {
+        allocator.free(self.socket_path);
+        self.* = undefined;
+    }
+};
+
+fn connectToNewestControlSocket(allocator: std.mem.Allocator) !ControlConnection {
+    var candidates = try discoverControlCandidates(allocator);
+    defer {
+        for (candidates.items) |*candidate| candidate.deinit(allocator);
+        candidates.deinit(allocator);
+    }
+
+    if (candidates.items.len == 0) return error.NoControlDiscoveryFile;
+
+    while (candidates.items.len > 0) {
+        const idx = newestDiscoveryCandidateIndex(candidates.items);
+        const candidate = candidates.items[idx];
+        const fd = connectControlSocket(candidate.socket_path) catch |err| {
+            log.debug("failed to connect to discovered control socket {s}: {}", .{ candidate.socket_path, err });
+            var removed = candidates.swapRemove(idx);
+            removed.deinit(allocator);
+            continue;
+        };
+        errdefer posix.close(fd);
+        return .{
+            .fd = fd,
+            .socket_path = try allocator.dupe(u8, candidate.socket_path),
+        };
+    }
+
+    return error.NoLiveControlSocket;
+}
+
+fn discoverControlCandidates(allocator: std.mem.Allocator) !std.ArrayListUnmanaged(DiscoveryCandidate) {
+    var candidates: std.ArrayListUnmanaged(DiscoveryCandidate) = .empty;
+    errdefer {
+        for (candidates.items) |*candidate| candidate.deinit(allocator);
+        candidates.deinit(allocator);
+    }
+
+    var dir = std.fs.openDirAbsolute(runtimeDir(), .{ .iterate = true }) catch |err| switch (err) {
+        error.FileNotFound => return candidates,
+        else => return err,
+    };
+    defer dir.close();
+
+    const prefix = try controlDiscoveryFilePrefixAlloc(allocator);
+    defer allocator.free(prefix);
+
+    var iter = dir.iterate();
+    while (try iter.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (!isOwnControlDiscoveryFileName(entry.name, prefix)) continue;
+
+        const stat = dir.statFile(entry.name) catch |err| {
+            log.debug("failed to stat control discovery file {s}: {}", .{ entry.name, err });
+            continue;
+        };
+        const discovery = dir.readFileAlloc(allocator, entry.name, max_message_bytes) catch |err| {
+            log.debug("failed to read control discovery file {s}: {}", .{ entry.name, err });
+            continue;
+        };
+        defer allocator.free(discovery);
+
+        const socket_path = parseDiscoverySocketPath(allocator, discovery) catch |err| {
+            log.debug("failed to parse control discovery file {s}: {}", .{ entry.name, err });
+            continue;
+        };
+
+        candidates.append(allocator, .{
+            .socket_path = socket_path,
+            .mtime = stat.mtime,
+        }) catch |err| {
+            allocator.free(socket_path);
+            return err;
+        };
+    }
+
+    return candidates;
+}
+
+fn newestDiscoveryCandidateIndex(candidates: []const DiscoveryCandidate) usize {
+    var newest_idx: usize = 0;
+    for (candidates[1..], 1..) |candidate, idx| {
+        if (candidate.mtime > candidates[newest_idx].mtime) {
+            newest_idx = idx;
+        }
+    }
+    return newest_idx;
+}
+
+fn connectControlSocket(socket_path: []const u8) !posix.fd_t {
+    const fd = try posix.socket(posix.AF.UNIX, posix.SOCK.STREAM, 0);
+    errdefer posix.close(fd);
+
+    const addr = try std.net.Address.initUnix(socket_path);
+    try posix.connect(fd, &addr.any, addr.getOsSockLen());
+    return fd;
 }
 
 fn staticFailure(code: SpawnErrorCode, message: []const u8) OwnedSpawnResponse {
@@ -712,6 +891,30 @@ test "control response round-trips success and failure" {
         },
         .success => try std.testing.expect(false),
     }
+}
+
+test "control discovery file names are scoped to the current user and process" {
+    const allocator = std.testing.allocator;
+
+    const prefix = try controlDiscoveryFilePrefixAlloc(allocator);
+    defer allocator.free(prefix);
+
+    const file_name = try controlDiscoveryFileNameAlloc(allocator);
+    defer allocator.free(file_name);
+
+    try std.testing.expect(isOwnControlDiscoveryFileName(file_name, prefix));
+    try std.testing.expect(!isOwnControlDiscoveryFileName("architect_control.json", prefix));
+    try std.testing.expect(!isOwnControlDiscoveryFileName("not_architect_control_1_2.json", prefix));
+}
+
+test "newestDiscoveryCandidateIndex picks the highest mtime" {
+    const candidates = [_]DiscoveryCandidate{
+        .{ .socket_path = "/tmp/old.sock", .mtime = 10 },
+        .{ .socket_path = "/tmp/new.sock", .mtime = 30 },
+        .{ .socket_path = "/tmp/mid.sock", .mtime = 20 },
+    };
+
+    try std.testing.expectEqual(@as(usize, 1), newestDiscoveryCandidateIndex(&candidates));
 }
 
 test "SpawnQueue drains queued requests" {

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -13,6 +13,7 @@ const layout = @import("layout.zig");
 const terminal_actions = @import("terminal_actions.zig");
 const ui_host = @import("ui_host.zig");
 const worktree = @import("worktree.zig");
+const control = @import("control.zig");
 const notify = @import("../session/notify.zig");
 const session_state = @import("../session/state.zig");
 const view_state = @import("../ui/session_view_state.zig");
@@ -50,6 +51,7 @@ const foreground_process_cache_ms: i64 = 150;
 const Rect = app_state.Rect;
 const AnimationState = app_state.AnimationState;
 const NotificationQueue = notify.NotificationQueue;
+const ControlQueue = control.SpawnQueue;
 const SessionState = session_state.SessionState;
 const SessionViewState = view_state.SessionViewState;
 const GridLayout = grid_layout.GridLayout;
@@ -477,6 +479,204 @@ const WorkingDir = struct {
     }
 };
 
+const ExternalSpawnPlan = struct {
+    slot_index: usize,
+    cols: usize,
+    rows: usize,
+    expands_grid: bool,
+};
+
+fn planExternalSpawnSlot(
+    sessions: []const *SessionState,
+    grid_cols: usize,
+    grid_rows: usize,
+    focused_session: usize,
+) ?ExternalSpawnPlan {
+    const spawned_count = countSpawnedSessions(sessions);
+    if (spawned_count >= grid_layout.max_terminals) return null;
+
+    const capacity = grid_cols * grid_rows;
+    if (spawned_count >= capacity) {
+        const new_dims = GridLayout.calculateDimensions(spawned_count + 1);
+        const new_capacity = new_dims.cols * new_dims.rows;
+        if (new_capacity > grid_layout.max_terminals) return null;
+        const slot_index = findNextFreeSlotAfter(sessions, new_capacity, focused_session) orelse return null;
+        return .{
+            .slot_index = slot_index,
+            .cols = new_dims.cols,
+            .rows = new_dims.rows,
+            .expands_grid = true,
+        };
+    }
+
+    const slot_index = if (focused_session < sessions.len and !sessions[focused_session].spawned)
+        focused_session
+    else
+        findNextFreeSlotAfter(sessions, capacity, focused_session) orelse return null;
+
+    return .{
+        .slot_index = slot_index,
+        .cols = grid_cols,
+        .rows = grid_rows,
+        .expands_grid = false,
+    };
+}
+
+fn validateExternalSpawnCwd(cwd: []const u8) ?control.SpawnFailure {
+    if (!std.fs.path.isAbsolute(cwd)) {
+        return .{
+            .code = .invalid_cwd,
+            .message = "cwd must be an absolute directory",
+        };
+    }
+
+    var dir = std.fs.openDirAbsolute(cwd, .{}) catch {
+        return .{
+            .code = .invalid_cwd,
+            .message = "cwd must be an existing directory",
+        };
+    };
+    dir.close();
+    return null;
+}
+
+fn buildQueuedCommand(allocator: std.mem.Allocator, command: []const u8) ![]u8 {
+    if (command.len == 0) return error.EmptyCommand;
+    const needs_newline = command[command.len - 1] != '\n';
+    const out_len = command.len + @as(usize, if (needs_newline) 1 else 0);
+    const out = try allocator.alloc(u8, out_len);
+    @memcpy(out[0..command.len], command);
+    if (needs_newline) out[out.len - 1] = '\n';
+    return out;
+}
+
+fn completeExternalSpawnFailure(
+    pending: *control.PendingSpawn,
+    code: control.SpawnErrorCode,
+    message: []const u8,
+) void {
+    pending.completion.complete(.{ .failure = .{
+        .code = code,
+        .message = message,
+    } });
+}
+
+fn handleExternalSpawnRequest(
+    allocator: std.mem.Allocator,
+    pending: *control.PendingSpawn,
+    sessions: []const *SessionState,
+    grid: *GridLayout,
+    anim_state: *AnimationState,
+    session_interaction_component: *ui_mod.SessionInteractionComponent,
+    loop: *xev.Loop,
+    animations_enabled: bool,
+    now: i64,
+    render_width: c_int,
+    render_height: c_int,
+    ui_scale: f32,
+    font: *font_mod.Font,
+    grid_font_scale: f32,
+    full_cols: *u16,
+    full_rows: *u16,
+    cell_width_pixels: *c_int,
+    cell_height_pixels: *c_int,
+) void {
+    if (validateExternalSpawnCwd(pending.request.cwd)) |failure| {
+        pending.completion.complete(.{ .failure = failure });
+        return;
+    }
+
+    const plan = planExternalSpawnSlot(sessions, grid.cols, grid.rows, anim_state.focused_session) orelse {
+        completeExternalSpawnFailure(pending, .full_grid, "all Architect terminal slots are in use");
+        return;
+    };
+
+    const command_input = if (pending.request.command) |command| blk: {
+        break :blk buildQueuedCommand(allocator, command) catch |err| {
+            log.warn("failed to prepare external spawn command: {}", .{err});
+            completeExternalSpawnFailure(pending, .spawn_failed, "failed to prepare command for the new session");
+            return;
+        };
+    } else null;
+    defer if (command_input) |input_bytes| allocator.free(input_bytes);
+
+    const cwd_buf = allocZ(allocator, pending.request.cwd) catch |err| {
+        log.warn("failed to allocate external spawn cwd: {}", .{err});
+        completeExternalSpawnFailure(pending, .spawn_failed, "failed to prepare working directory");
+        return;
+    };
+    defer allocator.free(cwd_buf);
+    const cwd_z: [:0]const u8 = cwd_buf[0..pending.request.cwd.len :0];
+
+    if (plan.expands_grid) {
+        var moves = collectSessionMovesCurrent(sessions, allocator) catch |err| {
+            log.warn("failed to collect external spawn grid moves: {}", .{err});
+            completeExternalSpawnFailure(pending, .spawn_failed, "failed to prepare grid expansion");
+            return;
+        };
+        defer moves.deinit(allocator);
+
+        if (animations_enabled) {
+            grid.startResize(plan.cols, plan.rows, now, render_width, render_height, moves.items) catch |err| {
+                log.warn("failed to start external spawn grid resize: {}", .{err});
+                grid.cols = plan.cols;
+                grid.rows = plan.rows;
+            };
+            if (grid.is_resizing) {
+                anim_state.mode = .GridResizing;
+            }
+        } else {
+            grid.cols = plan.cols;
+            grid.rows = plan.rows;
+        }
+    }
+
+    const session = sessions[plan.slot_index];
+    session.ensureSpawnedWithDir(cwd_z, loop) catch |err| {
+        log.warn("external spawn failed for cwd {s}: {}", .{ pending.request.cwd, err });
+        completeExternalSpawnFailure(pending, .spawn_failed, "failed to spawn terminal session");
+        return;
+    };
+
+    if (command_input) |input_bytes| {
+        session.pending_write.appendSlice(allocator, input_bytes) catch |err| {
+            log.warn("failed to queue external spawn command for session {d}: {}", .{ session.id, err });
+            completeExternalSpawnFailure(pending, .spawn_failed, "failed to queue command for the new session");
+            return;
+        };
+    }
+
+    session_interaction_component.setStatus(plan.slot_index, .running);
+    session_interaction_component.setAttention(plan.slot_index, false, now);
+    session_interaction_component.clearSelection(anim_state.focused_session);
+    session_interaction_component.clearSelection(plan.slot_index);
+
+    anim_state.previous_session = anim_state.focused_session;
+    anim_state.focused_session = plan.slot_index;
+
+    cell_width_pixels.* = @divFloor(render_width, @as(c_int, @intCast(grid.cols)));
+    cell_height_pixels.* = @divFloor(render_height, @as(c_int, @intCast(grid.rows)));
+    applyTerminalLayout(
+        sessions,
+        allocator,
+        font,
+        render_width,
+        render_height,
+        ui_scale,
+        anim_state.mode,
+        grid.cols,
+        grid.rows,
+        grid_font_scale,
+        full_cols,
+        full_rows,
+    );
+
+    pending.completion.complete(.{ .success = .{
+        .session_id = session.id,
+        .slot_index = plan.slot_index,
+    } });
+}
+
 fn initSharedFont(
     allocator: std.mem.Allocator,
     renderer: *c.SDL_Renderer,
@@ -901,10 +1101,20 @@ pub fn run() !void {
     var notify_queue = NotificationQueue{};
     defer notify_queue.deinit(allocator);
 
+    var control_queue = ControlQueue{};
+    defer control_queue.deinit(allocator);
+
     const notify_sock = try notify.getNotifySocketPath(allocator);
     defer allocator.free(notify_sock);
 
+    const control_sock = try control.getControlSocketPath(allocator);
+    defer allocator.free(control_sock);
+
+    const control_discovery_path = try control.getControlDiscoveryPath(allocator);
+    defer allocator.free(control_discovery_path);
+
     var notify_stop = std.atomic.Value(bool).init(false);
+    var control_stop = std.atomic.Value(bool).init(false);
 
     var config = config_mod.Config.load(allocator) catch |err| blk: {
         if (err == error.ConfigNotFound) {
@@ -1013,6 +1223,23 @@ pub fn run() !void {
     defer {
         notify_stop.store(true, .seq_cst);
         notify_thread.join();
+    }
+    const control_thread = try control.startControlThread(
+        allocator,
+        control_sock,
+        control_discovery_path,
+        &control_queue,
+        &control_stop,
+        .{
+            .context = &sdl,
+            .callback = platform.pushWakeEventFromOpaque,
+        },
+    );
+    defer {
+        control_stop.store(true, .seq_cst);
+        control.failPending(&control_queue, allocator, .app_not_running, "Architect is shutting down");
+        control_thread.join();
+        control.cleanupControlFiles(control_sock, control_discovery_path);
     }
     var text_input_active = true;
     var input_source_tracker = macos_input.InputSourceTracker.init();
@@ -2071,6 +2298,33 @@ pub fn run() !void {
         }
         const any_session_dirty = render_cache.anyDirty(sessions);
 
+        var control_requests = control_queue.drainAll();
+        defer control_requests.deinit(allocator);
+        const had_control_requests = control_requests.items.len > 0;
+        for (control_requests.items) |*request| {
+            handleExternalSpawnRequest(
+                allocator,
+                request,
+                sessions,
+                &grid,
+                &anim_state,
+                session_interaction_component,
+                &loop,
+                animations_enabled,
+                now,
+                render_width,
+                render_height,
+                ui_scale,
+                &font,
+                config.grid.font_scale,
+                &full_cols,
+                &full_rows,
+                &cell_width_pixels,
+                &cell_height_pixels,
+            );
+            request.request.deinit(allocator);
+        }
+
         var notifications = notify_queue.drainAll();
         defer notifications.deinit(allocator);
         const had_notifications = notifications.items.len > 0;
@@ -2690,7 +2944,7 @@ pub fn run() !void {
         const animating = anim_state.mode != .Grid and anim_state.mode != .Full;
         const ui_needs_frame = ui.needsFrame(&ui_render_host);
         const last_render_stale = last_render_ns == 0 or (frame_start_ns - last_render_ns) >= max_idle_render_gap_ns;
-        const should_render = animating or any_session_dirty or ui_needs_frame or processed_event or had_notifications or last_render_stale;
+        const should_render = animating or any_session_dirty or ui_needs_frame or processed_event or had_notifications or had_control_requests or last_render_stale;
 
         if (should_render) {
             if (relaunch_trace_frames > 0) {
@@ -2733,7 +2987,7 @@ pub fn run() !void {
             relaunch_trace_frames -= 1;
         }
 
-        const is_idle = !animating and !any_session_dirty and !ui_needs_frame and !processed_event and !had_notifications;
+        const is_idle = !animating and !any_session_dirty and !ui_needs_frame and !processed_event and !had_notifications and !had_control_requests;
 
         if (window_close_suppress_countdown > 0) {
             window_close_suppress_countdown -= 1;
@@ -2797,6 +3051,65 @@ fn allocZ(allocator: std.mem.Allocator, data: []const u8) ![]u8 {
     @memcpy(buf[0..data.len], data);
     buf[data.len] = 0;
     return buf;
+}
+
+test "planExternalSpawnSlot expands a full current grid" {
+    var first: SessionState = undefined;
+    first.spawned = true;
+    var second: SessionState = undefined;
+    second.spawned = false;
+    var sessions = [_]*SessionState{ &first, &second };
+
+    const plan = planExternalSpawnSlot(&sessions, 1, 1, 0) orelse return error.TestUnexpectedResult;
+    try std.testing.expect(plan.expands_grid);
+    try std.testing.expectEqual(@as(usize, 2), plan.cols);
+    try std.testing.expectEqual(@as(usize, 1), plan.rows);
+    try std.testing.expectEqual(@as(usize, 1), plan.slot_index);
+}
+
+test "planExternalSpawnSlot reuses free capacity" {
+    var first: SessionState = undefined;
+    first.spawned = true;
+    var second: SessionState = undefined;
+    second.spawned = false;
+    var sessions = [_]*SessionState{ &first, &second };
+
+    const plan = planExternalSpawnSlot(&sessions, 2, 1, 0) orelse return error.TestUnexpectedResult;
+    try std.testing.expect(!plan.expands_grid);
+    try std.testing.expectEqual(@as(usize, 2), plan.cols);
+    try std.testing.expectEqual(@as(usize, 1), plan.rows);
+    try std.testing.expectEqual(@as(usize, 1), plan.slot_index);
+}
+
+test "planExternalSpawnSlot reports full grid" {
+    var storage: [grid_layout.max_terminals]SessionState = undefined;
+    var sessions: [grid_layout.max_terminals]*SessionState = undefined;
+    for (&storage, 0..) |*session, idx| {
+        session.* = undefined;
+        session.spawned = true;
+        sessions[idx] = session;
+    }
+
+    try std.testing.expect(planExternalSpawnSlot(&sessions, grid_layout.max_grid_size, grid_layout.max_grid_size, 0) == null);
+}
+
+test "validateExternalSpawnCwd accepts directories and rejects relative paths" {
+    try std.testing.expect(validateExternalSpawnCwd("/tmp") == null);
+
+    const failure = validateExternalSpawnCwd("relative/path") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(control.SpawnErrorCode.invalid_cwd, failure.code);
+}
+
+test "buildQueuedCommand appends a newline only when needed" {
+    const allocator = std.testing.allocator;
+
+    const first = try buildQueuedCommand(allocator, "echo ok");
+    defer allocator.free(first);
+    try std.testing.expectEqualStrings("echo ok\n", first);
+
+    const second = try buildQueuedCommand(allocator, "echo ok\n");
+    defer allocator.free(second);
+    try std.testing.expectEqualStrings("echo ok\n", second);
 }
 
 test "waitTimeoutMsFromNs rounds up to whole milliseconds" {

--- a/src/mcp/main.zig
+++ b/src/mcp/main.zig
@@ -1,0 +1,503 @@
+const std = @import("std");
+const control = @import("control");
+
+const log = std.log.scoped(.mcp);
+const protocol_version = "2025-11-25";
+const server_name = "architect-mcp";
+const server_version = "0.1.0";
+const tool_name = "spawn_session";
+
+const JsonRpcErrorCode = enum(i32) {
+    parse_error = -32700,
+    invalid_request = -32600,
+    method_not_found = -32601,
+    invalid_params = -32602,
+    internal_error = -32603,
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    try run(gpa.allocator(), std.fs.File.stdin(), std.fs.File.stdout());
+}
+
+pub fn run(allocator: std.mem.Allocator, stdin_file: std.fs.File, stdout_file: std.fs.File) !void {
+    var buffer: std.ArrayList(u8) = .empty;
+    defer buffer.deinit(allocator);
+
+    var chunk: [4096]u8 = undefined;
+    while (true) {
+        const n = try stdin_file.read(&chunk);
+        if (n == 0) break;
+
+        for (chunk[0..n]) |byte| {
+            if (byte == '\n') {
+                if (buffer.items.len > 0) {
+                    try handleMessage(allocator, stdout_file, buffer.items);
+                    buffer.clearRetainingCapacity();
+                }
+                continue;
+            }
+            if (byte == '\r') continue;
+            if (buffer.items.len >= control.max_message_bytes) {
+                try writeJsonRpcError(allocator, stdout_file, null, .invalid_request, "message is too large");
+                buffer.clearRetainingCapacity();
+                continue;
+            }
+            try buffer.append(allocator, byte);
+        }
+    }
+
+    if (buffer.items.len > 0) {
+        try handleMessage(allocator, stdout_file, buffer.items);
+    }
+}
+
+fn handleMessage(
+    allocator: std.mem.Allocator,
+    stdout_file: std.fs.File,
+    bytes: []const u8,
+) !void {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, bytes, .{}) catch {
+        try writeJsonRpcError(allocator, stdout_file, null, .parse_error, "parse error");
+        return;
+    };
+    defer parsed.deinit();
+
+    if (parsed.value != .object) {
+        try writeJsonRpcError(allocator, stdout_file, null, .invalid_request, "request must be an object");
+        return;
+    }
+
+    const object = parsed.value.object;
+    const method_value = object.get("method") orelse {
+        try writeJsonRpcError(allocator, stdout_file, object.get("id"), .invalid_request, "method is required");
+        return;
+    };
+    if (method_value != .string) {
+        try writeJsonRpcError(allocator, stdout_file, object.get("id"), .invalid_request, "method must be a string");
+        return;
+    }
+
+    const id_value = object.get("id");
+    if (id_value == null) {
+        if (std.mem.eql(u8, method_value.string, "notifications/initialized")) {
+            return;
+        }
+        return;
+    }
+
+    if (std.mem.eql(u8, method_value.string, "initialize")) {
+        try writeInitializeResult(allocator, stdout_file, id_value);
+    } else if (std.mem.eql(u8, method_value.string, "ping")) {
+        try writeEmptyResult(allocator, stdout_file, id_value);
+    } else if (std.mem.eql(u8, method_value.string, "tools/list")) {
+        try writeToolsListResult(allocator, stdout_file, id_value);
+    } else if (std.mem.eql(u8, method_value.string, "tools/call")) {
+        try handleToolsCall(allocator, stdout_file, id_value, object.get("params"));
+    } else {
+        try writeJsonRpcError(allocator, stdout_file, id_value, .method_not_found, "method not found");
+    }
+}
+
+fn handleToolsCall(
+    allocator: std.mem.Allocator,
+    stdout_file: std.fs.File,
+    id_value: ?std.json.Value,
+    params_value: ?std.json.Value,
+) !void {
+    const params = params_value orelse {
+        try writeJsonRpcError(allocator, stdout_file, id_value, .invalid_params, "params are required");
+        return;
+    };
+    if (params != .object) {
+        try writeJsonRpcError(allocator, stdout_file, id_value, .invalid_params, "params must be an object");
+        return;
+    }
+
+    const name_value = params.object.get("name") orelse {
+        try writeJsonRpcError(allocator, stdout_file, id_value, .invalid_params, "tool name is required");
+        return;
+    };
+    if (name_value != .string or !std.mem.eql(u8, name_value.string, tool_name)) {
+        try writeJsonRpcError(allocator, stdout_file, id_value, .invalid_params, "unknown tool");
+        return;
+    }
+
+    const arguments = params.object.get("arguments") orelse {
+        try writeToolFailure(allocator, stdout_file, id_value, .invalid_request, "cwd is required");
+        return;
+    };
+    var request = control.parseSpawnRequestFromValue(allocator, arguments) catch |err| {
+        try writeToolFailure(
+            allocator,
+            stdout_file,
+            id_value,
+            .invalid_request,
+            control.parseErrorMessage(err),
+        );
+        return;
+    };
+    defer request.deinit(allocator);
+
+    var response = control.connectAndSendSpawnRequest(allocator, request) catch |err| {
+        var message_buf: [160]u8 = undefined;
+        const message = std.fmt.bufPrint(&message_buf, "failed to contact Architect: {}", .{err}) catch |fmt_err| blk: {
+            log.debug("failed to format Architect contact error: {}", .{fmt_err});
+            break :blk "failed to contact Architect";
+        };
+        try writeToolFailure(allocator, stdout_file, id_value, .app_not_running, message);
+        return;
+    };
+    defer response.deinit(allocator);
+
+    switch (response.response) {
+        .success => |success| try writeToolSuccess(allocator, stdout_file, id_value, success),
+        .failure => |failure| try writeToolFailure(allocator, stdout_file, id_value, failure.code, failure.message),
+    }
+}
+
+fn writeInitializeResult(
+    allocator: std.mem.Allocator,
+    stdout_file: std.fs.File,
+    id_value: ?std.json.Value,
+) !void {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    defer out.deinit();
+    var json: std.json.Stringify = .{ .writer = &out.writer };
+
+    try beginRpcResult(&json, id_value);
+    try json.objectField("protocolVersion");
+    try json.write(protocol_version);
+    try json.objectField("capabilities");
+    try json.beginObject();
+    try json.objectField("tools");
+    try json.beginObject();
+    try json.endObject();
+    try json.endObject();
+    try json.objectField("serverInfo");
+    try json.beginObject();
+    try json.objectField("name");
+    try json.write(server_name);
+    try json.objectField("version");
+    try json.write(server_version);
+    try json.endObject();
+    try endRpcResult(&json);
+
+    try writeJsonLine(stdout_file, out.written());
+}
+
+fn writeEmptyResult(
+    allocator: std.mem.Allocator,
+    stdout_file: std.fs.File,
+    id_value: ?std.json.Value,
+) !void {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    defer out.deinit();
+    var json: std.json.Stringify = .{ .writer = &out.writer };
+
+    try beginRpcResult(&json, id_value);
+    try endRpcResult(&json);
+
+    try writeJsonLine(stdout_file, out.written());
+}
+
+fn writeToolsListResult(
+    allocator: std.mem.Allocator,
+    stdout_file: std.fs.File,
+    id_value: ?std.json.Value,
+) !void {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    defer out.deinit();
+    var json: std.json.Stringify = .{ .writer = &out.writer };
+
+    try beginRpcResult(&json, id_value);
+    try json.objectField("tools");
+    try json.beginArray();
+    try writeSpawnSessionTool(&json);
+    try json.endArray();
+    try endRpcResult(&json);
+
+    try writeJsonLine(stdout_file, out.written());
+}
+
+fn writeSpawnSessionTool(json: *std.json.Stringify) !void {
+    try json.beginObject();
+    try json.objectField("name");
+    try json.write(tool_name);
+    try json.objectField("description");
+    try json.write("Ask the running Architect app to create a terminal session in a working directory.");
+    try json.objectField("inputSchema");
+    try writeSpawnInputSchema(json);
+    try json.objectField("outputSchema");
+    try writeSpawnOutputSchema(json);
+    try json.endObject();
+}
+
+fn writeSpawnInputSchema(json: *std.json.Stringify) !void {
+    try json.beginObject();
+    try json.objectField("type");
+    try json.write("object");
+    try json.objectField("additionalProperties");
+    try json.write(false);
+    try json.objectField("required");
+    try json.beginArray();
+    try json.write("cwd");
+    try json.endArray();
+    try json.objectField("properties");
+    try json.beginObject();
+
+    try json.objectField("cwd");
+    try json.beginObject();
+    try json.objectField("type");
+    try json.write("string");
+    try json.objectField("description");
+    try json.write("Absolute working directory for the new Architect terminal session.");
+    try json.endObject();
+
+    try json.objectField("command");
+    try json.beginObject();
+    try json.objectField("type");
+    try json.write("string");
+    try json.objectField("description");
+    try json.write("Optional command text queued into the new shell. Architect appends a newline when needed.");
+    try json.endObject();
+
+    try json.objectField("display_name");
+    try json.beginObject();
+    try json.objectField("type");
+    try json.write("string");
+    try json.objectField("description");
+    try json.write("Optional display label reserved for clients and future Architect UI.");
+    try json.endObject();
+
+    try json.endObject();
+    try json.endObject();
+}
+
+fn writeSpawnOutputSchema(json: *std.json.Stringify) !void {
+    try json.beginObject();
+    try json.objectField("type");
+    try json.write("object");
+    try json.objectField("required");
+    try json.beginArray();
+    try json.write("status");
+    try json.endArray();
+    try json.objectField("properties");
+    try json.beginObject();
+
+    try json.objectField("status");
+    try json.beginObject();
+    try json.objectField("type");
+    try json.write("string");
+    try json.endObject();
+
+    try json.objectField("session_id");
+    try json.beginObject();
+    try json.objectField("type");
+    try json.write("integer");
+    try json.endObject();
+
+    try json.objectField("slot_index");
+    try json.beginObject();
+    try json.objectField("type");
+    try json.write("integer");
+    try json.endObject();
+
+    try json.objectField("code");
+    try json.beginObject();
+    try json.objectField("type");
+    try json.write("string");
+    try json.endObject();
+
+    try json.objectField("message");
+    try json.beginObject();
+    try json.objectField("type");
+    try json.write("string");
+    try json.endObject();
+
+    try json.endObject();
+    try json.endObject();
+}
+
+fn writeToolSuccess(
+    allocator: std.mem.Allocator,
+    stdout_file: std.fs.File,
+    id_value: ?std.json.Value,
+    success: control.SpawnSuccess,
+) !void {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    defer out.deinit();
+    var json: std.json.Stringify = .{ .writer = &out.writer };
+
+    try beginRpcResult(&json, id_value);
+    try json.objectField("content");
+    try json.beginArray();
+    try json.beginObject();
+    try json.objectField("type");
+    try json.write("text");
+    try json.objectField("text");
+    try json.print("\"Spawned Architect session {d} in slot {d}.\"", .{ success.session_id, success.slot_index });
+    try json.endObject();
+    try json.endArray();
+    try json.objectField("structuredContent");
+    try json.beginObject();
+    try json.objectField("status");
+    try json.write("spawned");
+    try json.objectField("session_id");
+    try json.write(success.session_id);
+    try json.objectField("slot_index");
+    try json.write(success.slot_index);
+    try json.endObject();
+    try json.objectField("isError");
+    try json.write(false);
+    try endRpcResult(&json);
+
+    try writeJsonLine(stdout_file, out.written());
+}
+
+fn writeToolFailure(
+    allocator: std.mem.Allocator,
+    stdout_file: std.fs.File,
+    id_value: ?std.json.Value,
+    code: control.SpawnErrorCode,
+    message: []const u8,
+) !void {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    defer out.deinit();
+    var json: std.json.Stringify = .{ .writer = &out.writer };
+
+    try beginRpcResult(&json, id_value);
+    try json.objectField("content");
+    try json.beginArray();
+    try json.beginObject();
+    try json.objectField("type");
+    try json.write("text");
+    try json.objectField("text");
+    try json.write(message);
+    try json.endObject();
+    try json.endArray();
+    try json.objectField("structuredContent");
+    try json.beginObject();
+    try json.objectField("status");
+    try json.write("error");
+    try json.objectField("code");
+    try json.write(code.jsonString());
+    try json.objectField("message");
+    try json.write(message);
+    try json.endObject();
+    try json.objectField("isError");
+    try json.write(true);
+    try endRpcResult(&json);
+
+    try writeJsonLine(stdout_file, out.written());
+}
+
+fn writeJsonRpcError(
+    allocator: std.mem.Allocator,
+    stdout_file: std.fs.File,
+    id_value: ?std.json.Value,
+    code: JsonRpcErrorCode,
+    message: []const u8,
+) !void {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    defer out.deinit();
+    var json: std.json.Stringify = .{ .writer = &out.writer };
+
+    try json.beginObject();
+    try json.objectField("jsonrpc");
+    try json.write("2.0");
+    try json.objectField("id");
+    if (id_value) |id| {
+        try json.write(id);
+    } else {
+        try json.write(null);
+    }
+    try json.objectField("error");
+    try json.beginObject();
+    try json.objectField("code");
+    try json.write(@intFromEnum(code));
+    try json.objectField("message");
+    try json.write(message);
+    try json.endObject();
+    try json.endObject();
+
+    try writeJsonLine(stdout_file, out.written());
+}
+
+fn beginRpcResult(json: *std.json.Stringify, id_value: ?std.json.Value) !void {
+    try json.beginObject();
+    try json.objectField("jsonrpc");
+    try json.write("2.0");
+    try json.objectField("id");
+    if (id_value) |id| {
+        try json.write(id);
+    } else {
+        try json.write(null);
+    }
+    try json.objectField("result");
+    try json.beginObject();
+}
+
+fn endRpcResult(json: *std.json.Stringify) !void {
+    try json.endObject();
+    try json.endObject();
+}
+
+fn writeJsonLine(stdout_file: std.fs.File, bytes: []const u8) !void {
+    try stdout_file.writeAll(bytes);
+    try stdout_file.writeAll("\n");
+}
+
+test "tools/list exposes exactly spawn_session" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var out = try tmp.dir.createFile("tools-list.jsonl", .{ .truncate = true });
+
+    const id = std.json.Value{ .integer = 1 };
+    try writeToolsListResult(allocator, out, id);
+    out.close();
+
+    const input = try tmp.dir.readFileAlloc(allocator, "tools-list.jsonl", 16 * 1024);
+    defer allocator.free(input);
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, std.mem.trim(u8, input, "\n"), .{});
+    defer parsed.deinit();
+
+    const result_value = parsed.value.object.get("result") orelse return error.TestUnexpectedResult;
+    const tools_value = result_value.object.get("tools") orelse return error.TestUnexpectedResult;
+    const tools = tools_value.array;
+    try std.testing.expectEqual(@as(usize, 1), tools.items.len);
+    const name_value = tools.items[0].object.get("name") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(tool_name, name_value.string);
+}
+
+test "tool failure response is an MCP tool error result" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var out = try tmp.dir.createFile("failure.jsonl", .{ .truncate = true });
+
+    const id = std.json.Value{ .integer = 9 };
+    try writeToolFailure(allocator, out, id, .invalid_cwd, "cwd does not exist");
+    out.close();
+
+    const input = try tmp.dir.readFileAlloc(allocator, "failure.jsonl", 16 * 1024);
+    defer allocator.free(input);
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, std.mem.trim(u8, input, "\n"), .{});
+    defer parsed.deinit();
+
+    const result_value = parsed.value.object.get("result") orelse return error.TestUnexpectedResult;
+    const result = result_value.object;
+    const is_error = result.get("isError") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(is_error.bool);
+    const structured_content = result.get("structuredContent") orelse return error.TestUnexpectedResult;
+    const status = structured_content.object.get("status") orelse return error.TestUnexpectedResult;
+    const code = structured_content.object.get("code") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("error", status.string);
+    try std.testing.expectEqualStrings("invalid_cwd", code.string);
+}

--- a/src/mcp/main.zig
+++ b/src/mcp/main.zig
@@ -25,12 +25,20 @@ pub fn run(allocator: std.mem.Allocator, stdin_file: std.fs.File, stdout_file: s
     var buffer: std.ArrayList(u8) = .empty;
     defer buffer.deinit(allocator);
 
+    var discarding_oversized_line = false;
     var chunk: [4096]u8 = undefined;
     while (true) {
         const n = try stdin_file.read(&chunk);
         if (n == 0) break;
 
         for (chunk[0..n]) |byte| {
+            if (discarding_oversized_line) {
+                if (byte == '\n') {
+                    discarding_oversized_line = false;
+                }
+                continue;
+            }
+
             if (byte == '\n') {
                 if (buffer.items.len > 0) {
                     try handleMessage(allocator, stdout_file, buffer.items);
@@ -42,13 +50,14 @@ pub fn run(allocator: std.mem.Allocator, stdin_file: std.fs.File, stdout_file: s
             if (buffer.items.len >= control.max_message_bytes) {
                 try writeJsonRpcError(allocator, stdout_file, null, .invalid_request, "message is too large");
                 buffer.clearRetainingCapacity();
+                discarding_oversized_line = true;
                 continue;
             }
             try buffer.append(allocator, byte);
         }
     }
 
-    if (buffer.items.len > 0) {
+    if (!discarding_oversized_line and buffer.items.len > 0) {
         try handleMessage(allocator, stdout_file, buffer.items);
     }
 }
@@ -500,4 +509,43 @@ test "tool failure response is an MCP tool error result" {
     const code = structured_content.object.get("code") orelse return error.TestUnexpectedResult;
     try std.testing.expectEqualStrings("error", status.string);
     try std.testing.expectEqualStrings("invalid_cwd", code.string);
+}
+
+test "run discards the rest of an oversized line" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var input = try tmp.dir.createFile("input.jsonl", .{ .read = true });
+    defer input.close();
+
+    const oversized = try allocator.alloc(u8, control.max_message_bytes + 10);
+    defer allocator.free(oversized);
+    @memset(oversized, 'x');
+
+    try input.writeAll(oversized);
+    try input.writeAll("\n");
+    try input.writeAll("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}\n");
+    try input.seekTo(0);
+
+    var out = try tmp.dir.createFile("output.jsonl", .{ .read = true });
+    defer out.close();
+
+    try run(allocator, input, out);
+    try out.seekTo(0);
+
+    const output = try out.readToEndAlloc(allocator, 64 * 1024);
+    defer allocator.free(output);
+
+    var line_count: usize = 0;
+    var lines = std.mem.splitScalar(u8, std.mem.trim(u8, output, "\n"), '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        line_count += 1;
+    }
+
+    try std.testing.expectEqual(@as(usize, 2), line_count);
+    try std.testing.expect(std.mem.indexOf(u8, output, "\"message\":\"message is too large\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "\"tools\"") != null);
 }


### PR DESCRIPTION
## Solution

Adds a separate `architect-mcp` stdio helper for local MCP clients. It exposes `spawn_session`, validates the tool arguments, and forwards requests to the running Architect app through a Unix-domain control socket discovered from the runtime temp directory.

The app handles those requests on the main loop: it validates the working directory, picks or expands a grid slot, spawns the terminal session, queues optional command text, focuses the new session, and returns structured success or stable error codes. Build, release packaging, Homebrew, and docs now ship and describe the helper.

Closes #291

## Checks

- `nix develop -c zig build`
- `nix develop -c zig build test`
- `nix develop -c just lint`
- `git diff --check`
- MCP smoke checks for `tools/list` and `spawn_session`

## Test plan

- [ ] Start Architect, call `spawn_session` through `architect-mcp` with an existing absolute `cwd`, and confirm a new focused session appears.
- [ ] Call `spawn_session` with a `command` value and confirm the command is submitted in the new shell.
