### PR TITLE
[codex] Sign macOS MCP helper before app binary

### DIFF
--- a/scripts/bundle-macos.sh
+++ b/scripts/bundle-macos.sh
@@ -287,11 +287,11 @@ if [[ "$SIGN_APP" == true ]]; then
     done
     shopt -u nullglob
 
-    echo "Signing architect..."
-    codesign --force --sign - --entitlements "$ENTITLEMENTS" "$MACOS_DIR/architect"
-
     echo "Signing architect-mcp..."
     codesign --force --sign - --entitlements "$ENTITLEMENTS" "$MACOS_DIR/architect-mcp"
+
+    echo "Signing architect..."
+    codesign --force --sign - --entitlements "$ENTITLEMENTS" "$MACOS_DIR/architect"
 
     echo "Signing ${APP_NAME}.app..."
     codesign --force --sign - --entitlements "$ENTITLEMENTS" "$APP_DIR"


### PR DESCRIPTION
## Summary

The `v0.60.0` Intel release got past the install-name rewrite, but failed in the signing phase:

```text
Signing architect...
release/Architect.app/Contents/MacOS/architect: code object is not signed at all
In subcomponent: .../release/Architect.app/Contents/MacOS/architect-mcp
```

The bundle script was signing the main `architect` executable before `architect-mcp`. On Intel, the helper starts unsigned, so `codesign` rejects the main executable while the helper is still an unsigned subcomponent. This changes the order to sign `architect-mcp` first, then `architect`, then the app bundle.

## Checks

- `bash -n scripts/bundle-macos.sh`
- `git diff --check`
- `./scripts/bundle-macos.sh zig-out/bin/architect /tmp/architect-bundle-helper-signing-20260428163652 zig-out/bin/architect-mcp`
- `codesign --verify --verbose=2 /tmp/architect-bundle-helper-signing-20260428163652/Architect.app`
- `codesign --verify --verbose=2 /tmp/architect-bundle-helper-signing-20260428163652/Architect.app/Contents/MacOS/architect-mcp`
- `codesign --verify --verbose=2 /tmp/architect-bundle-helper-signing-20260428163652/Architect.app/Contents/MacOS/architect`
- `nix develop -c just lint`
- `nix develop -c zig build test`