### PR TITLE
Add first-launch onboarding hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ architect hook claude
 architect hook codex
 architect hook gemini
 ```
+On first launch, Architect shows a faint in-terminal hint with the core shortcuts and the `architect hook` setup command. The hint is shown once and is not sent to the shell.
 
 ## MCP
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -381,7 +381,7 @@ Rotate: rename active file to architect-<UTC timestamp>.log and continue in new 
 | Glyph cache | GPU textures + in-memory LRU | Up to 4096 shaped glyph textures |
 | Render cache | GPU textures per session | Cached terminal renders, epoch-invalidated |
 | config.toml | `~/.config/architect/config.toml` | User preferences (font, theme, UI flags, worktree location) |
-| persistence.toml | `~/.config/architect/persistence.toml` | Runtime state (window pos, font size, terminal cwds, agent session IDs) |
+| persistence.toml | `~/.config/architect/persistence.toml` | Runtime state (window pos, font size, terminal cwds, agent session IDs, onboarding state) |
 | architect.log + archives | `~/Library/Logs/Architect/` | Structured application logs with size-based rotation (10 MiB active-file threshold) |
 | diff_comments.json | `<repo>/.architect/diff_comments.json` | Per-repo inline diff review comments (unsent) |
 | architect_control_<uid>_<pid>.json | `XDG_RUNTIME_DIR`, or `~/Library/Caches/Architect/runtime` on macOS / `~/.cache/architect/runtime` elsewhere | Per-instance discovery file pointing `architect-mcp` at a running app's local control socket |
@@ -413,7 +413,7 @@ Rotate: rename active file to architect-<UTC timestamp>.log and continue in new 
 | `session/notify.zig` | Background notification socket thread and queue; handles status and story notifications | `NotificationQueue`, `Notification` (union: status/story), `startThread()`, `push()`, `drain()` | std (socket, thread) |
 | `session/pty_watcher.zig` | Background thread that `poll(2)`s spawned sessions' PTY master fds and posts a wake event when one becomes readable (or hangs up/errors); mutex-guarded fd list refreshed once per frame by the runtime | `PtyWatcher`, `start()`, `updateFds()` | std (poll, thread) |
 | `session/*` (shell, pty, vt_stream, cwd) | Shell spawning, PTY abstraction, VT parsing, working directory detection | `spawn()`, `Pty`, `VtStream.processBytes()`, `getCwd()` | std (posix), ghostty-vt |
-| `render/renderer.zig` | Scene rendering: terminals, borders, animations, terminal scrollbar painting | `render()`, `RenderCache`, per-session texture management | `font`, `font_cache`, `gfx/*`, `anim/easing`, `app/app_state`, `ui/components/scrollbar`, `c` |
+| `render/renderer.zig` | Scene rendering: terminals, borders, animations, terminal scrollbar painting, first-launch onboarding hint | `render()`, `RenderCache`, per-session texture management | `font`, `font_cache`, `gfx/*`, `anim/easing`, `app/app_state`, `ui/components/scrollbar`, `c` |
 | `font.zig` + `font_cache.zig` | Font rendering, HarfBuzz shaping, glyph LRU cache, shared font cache | `Font`, `openFont()`, `renderGlyph()`, `FontCache`, `getOrCreate()` | `font_paths`, `c` (SDL3_ttf) |
 | `gfx/*` (box_drawing, primitives) | Procedural box-drawing characters (U+2500-U+257F), rounded/thick border helpers, bezier arrow rendering | `renderBoxDrawing()`, `drawRoundedRect()`, `drawThickBorder()`, `fillRoundedRect()`, `renderBezierArrow()` | `c` |
 | `ui/root.zig` | UI component registry, z-index dispatch, action drain | `UiRoot`, `register()`, `handleEvent()`, `update()`, `render()`, `needsFrame()` | `ui/component`, `ui/types` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,6 +242,7 @@ Auto-managed runtime state. Do not edit manually unless troubleshooting.
 
 ```toml
 font_size = 14
+onboarding_shown = true
 
 terminals = [
   "/Users/me/projects/app",
@@ -269,6 +270,7 @@ y = 50
 | Field | Description |
 |-------|-------------|
 | `font_size` | Current font size (adjusted with `Cmd++`/`Cmd+-`) |
+| `onboarding_shown` | Whether the first-launch onboarding hint has been displayed; older persistence files without this field are treated as already shown |
 | `terminals` | Working directories for each terminal (ordered by session index) |
 | `terminal_agent_types` | Agent type for each terminal slot (`"claude"`, `"codex"`, `"gemini"`), or an empty string (`""`) when absent. Present only when at least one terminal had a running agent at quit time. |
 | `terminal_session_ids` | Session UUID for each terminal slot, or an empty string (`""`) when absent. Written alongside `terminal_agent_types` when an agent session ID was captured at quit. On next launch, Architect writes the corresponding resume command (e.g., `claude --resume <uuid>`) to the terminal as soon as the shell is ready. |

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -1266,6 +1266,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
     };
     errdefer persistence.deinit(allocator);
     persistence.font_size = std.math.clamp(persistence.font_size, min_font_size, max_font_size);
+    const show_onboarding = !persistence.onboarding_shown;
 
     // Initialize recent folders with home directory if empty
     if (persistence.recent_folders.items.len == 0) {
@@ -1527,6 +1528,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
     var running = true;
     var persistence_dirty = false;
     var persistence_dirty_since_ms: i64 = 0;
+    var onboarding_displayed = false;
     var quit_teardown = QuitTeardownState{};
     defer quit_teardown.join();
 
@@ -3116,10 +3118,16 @@ pub fn run(log_dir_override: ?[]const u8) !void {
                 ui_scale,
                 config.grid.font_scale,
                 &grid,
+                show_onboarding,
+                &onboarding_displayed,
             ) catch |err| {
                 log.err("render failed: {}", .{err});
                 return err;
             };
+            if (show_onboarding and onboarding_displayed and !persistence.onboarding_shown) {
+                persistence.onboarding_shown = true;
+                markPersistenceDirty(&persistence_dirty, &persistence_dirty_since_ms, now);
+            }
             ui.render(&ui_render_host, renderer);
             _ = c.SDL_RenderPresent(renderer);
             if (relaunch_trace_frames > 0) {

--- a/src/config.zig
+++ b/src/config.zig
@@ -326,6 +326,7 @@ pub const Persistence = struct {
     terminal_entries: std.ArrayListUnmanaged(TerminalEntry) = .{},
     recent_folders: std.ArrayListUnmanaged(RecentFolder) = .{},
     visit_counter: u32 = 0,
+    onboarding_shown: bool = false,
 
     const TomlPersistenceV3 = struct {
         window: WindowConfig = .{},
@@ -334,6 +335,7 @@ pub const Persistence = struct {
         terminal_agent_types: ?[]const []const u8 = null,
         terminal_session_ids: ?[]const []const u8 = null,
         recent_folders: ?toml.HashMap(u32) = null,
+        onboarding_shown: ?bool = null,
     };
 
     const TomlPersistenceV2 = struct {
@@ -341,12 +343,14 @@ pub const Persistence = struct {
         font_size: c_int = 14,
         terminals: ?[]const []const u8 = null,
         recent_folders: ?[]const []const u8 = null,
+        onboarding_shown: ?bool = null,
     };
 
     const TomlPersistenceV1 = struct {
         window: WindowConfig = .{},
         font_size: c_int = 14,
         terminals: ?toml.HashMap([]const u8) = null,
+        onboarding_shown: ?bool = null,
     };
 
     pub fn init(allocator: std.mem.Allocator) Persistence {
@@ -386,6 +390,7 @@ pub const Persistence = struct {
             defer result.deinit();
             persistence.window = result.value.window;
             persistence.font_size = result.value.font_size;
+            persistence.onboarding_shown = onboardingShownFromStoredValue(result.value.onboarding_shown);
 
             if (result.value.terminals) |paths| {
                 for (paths, 0..) |path, idx| {
@@ -416,6 +421,7 @@ pub const Persistence = struct {
             defer result.deinit();
             persistence.window = result.value.window;
             persistence.font_size = result.value.font_size;
+            persistence.onboarding_shown = onboardingShownFromStoredValue(result.value.onboarding_shown);
 
             if (result.value.terminals) |paths| {
                 for (paths) |path| {
@@ -446,6 +452,7 @@ pub const Persistence = struct {
 
         persistence.window = result_v1.value.window;
         persistence.font_size = result_v1.value.font_size;
+        persistence.onboarding_shown = onboardingShownFromStoredValue(result_v1.value.onboarding_shown);
 
         if (result_v1.value.terminals) |stored| {
             try persistence.appendLegacyTerminalEntries(allocator, stored);
@@ -479,6 +486,7 @@ pub const Persistence = struct {
     pub fn serializeToWriter(self: Persistence, writer: anytype) !void {
         // Write font_size first (top-level scalar)
         try writer.print("font_size = {d}\n", .{self.font_size});
+        try writer.print("onboarding_shown = {}\n", .{self.onboarding_shown});
 
         // Write terminal path and agent arrays before any sections
         if (self.terminal_entries.items.len > 0) {
@@ -525,6 +533,10 @@ pub const Persistence = struct {
                 try writer.print(" = {d}\n", .{folder.count});
             }
         }
+    }
+
+    fn onboardingShownFromStoredValue(value: ?bool) bool {
+        return value orelse true;
     }
 
     pub fn getPersistencePath(allocator: std.mem.Allocator) ![]u8 {
@@ -1180,6 +1192,7 @@ test "Persistence save/load round-trip preserves all fields" {
     original.window.x = 100;
     original.window.y = 200;
     original.font_size = 16;
+    original.onboarding_shown = true;
     try original.appendTerminalEntry(allocator, "/home/user/project1", null, null);
     try original.appendTerminalEntry(allocator, "/home/user/project2", "claude", "abc-123-def");
     try original.appendTerminalEntry(allocator, "/tmp/test", null, null);
@@ -1202,6 +1215,7 @@ test "Persistence save/load round-trip preserves all fields" {
 
     loaded.window = result.value.window;
     loaded.font_size = result.value.font_size;
+    loaded.onboarding_shown = Persistence.onboardingShownFromStoredValue(result.value.onboarding_shown);
 
     if (result.value.terminals) |paths| {
         for (paths, 0..) |path, idx| {
@@ -1222,6 +1236,7 @@ test "Persistence save/load round-trip preserves all fields" {
     try std.testing.expectEqual(original.window.x, loaded.window.x);
     try std.testing.expectEqual(original.window.y, loaded.window.y);
     try std.testing.expectEqual(original.font_size, loaded.font_size);
+    try std.testing.expectEqual(original.onboarding_shown, loaded.onboarding_shown);
     try std.testing.expectEqual(original.terminal_entries.items.len, loaded.terminal_entries.items.len);
 
     for (original.terminal_entries.items, loaded.terminal_entries.items) |orig, loaded_entry| {
@@ -1237,6 +1252,16 @@ test "Persistence save/load round-trip preserves all fields" {
             try std.testing.expect(loaded_entry.agent_session_id == null);
         }
     }
+}
+
+test "Persistence treats missing onboarding state as already shown" {
+    var persistence = Persistence.init(std.testing.allocator);
+    defer persistence.deinit(std.testing.allocator);
+
+    try std.testing.expect(!persistence.onboarding_shown);
+    try std.testing.expect(Persistence.onboardingShownFromStoredValue(null));
+    try std.testing.expect(!Persistence.onboardingShownFromStoredValue(false));
+    try std.testing.expect(Persistence.onboardingShownFromStoredValue(true));
 }
 
 test "writeFileAtomicallyAbsolute replaces file with valid TOML" {

--- a/src/render/renderer.zig
+++ b/src/render/renderer.zig
@@ -31,6 +31,12 @@ pub const grid_border_thickness: c_int = attention_thickness;
 const faint_factor: f32 = 0.6;
 const cursor_color = c.SDL_Color{ .r = 215, .g = 186, .b = 125, .a = 255 };
 const dark_fallback = c.SDL_Color{ .r = 0, .g = 0, .b = 0, .a = 255 };
+const onboarding_hint_lines = [_][]const u8{
+    "Welcome to Architect",
+    "Cmd+N adds a terminal; Cmd+W closes one.",
+    "Cmd+Enter toggles grid/full; hold Escape to interrupt agents.",
+    "Hooks: architect hook claude | codex | gemini",
+};
 
 pub const RenderError = font_mod.Font.RenderGlyphError;
 
@@ -143,6 +149,8 @@ pub fn render(
     ui_scale: f32,
     grid_font_scale: f32,
     grid: ?*const GridLayout,
+    show_onboarding: bool,
+    onboarding_displayed: *bool,
 ) RenderError!void {
     _ = c.SDL_SetRenderDrawColor(renderer, theme.background.r, theme.background.g, theme.background.b, 255);
     _ = c.SDL_RenderClear(renderer);
@@ -190,7 +198,7 @@ pub fn render(
 
                     const entry = render_cache.entry(i);
                     const session_dims = sessionTermDims(session, term_cols, term_rows);
-                    try renderSessionCached(renderer, session, view, entry, cell_rect, grid_scale, i == anim_state.focused_session, true, true, currentWaveEffect(view, current_time), font, session_dims.cols, session_dims.rows, current_time, true, theme, ui_scale);
+                    try renderSessionCached(renderer, session, view, entry, cell_rect, grid_scale, i == anim_state.focused_session, true, true, currentWaveEffect(view, current_time), font, session_dims.cols, session_dims.rows, current_time, true, theme, ui_scale, show_onboarding, onboarding_displayed);
                 }
             }
         },
@@ -200,7 +208,7 @@ pub fn render(
             const entry = render_cache.entry(anim_state.focused_session);
             const focused_session = sessions[anim_state.focused_session];
             const focused_dims = sessionTermDims(focused_session, term_cols, term_rows);
-            try renderSessionCached(renderer, focused_session, &views[anim_state.focused_session], entry, full_rect, 1.0, true, false, true, null, font, focused_dims.cols, focused_dims.rows, current_time, false, theme, ui_scale);
+            try renderSessionCached(renderer, focused_session, &views[anim_state.focused_session], entry, full_rect, 1.0, true, false, true, null, font, focused_dims.cols, focused_dims.rows, current_time, false, theme, ui_scale, show_onboarding, onboarding_displayed);
         },
         .PanningLeft, .PanningRight => {
             const elapsed = current_time - anim_state.start_time;
@@ -214,7 +222,7 @@ pub fn render(
             const prev_entry = render_cache.entry(anim_state.previous_session);
             const prev_session = sessions[anim_state.previous_session];
             const prev_dims = sessionTermDims(prev_session, term_cols, term_rows);
-            try renderSession(renderer, prev_session, &views[anim_state.previous_session], prev_entry, prev_rect, 1.0, false, false, font, prev_dims.cols, prev_dims.rows, current_time, false, theme, ui_scale);
+            try renderSession(renderer, prev_session, &views[anim_state.previous_session], prev_entry, prev_rect, 1.0, false, false, font, prev_dims.cols, prev_dims.rows, current_time, false, theme, ui_scale, show_onboarding, onboarding_displayed);
 
             const new_offset = if (anim_state.mode == .PanningLeft)
                 window_width - offset
@@ -224,7 +232,7 @@ pub fn render(
             const new_entry = render_cache.entry(anim_state.focused_session);
             const new_session = sessions[anim_state.focused_session];
             const new_dims = sessionTermDims(new_session, term_cols, term_rows);
-            try renderSession(renderer, new_session, &views[anim_state.focused_session], new_entry, new_rect, 1.0, true, false, font, new_dims.cols, new_dims.rows, current_time, false, theme, ui_scale);
+            try renderSession(renderer, new_session, &views[anim_state.focused_session], new_entry, new_rect, 1.0, true, false, font, new_dims.cols, new_dims.rows, current_time, false, theme, ui_scale, show_onboarding, onboarding_displayed);
         },
         .PanningUp, .PanningDown => {
             const elapsed = current_time - anim_state.start_time;
@@ -238,7 +246,7 @@ pub fn render(
             const prev_entry = render_cache.entry(anim_state.previous_session);
             const prev_session = sessions[anim_state.previous_session];
             const prev_dims = sessionTermDims(prev_session, term_cols, term_rows);
-            try renderSession(renderer, prev_session, &views[anim_state.previous_session], prev_entry, prev_rect, 1.0, false, false, font, prev_dims.cols, prev_dims.rows, current_time, false, theme, ui_scale);
+            try renderSession(renderer, prev_session, &views[anim_state.previous_session], prev_entry, prev_rect, 1.0, false, false, font, prev_dims.cols, prev_dims.rows, current_time, false, theme, ui_scale, show_onboarding, onboarding_displayed);
 
             const new_offset = if (anim_state.mode == .PanningUp)
                 window_height - offset
@@ -248,7 +256,7 @@ pub fn render(
             const new_entry = render_cache.entry(anim_state.focused_session);
             const new_session = sessions[anim_state.focused_session];
             const new_dims = sessionTermDims(new_session, term_cols, term_rows);
-            try renderSession(renderer, new_session, &views[anim_state.focused_session], new_entry, new_rect, 1.0, true, false, font, new_dims.cols, new_dims.rows, current_time, false, theme, ui_scale);
+            try renderSession(renderer, new_session, &views[anim_state.focused_session], new_entry, new_rect, 1.0, true, false, font, new_dims.cols, new_dims.rows, current_time, false, theme, ui_scale, show_onboarding, onboarding_displayed);
         },
         .Expanding, .Collapsing => {
             const animating_rect = anim_state.getCurrentRect(current_time);
@@ -277,7 +285,7 @@ pub fn render(
 
                     const entry = render_cache.entry(i);
                     const session_dims = sessionTermDims(session, term_cols, term_rows);
-                    try renderSessionCached(renderer, session, &views[i], entry, cell_rect, grid_scale, false, true, true, currentWaveEffect(&views[i], current_time), font, session_dims.cols, session_dims.rows, current_time, true, theme, ui_scale);
+                    try renderSessionCached(renderer, session, &views[i], entry, cell_rect, grid_scale, false, true, true, currentWaveEffect(&views[i], current_time), font, session_dims.cols, session_dims.rows, current_time, true, theme, ui_scale, show_onboarding, onboarding_displayed);
                 }
             }
 
@@ -285,7 +293,7 @@ pub fn render(
             const entry = render_cache.entry(anim_state.focused_session);
             const focused_session = sessions[anim_state.focused_session];
             const focused_dims = sessionTermDims(focused_session, term_cols, term_rows);
-            try renderSession(renderer, focused_session, &views[anim_state.focused_session], entry, animating_rect, anim_scale, true, apply_effects, font, focused_dims.cols, focused_dims.rows, current_time, true, theme, ui_scale);
+            try renderSession(renderer, focused_session, &views[anim_state.focused_session], entry, animating_rect, anim_scale, true, apply_effects, font, focused_dims.cols, focused_dims.rows, current_time, true, theme, ui_scale, show_onboarding, onboarding_displayed);
         },
         .GridResizing => {
             // Render session contents first so borders draw on top.
@@ -319,7 +327,7 @@ pub fn render(
 
                 const entry = render_cache.entry(i);
                 const session_dims = sessionTermDims(session, term_cols, term_rows);
-                try renderSessionCached(renderer, session, &views[i], entry, cell_rect, grid_scale, i == anim_state.focused_session, true, false, currentWaveEffect(&views[i], current_time), font, session_dims.cols, session_dims.rows, current_time, true, theme, ui_scale);
+                try renderSessionCached(renderer, session, &views[i], entry, cell_rect, grid_scale, i == anim_state.focused_session, true, false, currentWaveEffect(&views[i], current_time), font, session_dims.cols, session_dims.rows, current_time, true, theme, ui_scale, show_onboarding, onboarding_displayed);
             }
 
             // Render borders and overlays on top of the animated content.
@@ -370,8 +378,10 @@ fn renderSession(
     is_grid_view: bool,
     theme: *const colors.Theme,
     ui_scale: f32,
+    show_onboarding: bool,
+    onboarding_displayed: *bool,
 ) RenderError!void {
-    try renderSessionContent(renderer, session, view, rect, scale, is_focused, font, term_cols, term_rows, current_time_ms, is_grid_view, theme, ui_scale);
+    try renderSessionContent(renderer, session, view, rect, scale, is_focused, font, term_cols, term_rows, current_time_ms, is_grid_view, theme, ui_scale, show_onboarding, onboarding_displayed);
     renderSessionOverlays(renderer, session, view, rect, is_focused, apply_effects, current_time_ms, is_grid_view, theme, ui_scale);
     cache_entry.presented_epoch = session.render_epoch;
 }
@@ -390,6 +400,8 @@ fn renderSessionContent(
     is_grid_view: bool,
     theme: *const colors.Theme,
     ui_scale: f32,
+    show_onboarding: bool,
+    onboarding_displayed: *bool,
 ) RenderError!void {
     if (!session.spawned) return;
 
@@ -674,6 +686,21 @@ fn renderSessionContent(
         }
     }
 
+    if (shouldShowOnboarding(show_onboarding, is_focused, session.slot_index, session.dead)) {
+        if (try renderOnboardingHint(
+            font,
+            origin_x,
+            origin_y,
+            cell_width_actual,
+            cell_height_actual,
+            visible_cols,
+            visible_rows,
+            theme,
+        )) {
+            onboarding_displayed.* = true;
+        }
+    }
+
     if (session.dead) {
         const message = "[Process completed]";
         const message_row: usize = @intCast(cursor.y);
@@ -692,6 +719,44 @@ fn renderSessionContent(
             }
         }
     }
+}
+
+fn shouldShowOnboarding(show_onboarding: bool, is_focused: bool, slot_index: usize, session_dead: bool) bool {
+    return show_onboarding and is_focused and slot_index == 0 and !session_dead;
+}
+
+test "onboarding hint is limited to the focused live first session" {
+    try std.testing.expect(shouldShowOnboarding(true, true, 0, false));
+    try std.testing.expect(!shouldShowOnboarding(false, true, 0, false));
+    try std.testing.expect(!shouldShowOnboarding(true, false, 0, false));
+    try std.testing.expect(!shouldShowOnboarding(true, true, 1, false));
+    try std.testing.expect(!shouldShowOnboarding(true, true, 0, true));
+}
+
+fn renderOnboardingHint(
+    font: *font_mod.Font,
+    origin_x: c_int,
+    origin_y: c_int,
+    cell_width_actual: c_int,
+    cell_height_actual: c_int,
+    visible_cols: usize,
+    visible_rows: usize,
+    theme: *const colors.Theme,
+) RenderError!bool {
+    if (visible_cols == 0 or visible_rows < onboarding_hint_lines.len) return false;
+
+    const hint_color = applyFaint(theme.foreground);
+    const start_row = visible_rows - onboarding_hint_lines.len;
+    for (onboarding_hint_lines, 0..) |line, idx| {
+        const line_y = origin_y + @as(c_int, @intCast(start_row + idx)) * cell_height_actual;
+        var offset_x = origin_x;
+        for (line, 0..) |ch, col| {
+            if (col >= visible_cols) break;
+            try font.renderGlyph(ch, offset_x, line_y, cell_width_actual, cell_height_actual, hint_color);
+            offset_x += cell_width_actual;
+        }
+    }
+    return true;
 }
 
 fn activeScreenRowOffset(term_rows: u16, visible_rows: usize, cursor_row: usize, is_grid_view: bool, is_viewing_scrollback: bool) usize {
@@ -1002,6 +1067,8 @@ fn refreshSessionCacheTexture(
     is_grid_view: bool,
     theme: *const colors.Theme,
     ui_scale: f32,
+    show_onboarding: bool,
+    onboarding_displayed: *bool,
 ) RenderError!void {
     log.debug("rendering to cache: session={d} spawned={} focused={}", .{ session.id, session.spawned, is_focused });
     const render_mode = cacheRenderMode(is_grid_view);
@@ -1015,7 +1082,7 @@ fn refreshSessionCacheTexture(
     _ = c.SDL_RenderClear(renderer);
 
     const local_rect = Rect{ .x = 0, .y = 0, .w = rect.w, .h = rect.h };
-    try renderSessionContent(renderer, session, view, local_rect, scale, is_focused, font, term_cols, term_rows, current_time_ms, is_grid_view, theme, ui_scale);
+    try renderSessionContent(renderer, session, view, local_rect, scale, is_focused, font, term_cols, term_rows, current_time_ms, is_grid_view, theme, ui_scale, show_onboarding, onboarding_displayed);
     if (cache_overlays) {
         renderSessionOverlays(renderer, session, view, local_rect, is_focused, apply_effects, current_time_ms, is_grid_view, theme, ui_scale);
     }
@@ -1052,6 +1119,8 @@ fn renderSessionCached(
     is_grid_view: bool,
     theme: *const colors.Theme,
     ui_scale: f32,
+    show_onboarding: bool,
+    onboarding_displayed: *bool,
 ) RenderError!void {
     if (!session.spawned) {
         cache_entry.presented_epoch = session.render_epoch;
@@ -1067,7 +1136,7 @@ fn renderSessionCached(
         if (cache_entry.texture) |tex| {
             const sync_holding = synchronizedOutputHoldsCache(session, cache_entry, composition);
             if (!sync_holding and cacheNeedsRefresh(cache_entry, session.render_epoch, composition, render_mode)) {
-                try refreshSessionCacheTexture(renderer, session, view, cache_entry, rect, scale, is_focused, apply_effects, font, term_cols, term_rows, current_time_ms, cache_overlays, composition, is_grid_view, theme, ui_scale);
+                try refreshSessionCacheTexture(renderer, session, view, cache_entry, rect, scale, is_focused, apply_effects, font, term_cols, term_rows, current_time_ms, cache_overlays, composition, is_grid_view, theme, ui_scale, show_onboarding, onboarding_displayed);
             }
 
             if (wave_effect) |wave| {
@@ -1085,11 +1154,11 @@ fn renderSessionCached(
     }
 
     if (render_overlays) {
-        try renderSession(renderer, session, view, cache_entry, rect, scale, is_focused, apply_effects, font, term_cols, term_rows, current_time_ms, is_grid_view, theme, ui_scale);
+        try renderSession(renderer, session, view, cache_entry, rect, scale, is_focused, apply_effects, font, term_cols, term_rows, current_time_ms, is_grid_view, theme, ui_scale, show_onboarding, onboarding_displayed);
         return;
     }
 
-    try renderSessionContent(renderer, session, view, rect, scale, is_focused, font, term_cols, term_rows, current_time_ms, is_grid_view, theme, ui_scale);
+    try renderSessionContent(renderer, session, view, rect, scale, is_focused, font, term_cols, term_rows, current_time_ms, is_grid_view, theme, ui_scale, show_onboarding, onboarding_displayed);
     cache_entry.presented_epoch = session.render_epoch;
 }
 


### PR DESCRIPTION
## Issue

New users need a concise introduction to Architect's core terminal shortcuts and AI-agent hook setup. PRs #177 and #178 implemented overlapping versions of this behavior, but both were based on an old `main` and are now superseded.

## Solution

Render a faint four-line onboarding hint in the first focused live terminal. It is drawn by the scene renderer rather than sent through the PTY, so it does not affect shell history, terminal state, or agent sessions.

Persist `onboarding_shown` after the hint is actually drawable, preserve the value across all current persistence formats, and treat older persistence files without the field as already seen. A genuinely new installation still starts with the hint enabled. Regression tests cover persistence round-tripping, migration behavior, and renderer gating. Documentation describes the user-visible behavior and persisted field.

## Context

This PR consolidates the best parts of [#177](https://github.com/forketyfork/architect/pull/177) and [#178](https://github.com/forketyfork/architect/pull/178) on top of the current `origin/main`.

## Test plan

- [x] On a fresh configuration, launch Architect and confirm the faint hint appears in the first terminal with the Cmd+N, Cmd+W, Cmd+Enter, Escape, and hook instructions.
- [x] Relaunch Architect and confirm the hint is not shown again.
- [x] Confirm the hint is visual-only and does not appear in shell history or terminal scrollback.
