### PR TITLE
build(nix): bump SDL3 from 3.4.0 to 3.4.10

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -61,7 +61,7 @@ zig build run
 ## Dependencies and Tooling
 
 - **ghostty-vt** is fetched as a pinned tarball via the Zig package manager (`build.zig.zon`).
-- **SDL3** and **SDL3_ttf** are provided by Nix. SDL3 is pinned to 3.4.0 via `overlays/sdl3-3-4-0.nix` with binaries cached in the public `forketyfork` Cachix to avoid rebuilds.
+- **SDL3** and **SDL3_ttf** are provided by Nix. SDL3 is pinned to 3.4.10 via `overlays/sdl3-3-4-10.nix` with binaries cached in the public `forketyfork` Cachix to avoid rebuilds.
 
 ## Tests and Formatting
 

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
-            (import ./overlays/sdl3-3-4-0.nix)
+            (import ./overlays/sdl3-3-4-10.nix)
           ];
           config = {
             allowUnfree = true;

--- a/overlays/sdl3-3-4-10.nix
+++ b/overlays/sdl3-3-4-10.nix
@@ -1,15 +1,15 @@
 final: prev: {
   sdl3 = prev.sdl3.overrideAttrs (old: rec {
-    version = "3.4.0";
+    version = "3.4.10";
 
     src = prev.fetchFromGitHub {
       owner = "libsdl-org";
       repo = "SDL";
       rev = "release-${version}";
-      hash = "sha256-/A1y/NaZVebzI58F4TlwtDwuzlcA33Y1YuZqd5lz/Sk=";
+      hash = "sha256-6Dph2eLiJUmpQzPWe8EuY5LrWhrFwde2f2dwfgCcWNw=";
     };
 
-    # Drop nixpkgs' Linux-only zenity substitutions that no longer match SDL 3.4.0.
+    # Drop nixpkgs' Linux-only zenity substitutions that no longer match SDL 3.4.x.
     # Keep the test timeout bump to avoid slow CTest hangs.
     postPatch = ''
       substituteInPlace test/CMakeLists.txt \


### PR DESCRIPTION
Bumps SDL3 from 3.4.0 to 3.4.10 by updating the Nix overlay and its source hash.

## Solution

The overlay was pinned to SDL3 3.4.0. 3.4.10 is the current stable release, ten patch versions ahead with no API changes.

The overlay file is renamed from `sdl3-3-4-0.nix` to `sdl3-3-4-10.nix` with the updated version string and NAR hash. `flake.nix` points to the new file.

A few fixes in this range are worth mentioning. In 3.4.4, SDL reverted `SDL_GL_FRAMEBUFFER_SRGB_CAPABLE` to default 0 after an accidental change caused incorrect colors in OpenGL rendering. In 3.4.6, multi-threaded GPU crashes on Metal and Vulkan were fixed. Neither is likely to cause visible changes here, but both are good to have.
