### PR TITLE
[codex] Pin Homebrew formula to Zig 0.15

### DIFF
--- a/Formula/architect.rb
+++ b/Formula/architect.rb
@@ -6,7 +6,7 @@ class Architect < Formula
   license "MIT"
 
   depends_on "pkg-config" => :build
-  depends_on "zig" => :build
+  depends_on "zig@0.15" => :build
   depends_on xcode: :build
   depends_on "sdl3"
   depends_on "sdl3_ttf"


### PR DESCRIPTION
## Summary

Homebrew now defaults `zig` to the 0.16 series, while Architect still declares `minimum_zig_version = "0.15.2"` and builds against the 0.15 toolchain. This updates the formula build dependency from `zig` to `zig@0.15` so source installs keep using Zig 0.15.2.

## Checks

- `ruby -c Formula/architect.rb`
- `git diff --check`
- `brew info --formula zig@0.15` confirmed the formula resolves as stable 0.15.2, but exited non-zero after Homebrew tried to write its API cache in a sandboxed location.

`brew style Formula/architect.rb` could not complete in this sandbox because Homebrew tried to write under `/opt/homebrew/Library/Homebrew/vendor/bundle`.