### PR TITLE
fix(render): draw Cmd+hover link underline after glyph flush

### DIFF
--- a/src/render/renderer.zig
+++ b/src/render/renderer.zig
@@ -515,26 +515,19 @@ fn renderSessionContent(
                 }
             }
 
-            if (view.hovered_link_start) |link_start| {
-                if (view.hovered_link_end) |link_end| {
-                    const point_for_link = if (view.is_viewing_scrollback)
-                        ghostty_vt.point.Point{ .viewport = .{ .x = @intCast(col), .y = @intCast(row) } }
-                    else
-                        ghostty_vt.point.Point{ .active = .{ .x = @intCast(col), .y = @intCast(source_row) } };
-                    if (pages.pin(point_for_link)) |link_pin| {
-                        const link_sel = ghostty_vt.Selection.init(link_start, link_end, false);
-                        if (link_sel.contains(screen, link_pin)) {
-                            _ = c.SDL_SetRenderDrawColor(renderer, fg_color.r, fg_color.g, fg_color.b, 255);
-                            const underline_y: f32 = @floatFromInt(y + eff_ch - 1);
-                            const x_start: f32 = @floatFromInt(x);
-                            const x_end: f32 = @floatFromInt(x + eff_cw * glyph_width_cells - 1);
-                            _ = c.SDL_RenderLine(renderer, x_start, underline_y, x_end, underline_y);
-                        }
-                    }
-                }
-            }
+            const has_hover_underline = blk: {
+                const link_start = view.hovered_link_start orelse break :blk false;
+                const link_end = view.hovered_link_end orelse break :blk false;
+                const point_for_link = if (view.is_viewing_scrollback)
+                    ghostty_vt.point.Point{ .viewport = .{ .x = @intCast(col), .y = @intCast(row) } }
+                else
+                    ghostty_vt.point.Point{ .active = .{ .x = @intCast(col), .y = @intCast(source_row) } };
+                const link_pin = pages.pin(point_for_link) orelse break :blk false;
+                const link_sel = ghostty_vt.Selection.init(link_start, link_end, false);
+                break :blk link_sel.contains(screen, link_pin);
+            };
 
-            if (style.flags.underline != .none and underline_count < underline_segments.len) {
+            if ((style.flags.underline != .none or has_hover_underline) and underline_count < underline_segments.len) {
                 underline_segments[underline_count] = .{
                     .x_start = @floatFromInt(x),
                     .x_end = @floatFromInt(x + eff_cw * glyph_width_cells - 1),


### PR DESCRIPTION
## Summary

Cmd+hovering a URL in a terminal session did not visually highlight the link, even though Cmd+click still opened it. The hover-link underline was drawn inline during the per-cell render loop, before the row's text glyphs were flushed. The glyph pass landed on the same bottom-row pixel and overwrote the 1px underline.

This routes the hover check through the same deferred `underline_segments` buffer that cell-style underlines already use. That buffer flushes after the row's `flushRun`, so the underline now sits on top of the text. The check is folded into the existing style-underline append, so a cell that is both styled and hovered produces a single segment instead of two.

This is the symmetric counterpart to commit fe1a4c5d, which moved cell-style underlines into the deferred buffer for the same reason but did not migrate the hover-link path.

Closes #314

## Test plan

- [x] `zig build run`
- [x] In a terminal session, `echo https://example.com`
- [x] Hold Cmd and move the mouse over the URL; the URL is underlined while Cmd is held
- [x] Release Cmd or move the cursor off the URL; the underline disappears
- [x] Cmd+click the URL; it opens in the browser
