### PR TITLE
fix(runtime): keep architect alive when a session's terminal output errors

### DIFF
--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -144,6 +144,33 @@ fn writeRuntimeEvent(message: []const u8, event_name: []const u8, extra_data: []
     };
 }
 
+fn agentLabel(session: *const SessionState) []const u8 {
+    if (session.agent_icon) |kind| return kind.name();
+    return "none";
+}
+
+/// Log a structured `session_failed` event plus a human-readable error line
+/// when a session is terminated due to an unrecoverable runtime error. The
+/// `source` argument names the failing call site (e.g. `process_output`) and
+/// becomes the `source=` field on the event so a future investigation can
+/// grep `event=session_failed source=process_output` and find every instance.
+fn reportSessionFailure(session: *const SessionState, err: anyerror, source: []const u8) void {
+    const agent = agentLabel(session);
+    const cwd = session.cwd_path orelse "<unknown>";
+    log.err(
+        "session {d}: {s} failed, marking session dead: {} (agent={s} cwd={s})",
+        .{ session.id, source, err, agent, cwd },
+    );
+    var extra_buf: [192]u8 = undefined;
+    const extra = std.fmt.bufPrint(&extra_buf, "session={d} agent={s} error={s} source={s}", .{
+        session.id, agent, @errorName(err), source,
+    }) catch |fmt_err| {
+        log.warn("failed to format session_failed event payload: {}", .{fmt_err});
+        return;
+    };
+    writeRuntimeEvent("session terminated after unrecoverable error", "session_failed", extra);
+}
+
 fn emitViewModeTransitionEvents(
     previous_mode: app_state.ViewMode,
     next_mode: app_state.ViewMode,
@@ -2294,12 +2321,12 @@ pub fn run() !void {
             }
             session.checkAlive();
             session.processOutput() catch |err| {
-                log.err("session {d}: process output failed, marking session dead: {}", .{ session.id, err });
+                reportSessionFailure(session, err, "process_output");
                 session.failAndTerminate();
                 continue;
             };
             session.flushPendingWrites() catch |err| {
-                log.err("session {d}: flush pending writes failed, marking session dead: {}", .{ session.id, err });
+                reportSessionFailure(session, err, "flush_pending_writes");
                 session.failAndTerminate();
                 continue;
             };
@@ -3139,6 +3166,18 @@ test "planExternalSpawnSlot reports full grid" {
     }
 
     try std.testing.expect(planExternalSpawnSlot(&sessions, grid_layout.max_grid_size, grid_layout.max_grid_size, 0) == null);
+}
+
+test "agentLabel reports the detected agent name or 'none'" {
+    var session: SessionState = undefined;
+    session.agent_icon = null;
+    try std.testing.expectEqualStrings("none", agentLabel(&session));
+
+    session.agent_icon = .codex;
+    try std.testing.expectEqualStrings("codex", agentLabel(&session));
+
+    session.agent_icon = .claude;
+    try std.testing.expectEqualStrings("claude", agentLabel(&session));
 }
 
 test "validateExternalSpawnCwd accepts directories and rejects relative paths" {

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -102,6 +102,15 @@ fn countSpawnedSessions(sessions: []const *SessionState) usize {
     return count;
 }
 
+/// Mark a session as dead and dirty after a non-recoverable I/O or terminal-state error.
+/// Used to keep the runtime loop alive when a single session's output processing fails
+/// (e.g. ghostty-vt resource exhaustion like `HyperlinkSetOutOfMemory`). The user can
+/// then restart the session or quit cleanly, preserving persistence.
+fn failSession(session: *SessionState) void {
+    session.dead = true;
+    session.markDirty();
+}
+
 fn remainingFrameBudgetNs(target_frame_ns: i128, frame_ns: i128) u64 {
     if (frame_ns >= target_frame_ns) return 0;
     return @intCast(target_frame_ns - frame_ns);
@@ -2291,12 +2300,14 @@ pub fn run() !void {
             }
             session.checkAlive();
             session.processOutput() catch |err| {
-                log.err("session {d}: process output failed: {}", .{ session.id, err });
-                return err;
+                log.err("session {d}: process output failed, marking session dead: {}", .{ session.id, err });
+                failSession(session);
+                continue;
             };
             session.flushPendingWrites() catch |err| {
-                log.err("session {d}: flush pending writes failed: {}", .{ session.id, err });
-                return err;
+                log.err("session {d}: flush pending writes failed, marking session dead: {}", .{ session.id, err });
+                failSession(session);
+                continue;
             };
             const prev_cwd_ptr = if (session.cwd_path) |p| p.ptr else null;
             session.updateCwd(now);
@@ -3131,6 +3142,17 @@ test "planExternalSpawnSlot reports full grid" {
     }
 
     try std.testing.expect(planExternalSpawnSlot(&sessions, grid_layout.max_grid_size, grid_layout.max_grid_size, 0) == null);
+}
+
+test "failSession marks the session dead and bumps render epoch" {
+    var session: SessionState = undefined;
+    session.dead = false;
+    session.render_epoch = 7;
+
+    failSession(&session);
+
+    try std.testing.expect(session.dead);
+    try std.testing.expectEqual(@as(u64, 8), session.render_epoch);
 }
 
 test "validateExternalSpawnCwd accepts directories and rejects relative paths" {

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -102,15 +102,6 @@ fn countSpawnedSessions(sessions: []const *SessionState) usize {
     return count;
 }
 
-/// Mark a session as dead and dirty after a non-recoverable I/O or terminal-state error.
-/// Used to keep the runtime loop alive when a single session's output processing fails
-/// (e.g. ghostty-vt resource exhaustion like `HyperlinkSetOutOfMemory`). The user can
-/// then restart the session or quit cleanly, preserving persistence.
-fn failSession(session: *SessionState) void {
-    session.dead = true;
-    session.markDirty();
-}
-
 fn remainingFrameBudgetNs(target_frame_ns: i128, frame_ns: i128) u64 {
     if (frame_ns >= target_frame_ns) return 0;
     return @intCast(target_frame_ns - frame_ns);
@@ -2301,12 +2292,12 @@ pub fn run() !void {
             session.checkAlive();
             session.processOutput() catch |err| {
                 log.err("session {d}: process output failed, marking session dead: {}", .{ session.id, err });
-                failSession(session);
+                session.failAndTerminate();
                 continue;
             };
             session.flushPendingWrites() catch |err| {
                 log.err("session {d}: flush pending writes failed, marking session dead: {}", .{ session.id, err });
-                failSession(session);
+                session.failAndTerminate();
                 continue;
             };
             const prev_cwd_ptr = if (session.cwd_path) |p| p.ptr else null;
@@ -3142,17 +3133,6 @@ test "planExternalSpawnSlot reports full grid" {
     }
 
     try std.testing.expect(planExternalSpawnSlot(&sessions, grid_layout.max_grid_size, grid_layout.max_grid_size, 0) == null);
-}
-
-test "failSession marks the session dead and bumps render epoch" {
-    var session: SessionState = undefined;
-    session.dead = false;
-    session.render_epoch = 7;
-
-    failSession(&session);
-
-    try std.testing.expect(session.dead);
-    try std.testing.expectEqual(@as(u64, 8), session.render_epoch);
 }
 
 test "validateExternalSpawnCwd accepts directories and rejects relative paths" {

--- a/src/session/state.zig
+++ b/src/session/state.zig
@@ -610,6 +610,24 @@ pub const SessionState = struct {
         return quit_capture_active;
     }
 
+    /// Mark the session as failed after an unrecoverable output-processing error
+    /// (e.g. ghostty-vt resource exhaustion like `HyperlinkSetOutOfMemory`). Sends
+    /// SIGTERM to the still-running child so it stops consuming resources behind a
+    /// "[Process completed]" UI, drops queued stdin so `flushPendingWrites` does
+    /// not retry every frame, then flips `dead` and bumps the render epoch. The
+    /// shell/terminal/stream wrappers stay alive so scrollback remains visible and
+    /// the session can be restarted through the existing dead-state UI path.
+    pub fn failAndTerminate(self: *SessionState) void {
+        if (self.shell) |shell| {
+            if (self.spawned and !self.dead) {
+                _ = std.c.kill(shell.child_pid, std.c.SIG.TERM);
+            }
+        }
+        self.pending_write.clearAndFree(self.allocator);
+        self.dead = true;
+        self.markDirty();
+    }
+
     /// Try to flush any queued stdin data; preserves ordering relative to new input.
     pub fn flushPendingWrites(self: *SessionState) !void {
         if (self.pending_write.items.len == 0) return;
@@ -1162,6 +1180,27 @@ test "shouldProcessOutput drains dead sessions only during quit capture" {
     try std.testing.expect(SessionState.shouldProcessOutput(true, false, false));
     try std.testing.expect(!SessionState.shouldProcessOutput(true, true, false));
     try std.testing.expect(SessionState.shouldProcessOutput(true, true, true));
+}
+
+test "failAndTerminate marks dead, bumps render epoch, and drops pending writes" {
+    const allocator = std.testing.allocator;
+
+    var session: SessionState = undefined;
+    session.shell = null;
+    session.spawned = false;
+    session.dead = false;
+    session.render_epoch = 4;
+    session.allocator = allocator;
+    session.pending_write = .empty;
+    try session.pending_write.appendSlice(allocator, "queued");
+    defer session.pending_write.deinit(allocator);
+
+    session.failAndTerminate();
+
+    try std.testing.expect(session.dead);
+    try std.testing.expectEqual(@as(u64, 5), session.render_epoch);
+    try std.testing.expectEqual(@as(usize, 0), session.pending_write.items.len);
+    try std.testing.expectEqual(@as(usize, 0), session.pending_write.capacity);
 }
 
 test "AgentKind.fromComm recognises known agent names" {


### PR DESCRIPTION
## Solution

Sending messages to codex was causing architect to exit silently, with no crash dialog, no confirmation, and no session persistence. Investigation traced the cause:

- `~/Library/Logs/Architect/architect.log` showed `session N: process output failed: error.HyperlinkSetOutOfMemory` immediately followed by the `shutdown` event marker.
- `launchd` confirmed the process exited via `exit(1)`, not a signal (which is why there were no `.ips` crash reports).
- The error originates in ghostty-vt's `stream.nextSlice` once enough OSC 8 hyperlinks (codex emits many clickable file paths) exhaust the per-page hyperlink set, then propagates through `SessionState.processOutput`, up through the runtime main loop's `return err`, out of `main()`, and into Zig's default `!void` error handler, which calls `exit(1)` before any teardown can run.

The fix catches per-session errors from `processOutput` and `flushPendingWrites` inside the main loop. They are logged, the offending session is marked dead via a new `failSession` helper (which also bumps `render_epoch` so the UI updates), and the loop continues to the next session. The session ends up in the same state as a normal child exit, so the user can restart it from the UI or quit cleanly with persistence intact. Other recoverable session-resource errors covered by `ProcessOutputError` (`StyleSetOutOfMemory`, `GraphemeMapOutOfMemory`, and so on) are handled the same way, since they share the same root cause: per-session terminal-buffer exhaustion that should not take the whole app down.

`failSession` is a tiny helper, but it has a unit test so that the dead/dirty contract stays explicit.

## Test plan

- [ ] Run architect, start a codex session, and use it for an extended period (or any workload that emits many OSC 8 hyperlinks). The app should stay running; if the per-session limit is hit, the affected session should show as dead while other sessions and persistence keep working.
- [ ] Confirm that `~/Library/Logs/Architect/architect.log` now contains a `marking session dead` log line in that scenario rather than an immediate `shutdown` event.
- [ ] Quit architect via the normal close path and verify `~/.config/architect/persistence.toml` is written.
