### PR TITLE
Build Zwanzig as a host lint dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -127,19 +127,18 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_exe_unit_tests.step);
     test_step.dependOn(&run_mcp_unit_tests.step);
 
-    // Lint step using zwanzig. Always build the linter with ReleaseFast: it is a
+    // Lint step using Zwanzig. Always build the linter with ReleaseFast: it is a
     // build-time tool and Debug-mode safety/allocator overhead makes analysis
     // multiple orders of magnitude slower on x86 Linux runners.
-    if (b.lazyDependency("zwanzig", .{
-        .target = target,
+    const zwanzig = b.dependency("zwanzig", .{
+        .target = b.graph.host,
         .optimize = .ReleaseFast,
-    })) |zw| {
-        const zw_exe = zw.artifact("zwanzig");
-        const lint_run = b.addRunArtifact(zw_exe);
-        lint_run.addArgs(&.{"src"});
-        const lint_step = b.step("lint", "Run zwanzig linter");
-        lint_step.dependOn(&lint_run.step);
-    }
+    });
+    const run_zwanzig = b.addRunArtifact(zwanzig.artifact("zwanzig"));
+    run_zwanzig.addArgs(&.{"src"});
+
+    const lint_step = b.step("lint", "Run Zwanzig");
+    lint_step.dependOn(&run_zwanzig.step);
 }
 
 // Prefer the active developer selection over hardcoded SDK locations so

--- a/build.zig
+++ b/build.zig
@@ -135,7 +135,11 @@ pub fn build(b: *std.Build) void {
         .optimize = .ReleaseFast,
     });
     const run_zwanzig = b.addRunArtifact(zwanzig.artifact("zwanzig"));
-    run_zwanzig.addArgs(&.{"src"});
+    const target_triple = b.fmt("{s}-{s}", .{
+        @tagName(target.result.cpu.arch),
+        @tagName(target.result.os.tag),
+    });
+    run_zwanzig.addArgs(&.{ "--target", target_triple, "src" });
 
     const lint_step = b.step("lint", "Run Zwanzig");
     lint_step.dependOn(&run_zwanzig.step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "toml-0.3.0-bV14Bd-EAQBKoXhpYft303BtA2vgLNlxntUCIWgRUl46",
         },
         .zwanzig = .{
-            .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.13.1.tar.gz",
-            .hash = "zwanzig-0.13.1-oiXZll27GADDlJfUdQH1T7i5bYapXxreg-OrBorzXnmI",
+            .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.14.0.tar.gz",
+            .hash = "zwanzig-0.14.0-oiXZljvxGACKRbJD3WEVSKM_gbCm6GUsrz2_TbFP7xfe",
         },
     },
     .paths = .{

--- a/docs/development.md
+++ b/docs/development.md
@@ -61,6 +61,7 @@ zig build run
 ## Dependencies and Tooling
 
 - **ghostty-vt** is fetched as a pinned tarball via the Zig package manager (`build.zig.zon`).
+- **Zwanzig** is pinned as a Zig build dependency and runs as a host-targeted `ReleaseFast` build tool through `zig build lint`.
 - **SDL3** and **SDL3_ttf** are provided by Nix. SDL3 is pinned to 3.4.10 via `overlays/sdl3-3-4-10.nix` with binaries cached in the public `forketyfork` Cachix to avoid rebuilds.
 
 ## Tests and Formatting

--- a/docs/development.md
+++ b/docs/development.md
@@ -61,7 +61,7 @@ zig build run
 ## Dependencies and Tooling
 
 - **ghostty-vt** is fetched as a pinned tarball via the Zig package manager (`build.zig.zon`).
-- **Zwanzig** is pinned as a Zig build dependency and runs as a host-targeted `ReleaseFast` build tool through `zig build lint`.
+- **Zwanzig** is pinned as a Zig build dependency and runs as a host-targeted `ReleaseFast` build tool through `zig build lint`. Architect passes its requested target architecture and operating system to Zwanzig for target-aware analysis.
 - **SDL3** and **SDL3_ttf** are provided by Nix. SDL3 is pinned to 3.4.10 via `overlays/sdl3-3-4-10.nix` with binaries cached in the public `forketyfork` Cachix to avoid rebuilds.
 
 ## Tests and Formatting


### PR DESCRIPTION
## Summary

Architect pinned Zwanzig v0.13.1 and built the linter for the application's target. That works for native builds, but a cross-compiled build can produce a Zwanzig executable that the host cannot run.

This updates the integration to the documented pattern:

- bump Zwanzig to v0.14.0 with its fetched Zig package hash
- build the linter for `b.graph.host` in `ReleaseFast`
- forward the application's target architecture and operating system to Zwanzig through `--target`
- expose the dependency through the direct `zig build lint` setup
- document Zwanzig as a build-time dependency

## Validation

- `zig build`
- `zig build test`
- `nix develop --command just lint`
- `nix develop --command zig build lint -Dtarget=x86_64-linux-gnu`
