### PR TITLE
[codex] Fix Intel release bundling for MCP helper

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -74,6 +74,9 @@ pub fn build(b: *std.Build) void {
     mcp_exe.linkLibC();
 
     if (target.result.os.tag == .macos) {
+        exe.headerpad_max_install_names = true;
+        mcp_exe.headerpad_max_install_names = true;
+
         exe.linkSystemLibrary("proc");
         exe.linkFramework("Carbon");
         exe.linkFramework("CoreFoundation");

--- a/scripts/bundle-macos.sh
+++ b/scripts/bundle-macos.sh
@@ -163,8 +163,36 @@ remove_signature_if_present() {
     fi
 }
 
+nix_deps_for() {
+    local file="$1"
+    otool -L "$file" | awk '/^[[:space:]]/ {print $1}' | grep '^/nix/store' || true
+}
+
+patch_binary_deps() {
+    local binary="$1"
+    local label="$2"
+    local deps original name
+
+    deps=$(nix_deps_for "$binary")
+    if [[ -z "$deps" ]]; then
+        echo "No Nix store dependencies found in $label"
+        return
+    fi
+
+    while IFS= read -r original; do
+        [[ -z "$original" ]] && continue
+        name=$(basename "$original")
+        install_name_tool -change "$original" "@executable_path/lib/$name" "$binary"
+    done <<< "$deps"
+}
+
 echo "Analyzing dynamic library dependencies..."
-initial_deps=$(otool -L "$EXECUTABLE" | awk '/^[[:space:]]/ {print $1}' | grep '^/nix/store' || true)
+initial_deps=$(
+    {
+        nix_deps_for "$EXECUTABLE"
+        nix_deps_for "$MCP_EXECUTABLE"
+    } | sort -u
+)
 
 # Use a flag instead of early return: bundling must still finish even without Nix deps
 skip_lib_patching=false
@@ -205,7 +233,7 @@ if [[ "$skip_lib_patching" != true ]]; then
 
         install_name_tool -id "@executable_path/lib/$lib_name" "$dest"
 
-        nested_list=$(otool -L "$lib_path" | awk '/^[[:space:]]/ {print $1}' | grep '^/nix/store' || true)
+        nested_list=$(nix_deps_for "$lib_path")
         while IFS= read -r nested_dep; do
             [[ -z "$nested_dep" ]] && continue
             nested_name=$(basename "$nested_dep")
@@ -214,12 +242,8 @@ if [[ "$skip_lib_patching" != true ]]; then
         done <<< "$nested_list"
     done
 
-    while IFS= read -r original; do
-        [[ -z "$original" ]] && continue
-        name=$(basename "$original")
-        install_name_tool -change "$original" "@executable_path/lib/$name" "$MACOS_DIR/architect" || true
-        install_name_tool -change "$original" "@executable_path/lib/$name" "$MACOS_DIR/architect-mcp" || true
-    done <<< "$seen_list"
+    patch_binary_deps "$MACOS_DIR/architect" "architect"
+    patch_binary_deps "$MACOS_DIR/architect-mcp" "architect-mcp"
 
     echo ""
     echo "Verifying final dependencies..."


### PR DESCRIPTION
## Summary

The Intel release job failed while bundling `architect-mcp` because the macOS bundle script tried to rewrite the GUI app's SDL dylib paths inside the MCP helper too. On Intel, `install_name_tool` could not fit those unrelated load-command edits into the helper binary.

This PR makes the bundler collect Nix dylibs from both executables, but patch each copied executable only for the dylibs it actually links. It also enables `headerpad_max_install_names` for both macOS executables, which gives future install-name edits more room.

## Checks

- `nix develop -c zig fmt --check build.zig`
- `nix develop -c zig build`
- `nix develop -c zig build test`
- `nix develop -c just lint`
- `./scripts/bundle-macos.sh zig-out/bin/architect /tmp/architect-bundle-intel-mcp-bundling-20260428160740 zig-out/bin/architect-mcp --unsigned`

The local bundle smoke test now logs `No Nix store dependencies found in architect-mcp` and leaves the helper linked only to `/usr/lib/libSystem.B.dylib`.