### PR TITLE
ci(release): bound macOS build steps with timeouts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,10 @@ jobs:
           - arch: x86_64
             runner: macos-15-intel
     runs-on: ${{ matrix.runner }}
+    # Backstop against a hung build (e.g. a stalled Zig compile on the Intel
+    # runner) so the job fails fast and frees the runner instead of sitting
+    # until the 6-hour Actions limit. A normal job finishes in well under 10m.
+    timeout-minutes: 30
     env:
       ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/architect/.zig-cache
       ZIG_LOCAL_CACHE_DIR: ${{ github.workspace }}/architect/.zig-cache/local
@@ -52,6 +56,7 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Prefetch Zig dependencies
+        timeout-minutes: 10
         run: |
           for i in 1 2 3; do
             nix develop --command just setup && break
@@ -61,6 +66,7 @@ jobs:
         working-directory: architect
 
       - name: Build release
+        timeout-minutes: 20
         run: |
           for i in 1 2 3; do
             nix develop --command zig build -Doptimize=ReleaseFast && break


### PR DESCRIPTION
## Solution

The v0.65.5 release run stalled: the x86_64 build on the `macos-15-intel` runner hung partway through `zig build`, and because nothing capped its runtime it would have stayed there until the 6-hour Actions limit. That blocks the release and the downstream `update-formula` job, which needs both matrix legs to finish. The arm64 leg, by contrast, completed in under 5 minutes, and every recent release has finished in 7–10 minutes total.

This adds GitHub Actions timeouts so a hang fails fast instead of sitting for hours:

- **Job-level `timeout-minutes: 30`** on `build-macos` as a hard backstop.
- **Step-level `timeout-minutes: 20`** on *Build release* — the step that actually hung.
- **Step-level `timeout-minutes: 10`** on *Prefetch Zig dependencies* — the other network-bound step.

Normal jobs finish well under 10 minutes, so these limits leave 2–3× headroom and won't trip on a genuinely slow-but-healthy run. The existing `for i in 1 2 3` retry loop is untouched and still covers transient non-zero failures.

I considered wrapping each build attempt in a `timeout` command so a hang would feed back into the retry loop, but the dev shell doesn't include `coreutils` and macOS runners don't ship `timeout` natively, so that would mean a new dependency. The built-in `timeout-minutes` reaches the same outcome without one.

## Test plan

- [ ] Confirm the next tagged release (or a `workflow_dispatch` run) completes both matrix legs within the new limits.
- [ ] If feasible, sanity-check that a deliberately hung step is killed at its `timeout-minutes` boundary rather than running indefinitely.
