### PR TITLE
chore(deps): bump zwanzig to 0.12.2

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -127,10 +127,12 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_exe_unit_tests.step);
     test_step.dependOn(&run_mcp_unit_tests.step);
 
-    // Lint step using zwanzig
+    // Lint step using zwanzig. Always build the linter with ReleaseFast: it is a
+    // build-time tool and Debug-mode safety/allocator overhead makes analysis
+    // multiple orders of magnitude slower on x86 Linux runners.
     if (b.lazyDependency("zwanzig", .{
         .target = target,
-        .optimize = optimize,
+        .optimize = .ReleaseFast,
     })) |zw| {
         const zw_exe = zw.artifact("zwanzig");
         const lint_run = b.addRunArtifact(zw_exe);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "toml-0.3.0-bV14Bd-EAQBKoXhpYft303BtA2vgLNlxntUCIWgRUl46",
         },
         .zwanzig = .{
-            .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.11.0.tar.gz",
-            .hash = "zwanzig-0.11.0-oiXZlqj7FgDQVjcn0XkxcmayLn6WPUCl2DHWZNkHQ4rm",
+            .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.12.1.tar.gz",
+            .hash = "zwanzig-0.12.1-oiXZluWwFwDOs3W2tYgKIX0Tgl6SqT5Nl-5OhZOoS2Al",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "toml-0.3.0-bV14Bd-EAQBKoXhpYft303BtA2vgLNlxntUCIWgRUl46",
         },
         .zwanzig = .{
-            .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.12.1.tar.gz",
-            .hash = "zwanzig-0.12.1-oiXZluWwFwDOs3W2tYgKIX0Tgl6SqT5Nl-5OhZOoS2Al",
+            .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.12.2.tar.gz",
+            .hash = "zwanzig-0.12.2-oiXZlmGxFwAnqSPwVKeafMevXetOji1UvkeLyl60WTm8",
         },
     },
     .paths = .{

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -2030,7 +2030,10 @@ pub fn run() !void {
                         }
 
                         var notification_buf: [64]u8 = undefined;
-                        const notification_msg = std.fmt.bufPrint(&notification_buf, "Font size: {d}pt", .{font_size}) catch "Font size changed";
+                        const notification_msg = std.fmt.bufPrint(&notification_buf, "Font size: {d}pt", .{font_size}) catch |err| blk: {
+                            log.warn("failed to format font size toast: {}", .{err});
+                            break :blk "Font size changed";
+                        };
                         ui.showToast(notification_msg, now);
                     } else if (key == c.SDLK_N and has_gui and !has_blocking_mod and (anim_state.mode == .Full or anim_state.mode == .Grid)) {
                         if (config.ui.show_hotkey_feedback) ui.showHotkey("⌘N", now);
@@ -2813,7 +2816,10 @@ pub fn run() !void {
                 session_interaction_component.setAttention(cd_action.session, false, now);
 
                 const basename = std.fs.path.basename(cd_action.path);
-                const toast_msg_buf = std.fmt.allocPrint(allocator, "Changed to {s}", .{basename}) catch null;
+                const toast_msg_buf: ?[]u8 = std.fmt.allocPrint(allocator, "Changed to {s}", .{basename}) catch |err| blk: {
+                    log.warn("failed to allocate cd toast: {}", .{err});
+                    break :blk null;
+                };
                 const toast_msg = toast_msg_buf orelse "Changed directory";
                 defer if (toast_msg_buf) |buf| allocator.free(buf);
                 ui.showToast(toast_msg, now);

--- a/src/ui/components/diff_overlay.zig
+++ b/src/ui/components/diff_overlay.zig
@@ -1904,7 +1904,10 @@ pub const DiffOverlayComponent = struct {
                 if (!is_continuation) {
                     if (line.old_line) |num| {
                         var num_buf: [12]u8 = undefined;
-                        const num_str = std.fmt.bufPrint(&num_buf, "{d}", .{num}) catch "";
+                        const num_str = std.fmt.bufPrint(&num_buf, "{d}", .{num}) catch |err| blk: {
+                            log.warn("failed to format old line number: {}", .{err});
+                            break :blk "";
+                        };
                         if (num_str.len > 0) {
                             const tex = try self.makeTextTexture(renderer, mono_font, num_str, dim_color);
                             errdefer c.SDL_DestroyTexture(tex.tex);
@@ -1922,7 +1925,10 @@ pub const DiffOverlayComponent = struct {
 
                     if (line.new_line) |num| {
                         var num_buf: [12]u8 = undefined;
-                        const num_str = std.fmt.bufPrint(&num_buf, "{d}", .{num}) catch "";
+                        const num_str = std.fmt.bufPrint(&num_buf, "{d}", .{num}) catch |err| blk: {
+                            log.warn("failed to format new line number: {}", .{err});
+                            break :blk "";
+                        };
                         if (num_str.len > 0) {
                             const tex = try self.makeTextTexture(renderer, mono_font, num_str, dim_color);
                             errdefer c.SDL_DestroyTexture(tex.tex);


### PR DESCRIPTION
## Solution

Three related changes in this PR:

**1. Bump zwanzig to 0.12.2 and fix the new findings.**

The newer linter version flagged four sites that dropped formatting errors silently:

- `src/app/runtime.zig` — font-size toast `bufPrint` and cd toast `allocPrint`
- `src/ui/components/diff_overlay.zig` — old and new line-number `bufPrint` in the gutter rendering path

Each now logs the error before falling back to its previous default, per the project's no-bare-catch convention in `CLAUDE.md`. The failure modes themselves are still effectively unreachable in practice (small fixed buffers for integer formatting, OOM for the cd toast), but logging when they do hit keeps them debuggable instead of invisible.

A separate `store-violations-engine` false positive on `ArrayList(u8).appendSlice` at `diff_overlay.zig:471` was fixed upstream in zwanzig 0.12.1, so no source suppression was needed here.

**2. Pin the zwanzig dependency to `ReleaseFast` in `build.zig`.**

An earlier attempt at this PR exposed a CI asymmetry: lint timed out at 37+ minutes on the Ubuntu runner while finishing in 3 minutes on macOS. Root cause: zwanzig inherits the host build's optimization mode via `b.lazyDependency`, which defaults to `Debug`. Debug-mode Zig adds bounds checks, integer overflow checks, and a safety-instrumented allocator that protects freed pages with `mprotect`. On x86 Linux SMP each `mprotect` triggers a TLB shootdown IPI across all cores, which is catastrophically slow for an allocator-heavy workload. Apple Silicon's MMU and larger base page size absorb the same work cheaply. The 0.12.0 analyzer roughly doubled the widening work, which amplified the platform-specific cost to the point of timing out.

The linter is a build-time tool and never needs debug instrumentation, so building it with `ReleaseFast` regardless of the parent build mode is the correct fix. The Zig package cache means the ReleaseFast zwanzig binary is built once per `build.zig.zon` hash and reused across runs.

**3. Bump to 0.12.2 to pick up an upstream allocator-retention fix.**

Even with the `ReleaseFast` pin in place, 0.12.1 still OOMed on the 4-core Ubuntu runner (peak RSS ~7.8 GB → SIGKILL). Profiling identified the root cause as the per-file scratch allocator: zwanzig used an `ArenaAllocator` over `page_allocator`, but the engine eagerly `free()`s its ~1.36M-per-file temporaries, and the arena was retaining all of that churn until file end. The 0.12.0 engine changes (switch-arm CFG visits + a wider `DeferredEntry` carrying `scope_node`) raised the churn enough to exceed available memory on Linux CI. macOS survived via memory compression; Linux didn't.

That root cause was fixed upstream in [forketyfork/zwanzig#89](https://github.com/forketyfork/zwanzig/pull/89), released as v0.12.2. With v0.12.2, lint on the 4-core Ubuntu reference environment completes in ~7.5s at ~1.4 GB peak RSS (the same workload that previously OOMed). The `ReleaseFast` pin is kept here as a defensive measure — the linter still has no business running with Debug-mode safety overhead.

`zig build`, `zig build test`, `zig fmt --check src/`, and `just lint` all pass on the branch.

> [!NOTE]
> The branch is still named `chore/zwanzig-0.12.1` because it predates the 0.12.2 release. Squash-merging will collapse the journey to a single tidy commit on `main`.
