### PR TITLE
fix(session): survive OSC 8 hyperlink capacity exhaustion

### DIFF
--- a/src/session/state.zig
+++ b/src/session/state.zig
@@ -594,7 +594,15 @@ pub const SessionState = struct {
                 };
             }
             const was_synchronized_output = self.synchronizedOutputActive();
-            try stream.nextSlice(self.output_buf[0..n]);
+            stream.nextSlice(self.output_buf[0..n]) catch |err| switch (err) {
+                // Hyperlink capacity errors: drop the hyperlink but keep the session alive.
+                // ghostty-vt already uses this strategy inside Terminal.print.
+                error.HyperlinkSetOutOfMemory,
+                error.HyperlinkSetNeedsRehash,
+                error.HyperlinkMapOutOfMemory,
+                => log.warn("session {d}: OSC 8 hyperlink capacity exhausted, hyperlink dropped: {}", .{ self.id, err }),
+                else => return err,
+            };
             const processed_at_ms = std.time.milliTimestamp();
             self.updateSynchronizedOutputState(was_synchronized_output, processed_at_ms);
             self.markDirty();

--- a/src/session/state.zig
+++ b/src/session/state.zig
@@ -594,15 +594,18 @@ pub const SessionState = struct {
                 };
             }
             const was_synchronized_output = self.synchronizedOutputActive();
-            stream.nextSlice(self.output_buf[0..n]) catch |err| switch (err) {
-                // Hyperlink capacity errors: drop the hyperlink but keep the session alive.
-                // ghostty-vt already uses this strategy inside Terminal.print.
-                error.HyperlinkSetOutOfMemory,
-                error.HyperlinkSetNeedsRehash,
-                error.HyperlinkMapOutOfMemory,
-                => log.warn("session {d}: OSC 8 hyperlink capacity exhausted, hyperlink dropped: {}", .{ self.id, err }),
-                else => return err,
-            };
+            // Process byte-by-byte so a hyperlink capacity error on byte N doesn't
+            // silently discard bytes N+1..end of the PTY read. Hyperlink errors drop
+            // only that byte's side effect; normal output/control sequences continue.
+            for (self.output_buf[0..n]) |byte| {
+                stream.next(byte) catch |err| switch (err) {
+                    error.HyperlinkSetOutOfMemory,
+                    error.HyperlinkSetNeedsRehash,
+                    error.HyperlinkMapOutOfMemory,
+                    => log.warn("session {d}: OSC 8 hyperlink capacity exhausted, hyperlink dropped: {}", .{ self.id, err }),
+                    else => return err,
+                };
+            }
             const processed_at_ms = std.time.milliTimestamp();
             self.updateSynchronizedOutputState(was_synchronized_output, processed_at_ms);
             self.markDirty();


### PR DESCRIPTION
## Summary

- Codex emits a lot of OSC 8 hyperlinks (clickable file paths in output). ghostty-vt allocates only 4 hyperlink slots per terminal page by default.
- When a scroll operation copies a hyperlinked row to a page whose hyperlink set is already full, it returns `HyperlinkSetOutOfMemory`. That error escaped through `stream.nextSlice()` into `processOutput()`, which treated it as unrecoverable and killed the session.
- The fix catches `HyperlinkSetOutOfMemory`, `HyperlinkSetNeedsRehash`, and `HyperlinkMapOutOfMemory` inside `processOutput()` and logs a warning instead. Affected cells lose their hyperlink, but the session keeps running. ghostty-vt already uses this exact strategy inside `Terminal.print` for the same failure mode.

## Test plan

- Run Codex in a terminal session long enough to generate substantial output with file links. Confirm the session stays alive throughout.
- Check the Architect log and verify hyperlink capacity hits appear as `WARN` rather than causing `event=session_failed`.
