### PR TITLE
build: upgrade Zwanzig to v0.15.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,8 +17,8 @@
             .hash = "toml-0.3.0-bV14Bd-EAQBKoXhpYft303BtA2vgLNlxntUCIWgRUl46",
         },
         .zwanzig = .{
-            .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.14.0.tar.gz",
-            .hash = "zwanzig-0.14.0-oiXZljvxGACKRbJD3WEVSKM_gbCm6GUsrz2_TbFP7xfe",
+            .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.15.1.tar.gz",
+            .hash = "zwanzig-0.15.1-oiXZliOBGQA1fkoEDA6UxFdOv1ezRF5Jc9YY7uZnHjKe",
         },
     },
     .paths = .{

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,7 +68,7 @@ zig build run -- --log-dir .tmp/architect-debug-logs
 ## Dependencies and Tooling
 
 - **ghostty-vt** is fetched as a pinned tarball via the Zig package manager (`build.zig.zon`).
-- **Zwanzig** is pinned as a Zig build dependency and runs as a host-targeted `ReleaseFast` build tool through `zig build lint`. Architect passes its requested target architecture and operating system to Zwanzig for target-aware analysis.
+- **Zwanzig v0.15.1** is pinned as a Zig build dependency and runs as a host-targeted `ReleaseFast` build tool through `zig build lint`. Architect passes its requested target architecture and operating system to Zwanzig for target-aware analysis.
 - **SDL3** and **SDL3_ttf** are provided by Nix. SDL3 is pinned to 3.4.10 via `overlays/sdl3-3-4-10.nix` with binaries cached in the public `forketyfork` Cachix to avoid rebuilds.
 
 ## Tests and Formatting


### PR DESCRIPTION
## Issue

Architect was pinned to Zwanzig v0.14.0 and needs to migrate to v0.15.1.

## Solution

Update the Zig package manifest to fetch Zwanzig v0.15.1 with its verified content hash. Keep the existing host-targeted `ReleaseFast` lint integration and document the exact pinned version for developers.

## Context

- [Zwanzig v0.15.1 release](https://github.com/forketyfork/zwanzig/releases/tag/v0.15.1)
