### PR TITLE
fix(shell): emit legacy short-int terminfo so macOS less stops warning

### DIFF
--- a/assets/terminfo/xterm-ghostty.terminfo
+++ b/assets/terminfo/xterm-ghostty.terminfo
@@ -5,8 +5,16 @@
 # to ~/.cache/architect/terminfo on first run.
 #
 # Manual compile: tic -x -o <output_dir> xterm-ghostty.terminfo
+#
+# pairs#0x7fff clamps the inherited xterm-256color value (0x10000 on modern
+# ncurses 6.x) back into signed 16-bit so tic emits the legacy short-int
+# format (magic 0x011a). macOS ships libncurses 5.4 inside dyld_shared_cache,
+# and tools linked against it (less, man, ...) cannot read the extended
+# format (magic 0x021e); without this override they fall back to
+# "WARNING: terminal is not fully functional". See issue #318.
 
 xterm-ghostty|Architect terminal with truecolor and kitty keyboard,
 	Tc,
 	RGB,
+	pairs#0x7fff,
 	use=xterm-256color,

--- a/src/main.zig
+++ b/src/main.zig
@@ -16,4 +16,5 @@ pub fn main() !void {
 test {
     _ = @import("app/layout.zig");
     _ = @import("ui/components/diff_comment_layout.zig");
+    _ = @import("shell.zig");
 }

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -1155,3 +1155,65 @@ test "pathContainsEntry" {
     try std.testing.expect(pathContainsEntry("/usr/bin", "/usr/bin"));
     try std.testing.expect(!pathContainsEntry("", "/usr/bin"));
 }
+
+// Regression test for issue #318: the bundled terminfo source must compile to
+// the legacy short-int format (magic 0x011a) so that macOS system tools linked
+// against the old libncurses 5.4 in dyld_shared_cache (less, man, etc.) can read
+// it. If `use=xterm-256color` inherits `pairs#0x10000` from a modern ncurses
+// terminfo DB without an override, tic emits the extended-numbers format (magic
+// 0x021e), which those tools cannot parse and they print "WARNING: terminal is
+// not fully functional".
+test "bundled terminfo compiles to legacy short-int format" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    const src_path = try std.fs.path.join(allocator, &.{ tmp_path, "xterm-ghostty.terminfo" });
+    defer allocator.free(src_path);
+
+    {
+        const src_file = try std.fs.createFileAbsolute(src_path, .{});
+        defer src_file.close();
+        try src_file.writeAll(architect_terminfo_src);
+    }
+
+    const tic_path = findExecutableInPath("tic") orelse return error.SkipZigTest;
+
+    var child = std.process.Child.init(&.{ tic_path, "-x", "-o", tmp_path, src_path }, allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Ignore;
+    child.stderr_behavior = .Ignore;
+    const term = try child.spawnAndWait();
+    try testing.expectEqual(std.process.Child.Term{ .Exited = 0 }, term);
+
+    // tic stores the compiled entry in either `78/xterm-ghostty` (hashed,
+    // modern ncurses default) or `x/xterm-ghostty` (legacy single-char), so try
+    // both locations.
+    const candidates = [_][]const u8{ "78/xterm-ghostty", "x/xterm-ghostty" };
+    var magic: [2]u8 = undefined;
+    var read_ok = false;
+    for (candidates) |rel| {
+        const full = try std.fs.path.join(allocator, &.{ tmp_path, rel });
+        defer allocator.free(full);
+        const file = std.fs.openFileAbsolute(full, .{}) catch continue;
+        defer file.close();
+        const n = try file.readAll(&magic);
+        if (n == magic.len) {
+            read_ok = true;
+            break;
+        }
+    }
+    try testing.expect(read_ok);
+
+    // Legacy short-int magic is 0x011a (little-endian on disk: 0x1a, 0x01).
+    // Extended-numbers magic 0x021e (0x1e, 0x02) means the entry inherited a
+    // numeric capability that overflows signed 16-bit and is unreadable by
+    // macOS's bundled libncurses 5.4.
+    try testing.expectEqual(@as(u8, 0x1a), magic[0]);
+    try testing.expectEqual(@as(u8, 0x01), magic[1]);
+}


### PR DESCRIPTION
## Summary

`less` (and other macOS pagers / TUI tools) printed `WARNING: terminal is not fully functional / Press RETURN to continue` whenever Architect set `TERM=xterm-ghostty`. `more` and other tools that skip terminfo lookups stayed silent. The bundled terminfo entry was technically present in `~/.cache/architect/terminfo` and resolvable by the Nix-provided `infocmp`, so the issue looked invisible until you traced which library each tool actually links against.

## Root cause

macOS ships `libncurses 5.4` inside `dyld_shared_cache`, and everything in `/usr/bin` that touches terminfo (`less`, `man`, ...) links against it. That library only understands the legacy short-int terminfo file format (magic bytes `0x011a`).

Architect bundles `xterm-ghostty.terminfo` whose source uses `use=xterm-256color`. When `tic` resolves that against the Nix ncurses 6.6 terminfo DB, it inherits `pairs#0x10000` (65536), which overflows signed 16-bit. `tic` then has to emit the file in the extended-numbers format (magic bytes `0x021e`). The 5.4 library cannot parse that format, so `less` can't find `clear` / `cup` and falls back to the warning.

## Solution

Pin `pairs#0x7fff` (32767 — the largest signed-16-bit value) in the bundled terminfo source ahead of the `use=` line. The override clamps the inherited capability back into signed-16-bit range, so `tic` emits the legacy short-int format that the system libncurses can read. 24-bit truecolor (`Tc` / `RGB`) and kitty keyboard protocol capabilities are unaffected.

The compiled cache entry is rewritten by `ensureTerminfoSetup` on every Architect launch, so existing users get the fix automatically the next time they open the app.

## Regression test

`src/shell.zig` adds a new test that writes the embedded terminfo source to a temp dir, runs `tic -x` against it, and asserts the first two bytes of the compiled file are `0x1a 0x01`. The test skips with `error.SkipZigTest` when `tic` is not on `PATH`. Verified: it fails before the fix (gets `0x1e`, the long-int marker) and passes after.

Also added `_ = @import("shell.zig");` to the root test block in `src/main.zig`, since shell.zig's tests weren't previously reachable from the test entry point. This incidentally enables the existing `pathContainsEntry` test, which still passes.

Closes #318

## Test plan

- [x] Pull this branch, delete `~/.cache/architect/terminfo` to force a fresh compile, build with `zig build`, launch Architect.
- [x] In a spawned terminal session, run `git log` and confirm the pager opens directly into the log view with no warning prompt above it.
- [x] In the same session, run `less /etc/hosts` and `man ls` — both should open without the warning.
- [x] Confirm `infocmp "$TERM"` inside the session resolves the entry and shows `pairs#0x7fff` near the top.
- [x] Spot-check that the kitty keyboard protocol still works as before (any feature that relied on it — e.g., modified-arrow key sequences in your editor of choice — should behave the same).
