### PR TITLE
fix: provision AIR Cloud without Nix

### DIFF
--- a/.air/cloud/startup.sh
+++ b/.air/cloud/startup.sh
@@ -1,83 +1,111 @@
 #!/usr/bin/env bash
-# AIR Cloud workspace provisioning script (see FLEET_WORKSPACE_SETUP_SCRIPT).
-# Runs once per fresh sandbox, before the coding agent session starts.
-# Prepares Nix (with flakes) so `nix develop` / `just build|test|lint` work
-# for Architect without every task re-installing the toolchain from scratch.
-set -uo pipefail
+# Provision Architect in AIR Cloud without Nix, apt, sudo, or root access.
+# Zig supplies the C compiler used for the two SDL builds; all other tools are
+# portable user-space archives. SDL 3.4.10 is parsed from the project's overlay
+# so this remains aligned with the normal development environment.
+set -euo pipefail
 
 log() { printf '[air-startup] %s\n' "$*"; }
+die() { printf '[air-startup] ERROR: %s\n' "$*" >&2; exit 1; }
 
-log "id: $(id)"
-log "sudo -l (permitted commands, if any):"
-sudo -n -l 2>&1 | tail -20 || true
+project_dir="${FLEET_WORKSPACE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+home_dir="${HOME:?HOME is required}"
+prefix="$home_dir/.local"
+bin_dir="$prefix/bin"
+src_dir="$prefix/src"
+sdl_prefix="$prefix/sdl3-prefix"
+profile="$home_dir/.profile"
+mkdir -p "$bin_dir" "$src_dir" "$sdl_prefix"
 
-if command -v nix >/dev/null 2>&1 && nix --version >/dev/null 2>&1; then
-  log "nix already present on PATH: $(nix --version)"
-else
-  log "installing Nix (Determinate installer, no-daemon single-user mode)"
-  if curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
-      | sh -s -- install linux --init none --no-confirm; then
-    log "nix-installer completed"
-  else
-    log "nix-installer exited non-zero; continuing to check whether nix is usable anyway"
+download() {
+  local url="$1" dest="$2"
+  if [ ! -s "$dest" ]; then
+    log "downloading $(basename "$dest")"
+    curl --fail --location --retry 3 --silent --show-error -o "$dest" "$url"
   fi
+}
+extract_tar() {
+  # Python's stdlib supports .xz even when the minimal image has no xz binary.
+  python3 -c 'import sys,tarfile; tarfile.open(sys.argv[1], "r:*").extractall(sys.argv[2], filter="data")' "$1" "$2"
+}
+
+zig_version="$(sed -n 's/.*minimum_zig_version = "\([0-9][0-9.]*\)".*/\1/p' "$project_dir/build.zig.zon")"
+[ -n "$zig_version" ] || die "could not read minimum_zig_version"
+zig_archive="$src_dir/zig-x86_64-linux-$zig_version.tar.xz"
+download "https://ziglang.org/download/$zig_version/zig-x86_64-linux-$zig_version.tar.xz" "$zig_archive"
+zig_dir="$prefix/zig-$zig_version"
+if [ ! -x "$zig_dir/zig" ]; then
+  rm -rf "$zig_dir.tmp"
+  mkdir "$zig_dir.tmp"
+  extract_tar "$zig_archive" "$zig_dir.tmp"
+  mv "$zig_dir.tmp/zig-x86_64-linux-$zig_version" "$zig_dir"
+  rmdir "$zig_dir.tmp"
+fi
+ln -sfn "$zig_dir/zig" "$bin_dir/zig"
+export PATH="$bin_dir:$PATH"
+if [ ! -x "$bin_dir/zig-ar" ]; then
+  printf '#!/usr/bin/env bash\nexec "%s" ar "$@"\n' "$zig_dir/zig" > "$bin_dir/zig-ar"
+  printf '#!/usr/bin/env bash\nexec "%s" ranlib "$@"\n' "$zig_dir/zig" > "$bin_dir/zig-ranlib"
+  chmod +x "$bin_dir/zig-ar" "$bin_dir/zig-ranlib"
 fi
 
-NIX_BIN="$(command -v nix || true)"
-if [ -z "$NIX_BIN" ]; then
-  NIX_BIN=$(find /nix/store -maxdepth 4 -type f -path '*/bin/nix' 2>/dev/null | head -1)
+cmake_version=3.31.8
+cmake_archive="$src_dir/cmake-$cmake_version-linux-x86_64.tar.gz"
+download "https://github.com/Kitware/CMake/releases/download/v$cmake_version/cmake-$cmake_version-linux-x86_64.tar.gz" "$cmake_archive"
+cmake_dir="$prefix/cmake-$cmake_version"
+if [ ! -x "$cmake_dir/bin/cmake" ]; then
+  extract_tar "$cmake_archive" "$prefix"
+  mv "$prefix/cmake-$cmake_version-linux-x86_64" "$cmake_dir"
+fi
+export PATH="$cmake_dir/bin:$PATH"
+
+ninja_version=1.12.1
+ninja_archive="$src_dir/ninja-linux.zip"
+download "https://github.com/ninja-build/ninja/releases/download/v$ninja_version/ninja-linux.zip" "$ninja_archive"
+if [ ! -x "$bin_dir/ninja" ]; then
+  python3 -c 'import zipfile,sys; zipfile.ZipFile(sys.argv[1]).extract("ninja",sys.argv[2])' "$ninja_archive" "$bin_dir"
+  chmod +x "$bin_dir/ninja"
 fi
 
-if [ -z "$NIX_BIN" ]; then
-  log "ERROR: no nix binary found after install attempt"
-else
-  # /nix may already exist root-owned (pre-baked into the base image, or a
-  # prior partial install), which blocks an unprivileged workspace user from
-  # running builds regardless of whether THIS script had to install nix
-  # itself. Always attempt the ownership fix, not just after a fresh install.
-  if [ -d /nix ]; then
-    target_user="${SUDO_USER:-${USER:-$(id -un)}}"
-    current_owner="$(stat -c '%U' /nix/var/nix 2>/dev/null || stat -f '%Su' /nix/var/nix 2>/dev/null || echo unknown)"
-    log "/nix/var/nix currently owned by: $current_owner; target user: $target_user"
-    if [ "$current_owner" = "$target_user" ]; then
-      log "/nix/var/nix already owned by $target_user; no chown needed"
-    elif [ "$(id -u)" -eq 0 ]; then
-      log "running as root; chowning /nix to $target_user"
-      chown -R "$target_user" /nix 2>&1 | tail -5 || true
-    elif sudo -n chown -R "$target_user" /nix 2>&1 | tail -5; then
-      log "sudo chown succeeded"
-    else
-      log "not root and sudo chown failed/unavailable; leaving /nix ownership as-is (build will likely fail with a permission error)"
-    fi
+download_archive_bin() {
+  local name="$1" archive="$2" url="$3"; local target="$bin_dir/$name"
+  if [ ! -x "$target" ]; then
+    download "$url" "$src_dir/$archive"
+    mkdir -p "$src_dir/$name"; extract_tar "$src_dir/$archive" "$src_dir/$name"
+    cp "$src_dir/$name"/*/"$name" "$target" 2>/dev/null || cp "$src_dir/$name/$name" "$target"
+    chmod +x "$target"
   fi
+}
+download_archive_bin just just-1.40.0.tar.gz "https://github.com/casey/just/releases/download/1.40.0/just-1.40.0-x86_64-unknown-linux-musl.tar.gz"
+download_archive_bin shellcheck shellcheck-0.10.0.tar.xz "https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz"
+download_archive_bin ruff ruff-0.12.10.tar.gz "https://github.com/astral-sh/ruff/releases/download/0.12.10/ruff-x86_64-unknown-linux-gnu.tar.gz"
 
-  NIX_CONF_DIR="${HOME:-/root}/.config/nix"
-  mkdir -p "$NIX_CONF_DIR"
-  grep -q '^experimental-features' "$NIX_CONF_DIR/nix.conf" 2>/dev/null \
-    || printf 'experimental-features = nix-command flakes\n' >> "$NIX_CONF_DIR/nix.conf"
-
-  log "verifying dev shell entry"
-  if [ -f "${FLEET_WORKSPACE_PROJECT_DIR:-.}/flake.nix" ]; then
-    ( cd "${FLEET_WORKSPACE_PROJECT_DIR:-.}" && "$NIX_BIN" develop --command zig version ) \
-      && log "dev shell OK" || log "dev shell entry failed (see above)"
+sdl_version="$(sed -n 's/.*version = "\([0-9][0-9.]*\)".*/\1/p' "$project_dir/overlays/sdl3-3-4-10.nix" | head -1)"
+[ -n "$sdl_version" ] || sdl_version=3.4.10
+build_sdl() {
+  local name="$1" url="$2" source="$src_dir/$1" build="$src_dir/$1-build"
+  shift 2
+  if [ ! -f "$sdl_prefix/.${name}.installed" ]; then
+    download "$url" "$src_dir/$name.tar.gz"
+    rm -rf "$source" "$build" "$source.tmp"; mkdir -p "$source.tmp" "$build"
+    extract_tar "$src_dir/$name.tar.gz" "$source.tmp"
+    mkdir "$source"; cp -a "$source.tmp"/*/. "$source"/
+    ( cd "$build"; CC="$zig_dir/zig cc" CXX="$zig_dir/zig c++" cmake -G Ninja "$source" -DCMAKE_AR="$bin_dir/zig-ar" -DCMAKE_RANLIB="$bin_dir/zig-ranlib" "$@"; cmake --build .; cmake --install . )
+    touch "$sdl_prefix/.${name}.installed"
   fi
-fi
+}
+build_sdl SDL "https://github.com/libsdl-org/SDL/archive/refs/tags/release-$sdl_version.tar.gz" \
+  -DCMAKE_INSTALL_PREFIX="$sdl_prefix" -DSDL_SHARED=ON -DSDL_STATIC=OFF -DSDL_TESTS=OFF \
+  -DSDL_X11=OFF -DSDL_WAYLAND=OFF -DSDL_ALSA=OFF -DSDL_PULSEAUDIO=OFF -DSDL_PIPEWIRE=OFF \
+  -DSDL_JACK=OFF -DSDL_SNDIO=OFF -DSDL_KMSDRM=OFF -DSDL_OPENGL=OFF -DSDL_OPENGLES=OFF \
+  -DSDL_VULKAN=OFF -DSDL_CAMERA=OFF -DSDL_HIDAPI=OFF -DSDL_VIDEO_DRIVER_DUMMY=ON \
+  -DSDL_UNIX_CONSOLE_BUILD=ON -DSDL_INSTALL=ON
+build_sdl SDL_ttf "https://github.com/libsdl-org/SDL_ttf/archive/refs/tags/release-3.2.2.tar.gz" \
+  -DCMAKE_INSTALL_PREFIX="$sdl_prefix" -DSDLTTF_VENDORED=ON -DSDLTTF_SAMPLES=OFF -DSDLTTF_TESTS=OFF
 
-# Best-effort: raise this repo's Codex sessions to the highest reasoning
-# effort. Only takes effect if config.toml is written before the Codex CLI
-# process starts, and only if no config.toml already exists (never clobber
-# an existing one, e.g. auth-related content).
-if [ -n "${CODEX_HOME:-}" ]; then
-  mkdir -p "$CODEX_HOME"
-  if [ ! -f "$CODEX_HOME/config.toml" ]; then
-    printf 'model_reasoning_effort = "xhigh"\n' > "$CODEX_HOME/config.toml"
-    log "wrote $CODEX_HOME/config.toml with model_reasoning_effort = xhigh"
-  elif ! grep -q 'model_reasoning_effort' "$CODEX_HOME/config.toml"; then
-    printf 'model_reasoning_effort = "xhigh"\n' >> "$CODEX_HOME/config.toml"
-    log "appended model_reasoning_effort = xhigh to existing $CODEX_HOME/config.toml"
-  else
-    log "$CODEX_HOME/config.toml already sets model_reasoning_effort; leaving it alone"
-  fi
-fi
+export SDL3_INCLUDE_PATH="$sdl_prefix/include/SDL3"
+export SDL3_TTF_INCLUDE_PATH="$sdl_prefix/include/SDL3"
+profile_line='# Architect AIR Cloud toolchain\nexport PATH="$HOME/.local/bin:$HOME/.local/cmake-3.31.8/bin:$PATH"\nexport SDL3_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include/SDL3"\nexport SDL3_TTF_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include/SDL3"'
+grep -q 'SDL3_INCLUDE_PATH=' "$profile" 2>/dev/null || printf '%b\n' "$profile_line" >> "$profile"
 
-log "startup script finished"
+log "ready: zig $(zig version), cmake $(cmake --version | head -1)"

--- a/.air/cloud/startup.sh
+++ b/.air/cloud/startup.sh
@@ -3,6 +3,12 @@
 # Zig supplies the C compiler used for the two SDL builds; all other tools are
 # portable user-space archives. SDL 3.4.10 is parsed from the project's overlay
 # so this remains aligned with the normal development environment.
+#
+# This provisions disposable, non-production CI sandboxes rather than release
+# artifacts. Downloads use pinned HTTPS release URLs but intentionally do not
+# carry SHA256 values: maintaining checksums for every platform archive and the
+# mutable third-party submodules fetched by SDL_ttf's upstream download script
+# would add substantial churn. Do not reuse this bootstrap for a release build.
 set -euo pipefail
 
 log() { printf '[air-startup] %s\n' "$*"; }
@@ -19,10 +25,12 @@ profile="$home_dir/.profile"
 mkdir -p "$bin_dir" "$src_dir" "$sdl_prefix"
 
 download() {
-  local url="$1" dest="$2"
+  local url="$1" dest="$2" temp="$2.tmp"
   if [ ! -s "$dest" ]; then
     log "downloading $(basename "$dest")"
-    curl --fail --location --retry 3 --silent --show-error -o "$dest" "$url"
+    rm -f "$temp"
+    curl --fail --location --retry 3 --silent --show-error -o "$temp" "$url"
+    mv "$temp" "$dest"
   fi
 }
 extract_tar() {
@@ -37,8 +45,8 @@ zig_download_started="$(seconds_now)"
 download "https://ziglang.org/download/$zig_version/zig-x86_64-linux-$zig_version.tar.xz" "$zig_archive"
 log "Zig download completed in $(( $(seconds_now) - zig_download_started ))s"
 zig_dir="$prefix/zig-$zig_version"
-if [ ! -x "$zig_dir/zig" ]; then
-  rm -rf "$zig_dir.tmp"
+if [ ! -x "$zig_dir/zig" ] || [ "$("$zig_dir/zig" version 2>/dev/null || true)" != "$zig_version" ]; then
+  rm -rf "$zig_dir" "$zig_dir.tmp"
   mkdir "$zig_dir.tmp"
   extract_tar "$zig_archive" "$zig_dir.tmp"
   mv "$zig_dir.tmp/zig-x86_64-linux-$zig_version" "$zig_dir"
@@ -46,17 +54,16 @@ if [ ! -x "$zig_dir/zig" ]; then
 fi
 ln -sfn "$zig_dir/zig" "$bin_dir/zig"
 export PATH="$bin_dir:$PATH"
-if [ ! -x "$bin_dir/zig-ar" ]; then
-  printf '#!/usr/bin/env bash\nexec "%s" ar "$@"\n' "$zig_dir/zig" > "$bin_dir/zig-ar"
-  printf '#!/usr/bin/env bash\nexec "%s" ranlib "$@"\n' "$zig_dir/zig" > "$bin_dir/zig-ranlib"
-  chmod +x "$bin_dir/zig-ar" "$bin_dir/zig-ranlib"
-fi
+printf '#!/usr/bin/env bash\nexec "%s" ar "$@"\n' "$zig_dir/zig" > "$bin_dir/zig-ar"
+printf '#!/usr/bin/env bash\nexec "%s" ranlib "$@"\n' "$zig_dir/zig" > "$bin_dir/zig-ranlib"
+chmod +x "$bin_dir/zig-ar" "$bin_dir/zig-ranlib"
 
 cmake_version=3.31.8
 cmake_archive="$src_dir/cmake-$cmake_version-linux-x86_64.tar.gz"
 download "https://github.com/Kitware/CMake/releases/download/v$cmake_version/cmake-$cmake_version-linux-x86_64.tar.gz" "$cmake_archive"
 cmake_dir="$prefix/cmake-$cmake_version"
-if [ ! -x "$cmake_dir/bin/cmake" ]; then
+if [ ! -x "$cmake_dir/bin/cmake" ] || [ "$("$cmake_dir/bin/cmake" --version 2>/dev/null | sed -n '1s/^cmake version //p')" != "$cmake_version" ]; then
+  rm -rf "$cmake_dir"
   extract_tar "$cmake_archive" "$prefix"
   mv "$prefix/cmake-$cmake_version-linux-x86_64" "$cmake_dir"
 fi
@@ -65,31 +72,45 @@ export PATH="$cmake_dir/bin:$PATH"
 ninja_version=1.12.1
 ninja_archive="$src_dir/ninja-linux.zip"
 download "https://github.com/ninja-build/ninja/releases/download/v$ninja_version/ninja-linux.zip" "$ninja_archive"
-if [ ! -x "$bin_dir/ninja" ]; then
+if [ ! -x "$bin_dir/ninja" ] || [ "$("$bin_dir/ninja" --version 2>/dev/null || true)" != "$ninja_version" ]; then
   python3 -c 'import zipfile,sys; zipfile.ZipFile(sys.argv[1]).extract("ninja",sys.argv[2])' "$ninja_archive" "$bin_dir"
   chmod +x "$bin_dir/ninja"
 fi
 
 download_archive_bin() {
   local name="$1" archive="$2" url="$3"; local target="$bin_dir/$name"
-  if [ ! -x "$target" ]; then
+  local expected_version="$4"
+  if ! tool_version_matches "$name" "$target" "$expected_version"; then
     download "$url" "$src_dir/$archive"
     mkdir -p "$src_dir/$name"; extract_tar "$src_dir/$archive" "$src_dir/$name"
     cp "$src_dir/$name"/*/"$name" "$target" 2>/dev/null || cp "$src_dir/$name/$name" "$target"
     chmod +x "$target"
   fi
 }
-download_archive_bin just just-1.40.0.tar.gz "https://github.com/casey/just/releases/download/1.40.0/just-1.40.0-x86_64-unknown-linux-musl.tar.gz"
-download_archive_bin shellcheck shellcheck-0.10.0.tar.xz "https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz"
-download_archive_bin ruff ruff-0.12.10.tar.gz "https://github.com/astral-sh/ruff/releases/download/0.12.10/ruff-x86_64-unknown-linux-gnu.tar.gz"
+tool_version_matches() {
+  local name="$1" target="$2" expected_version="$3" actual_version
+  [ -x "$target" ] || return 1
+  case "$name" in
+    just|ruff) actual_version="$("$target" --version 2>/dev/null | awk '{print $2}')" ;;
+    shellcheck) actual_version="$("$target" --version 2>/dev/null | sed -n 's/^version: //p')" ;;
+    *) die "no version check defined for $name" ;;
+  esac
+  [ "$actual_version" = "$expected_version" ]
+}
+download_archive_bin just just-1.40.0.tar.gz "https://github.com/casey/just/releases/download/1.40.0/just-1.40.0-x86_64-unknown-linux-musl.tar.gz" 1.40.0
+download_archive_bin shellcheck shellcheck-0.10.0.tar.xz "https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz" 0.10.0
+download_archive_bin ruff ruff-0.12.10.tar.gz "https://github.com/astral-sh/ruff/releases/download/0.12.10/ruff-x86_64-unknown-linux-gnu.tar.gz" 0.12.10
 
 sdl_version="$(sed -n 's/.*version = "\([0-9][0-9.]*\)".*/\1/p' "$project_dir/overlays/sdl3-3-4-10.nix" | head -1)"
-[ -n "$sdl_version" ] || sdl_version=3.4.10
+[ -n "$sdl_version" ] || die "could not read SDL3 version from overlay"
+sdl_ttf_version=3.2.2
 build_sdl() {
-  local name="$1" url="$2" source="$src_dir/$1" build="$src_dir/$1-build"
-  shift 2
-  if [ ! -f "$sdl_prefix/.${name}.installed" ]; then
-    local build_started="$(seconds_now)"
+  local name="$1" version="$2" url="$3" source="$src_dir/$1" build="$src_dir/$1-build"
+  local marker="$sdl_prefix/.${name}.installed"
+  local build_started
+  shift 3
+  if [ "$(cat "$marker" 2>/dev/null || true)" != "$version" ]; then
+    build_started="$(seconds_now)"
     download "$url" "$src_dir/$name.tar.gz"
     rm -rf "$source" "$build" "$source.tmp"; mkdir -p "$source.tmp" "$build"
     extract_tar "$src_dir/$name.tar.gz" "$source.tmp"
@@ -102,27 +123,29 @@ build_sdl() {
       cmake_prefix_args=(-DCMAKE_PREFIX_PATH="$sdl_prefix")
     fi
     ( cd "$build"; CC="$zig_dir/zig cc" CXX="$zig_dir/zig c++" cmake -G Ninja "$source" -DCMAKE_AR="$bin_dir/zig-ar" -DCMAKE_RANLIB="$bin_dir/zig-ranlib" "${cmake_prefix_args[@]}" "$@"; cmake --build .; cmake --install . )
-    touch "$sdl_prefix/.${name}.installed"
+    printf '%s\n' "$version" > "$marker"
     log "$name build and install completed in $(( $(seconds_now) - build_started ))s"
   fi
 }
-build_sdl SDL "https://github.com/libsdl-org/SDL/archive/refs/tags/release-$sdl_version.tar.gz" \
+build_sdl SDL "$sdl_version" "https://github.com/libsdl-org/SDL/archive/refs/tags/release-$sdl_version.tar.gz" \
   -DCMAKE_INSTALL_PREFIX="$sdl_prefix" -DSDL_SHARED=ON -DSDL_STATIC=OFF -DSDL_TESTS=OFF \
   -DSDL_X11=OFF -DSDL_WAYLAND=OFF -DSDL_ALSA=OFF -DSDL_PULSEAUDIO=OFF -DSDL_PIPEWIRE=OFF \
   -DSDL_JACK=OFF -DSDL_SNDIO=OFF -DSDL_KMSDRM=OFF -DSDL_OPENGL=OFF -DSDL_OPENGLES=OFF \
   -DSDL_VULKAN=OFF -DSDL_CAMERA=OFF -DSDL_HIDAPI=OFF -DSDL_VIDEO_DRIVER_DUMMY=ON \
   -DSDL_UNIX_CONSOLE_BUILD=ON -DSDL_INSTALL=ON
-build_sdl SDL_ttf "https://github.com/libsdl-org/SDL_ttf/archive/refs/tags/release-3.2.2.tar.gz" \
+build_sdl SDL_ttf "$sdl_ttf_version" "https://github.com/libsdl-org/SDL_ttf/archive/refs/tags/release-$sdl_ttf_version.tar.gz" \
   -DCMAKE_INSTALL_PREFIX="$sdl_prefix" -DSDLTTF_VENDORED=ON -DSDLTTF_SAMPLES=OFF -DSDLTTF_TESTS=OFF
 
 export SDL3_INCLUDE_PATH="$sdl_prefix/include"
 export SDL3_TTF_INCLUDE_PATH="$sdl_prefix/include"
 # Zig 0.15's HTTP client cannot reliably use AIR Cloud's injected proxy, while
 # direct HTTPS works. Clear it after all curl/git provisioning has finished.
-unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy
+unset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy
 touch "$profile"
 sed -i '/^# Architect AIR Cloud toolchain$/,/^unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy$/d' "$profile"
-profile_line='# Architect AIR Cloud toolchain\nexport PATH="$HOME/.local/bin:$HOME/.local/cmake-3.31.8/bin:$PATH"\nexport SDL3_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include"\nexport SDL3_TTF_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include"\ncase ":${LD_LIBRARY_PATH:-}:" in *":$HOME/.local/sdl3-prefix/lib:"*) ;; *) export LD_LIBRARY_PATH="$HOME/.local/sdl3-prefix/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ;; esac\nunset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy'
+sed -i '/^# Architect AIR Cloud toolchain$/,/^unset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy$/d' "$profile"
+# shellcheck disable=SC2016 # This is deliberately expanded when the profile is sourced.
+profile_line='# Architect AIR Cloud toolchain\nexport PATH="$HOME/.local/bin:$HOME/.local/cmake-3.31.8/bin:$PATH"\nexport SDL3_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include"\nexport SDL3_TTF_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include"\ncase ":${LD_LIBRARY_PATH:-}:" in *":$HOME/.local/sdl3-prefix/lib:"*) ;; *) export LD_LIBRARY_PATH="$HOME/.local/sdl3-prefix/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ;; esac\nunset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy'
 printf '%b\n' "$profile_line" >> "$profile"
 case ":${LD_LIBRARY_PATH:-}:" in *":$sdl_prefix/lib:"*) ;; *) export LD_LIBRARY_PATH="$sdl_prefix/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ;; esac
 

--- a/.air/cloud/startup.sh
+++ b/.air/cloud/startup.sh
@@ -120,6 +120,7 @@ export SDL3_TTF_INCLUDE_PATH="$sdl_prefix/include"
 # Zig 0.15's HTTP client cannot reliably use AIR Cloud's injected proxy, while
 # direct HTTPS works. Clear it after all curl/git provisioning has finished.
 unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy
+touch "$profile"
 sed -i '/^# Architect AIR Cloud toolchain$/,/^unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy$/d' "$profile"
 profile_line='# Architect AIR Cloud toolchain\nexport PATH="$HOME/.local/bin:$HOME/.local/cmake-3.31.8/bin:$PATH"\nexport SDL3_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include"\nexport SDL3_TTF_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include"\ncase ":${LD_LIBRARY_PATH:-}:" in *":$HOME/.local/sdl3-prefix/lib:"*) ;; *) export LD_LIBRARY_PATH="$HOME/.local/sdl3-prefix/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ;; esac\nunset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy'
 printf '%b\n' "$profile_line" >> "$profile"

--- a/.air/cloud/startup.sh
+++ b/.air/cloud/startup.sh
@@ -7,8 +7,12 @@ set -uo pipefail
 
 log() { printf '[air-startup] %s\n' "$*"; }
 
+log "id: $(id)"
+log "sudo -l (permitted commands, if any):"
+sudo -n -l 2>&1 | tail -20 || true
+
 if command -v nix >/dev/null 2>&1 && nix --version >/dev/null 2>&1; then
-  log "nix already present: $(nix --version)"
+  log "nix already present on PATH: $(nix --version)"
 else
   log "installing Nix (Determinate installer, no-daemon single-user mode)"
   if curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
@@ -27,17 +31,23 @@ fi
 if [ -z "$NIX_BIN" ]; then
   log "ERROR: no nix binary found after install attempt"
 else
-  # The no-daemon installer leaves /nix/var/nix owned by root, which blocks
-  # an unprivileged workspace user from running builds. Fix ownership when
-  # this script has the privilege to do so (root, or passwordless sudo).
+  # /nix may already exist root-owned (pre-baked into the base image, or a
+  # prior partial install), which blocks an unprivileged workspace user from
+  # running builds regardless of whether THIS script had to install nix
+  # itself. Always attempt the ownership fix, not just after a fresh install.
   if [ -d /nix ]; then
     target_user="${SUDO_USER:-${USER:-$(id -un)}}"
-    if [ "$(id -u)" -eq 0 ]; then
+    current_owner="$(stat -c '%U' /nix/var/nix 2>/dev/null || stat -f '%Su' /nix/var/nix 2>/dev/null || echo unknown)"
+    log "/nix/var/nix currently owned by: $current_owner; target user: $target_user"
+    if [ "$current_owner" = "$target_user" ]; then
+      log "/nix/var/nix already owned by $target_user; no chown needed"
+    elif [ "$(id -u)" -eq 0 ]; then
+      log "running as root; chowning /nix to $target_user"
       chown -R "$target_user" /nix 2>&1 | tail -5 || true
-    elif sudo -n true 2>/dev/null; then
-      sudo -n chown -R "$target_user" /nix 2>&1 | tail -5 || true
+    elif sudo -n chown -R "$target_user" /nix 2>&1 | tail -5; then
+      log "sudo chown succeeded"
     else
-      log "not root and no passwordless sudo; leaving /nix ownership as-is"
+      log "not root and sudo chown failed/unavailable; leaving /nix ownership as-is (build will likely fail with a permission error)"
     fi
   fi
 

--- a/.air/cloud/startup.sh
+++ b/.air/cloud/startup.sh
@@ -90,7 +90,14 @@ build_sdl() {
     rm -rf "$source" "$build" "$source.tmp"; mkdir -p "$source.tmp" "$build"
     extract_tar "$src_dir/$name.tar.gz" "$source.tmp"
     mkdir "$source"; cp -a "$source.tmp"/*/. "$source"/
-    ( cd "$build"; CC="$zig_dir/zig cc" CXX="$zig_dir/zig c++" cmake -G Ninja "$source" -DCMAKE_AR="$bin_dir/zig-ar" -DCMAKE_RANLIB="$bin_dir/zig-ranlib" "$@"; cmake --build .; cmake --install . )
+    if [ "$name" = SDL_ttf ]; then
+      ( cd "$source/external" && ./download.sh )
+    fi
+    local cmake_prefix_args=()
+    if [ "$name" = SDL_ttf ]; then
+      cmake_prefix_args=(-DCMAKE_PREFIX_PATH="$sdl_prefix")
+    fi
+    ( cd "$build"; CC="$zig_dir/zig cc" CXX="$zig_dir/zig c++" cmake -G Ninja "$source" -DCMAKE_AR="$bin_dir/zig-ar" -DCMAKE_RANLIB="$bin_dir/zig-ranlib" "${cmake_prefix_args[@]}" "$@"; cmake --build .; cmake --install . )
     touch "$sdl_prefix/.${name}.installed"
   fi
 }
@@ -103,9 +110,14 @@ build_sdl SDL "https://github.com/libsdl-org/SDL/archive/refs/tags/release-$sdl_
 build_sdl SDL_ttf "https://github.com/libsdl-org/SDL_ttf/archive/refs/tags/release-3.2.2.tar.gz" \
   -DCMAKE_INSTALL_PREFIX="$sdl_prefix" -DSDLTTF_VENDORED=ON -DSDLTTF_SAMPLES=OFF -DSDLTTF_TESTS=OFF
 
-export SDL3_INCLUDE_PATH="$sdl_prefix/include/SDL3"
-export SDL3_TTF_INCLUDE_PATH="$sdl_prefix/include/SDL3"
-profile_line='# Architect AIR Cloud toolchain\nexport PATH="$HOME/.local/bin:$HOME/.local/cmake-3.31.8/bin:$PATH"\nexport SDL3_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include/SDL3"\nexport SDL3_TTF_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include/SDL3"'
-grep -q 'SDL3_INCLUDE_PATH=' "$profile" 2>/dev/null || printf '%b\n' "$profile_line" >> "$profile"
+export SDL3_INCLUDE_PATH="$sdl_prefix/include"
+export SDL3_TTF_INCLUDE_PATH="$sdl_prefix/include"
+# Zig 0.15's HTTP client cannot reliably use AIR Cloud's injected proxy, while
+# direct HTTPS works. Clear it after all curl/git provisioning has finished.
+unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy
+sed -i '/^# Architect AIR Cloud toolchain$/,/^unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy$/d' "$profile"
+profile_line='# Architect AIR Cloud toolchain\nexport PATH="$HOME/.local/bin:$HOME/.local/cmake-3.31.8/bin:$PATH"\nexport SDL3_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include"\nexport SDL3_TTF_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include"\ncase ":${LD_LIBRARY_PATH:-}:" in *":$HOME/.local/sdl3-prefix/lib:"*) ;; *) export LD_LIBRARY_PATH="$HOME/.local/sdl3-prefix/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ;; esac\nunset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy'
+printf '%b\n' "$profile_line" >> "$profile"
+case ":${LD_LIBRARY_PATH:-}:" in *":$sdl_prefix/lib:"*) ;; *) export LD_LIBRARY_PATH="$sdl_prefix/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ;; esac
 
 log "ready: zig $(zig version), cmake $(cmake --version | head -1)"

--- a/.air/cloud/startup.sh
+++ b/.air/cloud/startup.sh
@@ -70,7 +70,7 @@ fi
 export PATH="$cmake_dir/bin:$PATH"
 
 ninja_version=1.12.1
-ninja_archive="$src_dir/ninja-linux.zip"
+ninja_archive="$src_dir/ninja-$ninja_version-linux.zip"
 download "https://github.com/ninja-build/ninja/releases/download/v$ninja_version/ninja-linux.zip" "$ninja_archive"
 if [ ! -x "$bin_dir/ninja" ] || [ "$("$bin_dir/ninja" --version 2>/dev/null || true)" != "$ninja_version" ]; then
   python3 -c 'import zipfile,sys; zipfile.ZipFile(sys.argv[1]).extract("ninja",sys.argv[2])' "$ninja_archive" "$bin_dir"
@@ -107,13 +107,14 @@ sdl_ttf_version=3.2.2
 build_sdl() {
   local name="$1" version="$2" url="$3" source="$src_dir/$1" build="$src_dir/$1-build"
   local marker="$sdl_prefix/.${name}.installed"
+  local archive="$src_dir/$name-$version.tar.gz"
   local build_started
   shift 3
   if [ "$(cat "$marker" 2>/dev/null || true)" != "$version" ]; then
     build_started="$(seconds_now)"
-    download "$url" "$src_dir/$name.tar.gz"
+    download "$url" "$archive"
     rm -rf "$source" "$build" "$source.tmp"; mkdir -p "$source.tmp" "$build"
-    extract_tar "$src_dir/$name.tar.gz" "$source.tmp"
+    extract_tar "$archive" "$source.tmp"
     mkdir "$source"; cp -a "$source.tmp"/*/. "$source"/
     if [ "$name" = SDL_ttf ]; then
       ( cd "$source/external" && ./download.sh )
@@ -142,10 +143,9 @@ export SDL3_TTF_INCLUDE_PATH="$sdl_prefix/include"
 # direct HTTPS works. Clear it after all curl/git provisioning has finished.
 unset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy
 touch "$profile"
-sed -i '/^# Architect AIR Cloud toolchain$/,/^unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy$/d' "$profile"
-sed -i '/^# Architect AIR Cloud toolchain$/,/^unset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy$/d' "$profile"
+sed -i '/^# >>> Architect AIR Cloud toolchain >>>$/,/^# <<< Architect AIR Cloud toolchain <<</d' "$profile"
 # shellcheck disable=SC2016 # This is deliberately expanded when the profile is sourced.
-profile_line='# Architect AIR Cloud toolchain\nexport PATH="$HOME/.local/bin:$HOME/.local/cmake-3.31.8/bin:$PATH"\nexport SDL3_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include"\nexport SDL3_TTF_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include"\ncase ":${LD_LIBRARY_PATH:-}:" in *":$HOME/.local/sdl3-prefix/lib:"*) ;; *) export LD_LIBRARY_PATH="$HOME/.local/sdl3-prefix/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ;; esac\nunset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy'
+profile_line='# >>> Architect AIR Cloud toolchain >>>\nexport PATH="$HOME/.local/bin:$HOME/.local/cmake-3.31.8/bin:$PATH"\nexport SDL3_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include"\nexport SDL3_TTF_INCLUDE_PATH="$HOME/.local/sdl3-prefix/include"\ncase ":${LD_LIBRARY_PATH:-}:" in *":$HOME/.local/sdl3-prefix/lib:"*) ;; *) export LD_LIBRARY_PATH="$HOME/.local/sdl3-prefix/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ;; esac\nunset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy\n# <<< Architect AIR Cloud toolchain <<<'
 printf '%b\n' "$profile_line" >> "$profile"
 case ":${LD_LIBRARY_PATH:-}:" in *":$sdl_prefix/lib:"*) ;; *) export LD_LIBRARY_PATH="$sdl_prefix/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ;; esac
 

--- a/.air/cloud/startup.sh
+++ b/.air/cloud/startup.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 log() { printf '[air-startup] %s\n' "$*"; }
 die() { printf '[air-startup] ERROR: %s\n' "$*" >&2; exit 1; }
+seconds_now() { date +%s; }
 
 project_dir="${FLEET_WORKSPACE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 home_dir="${HOME:?HOME is required}"
@@ -32,7 +33,9 @@ extract_tar() {
 zig_version="$(sed -n 's/.*minimum_zig_version = "\([0-9][0-9.]*\)".*/\1/p' "$project_dir/build.zig.zon")"
 [ -n "$zig_version" ] || die "could not read minimum_zig_version"
 zig_archive="$src_dir/zig-x86_64-linux-$zig_version.tar.xz"
+zig_download_started="$(seconds_now)"
 download "https://ziglang.org/download/$zig_version/zig-x86_64-linux-$zig_version.tar.xz" "$zig_archive"
+log "Zig download completed in $(( $(seconds_now) - zig_download_started ))s"
 zig_dir="$prefix/zig-$zig_version"
 if [ ! -x "$zig_dir/zig" ]; then
   rm -rf "$zig_dir.tmp"
@@ -86,6 +89,7 @@ build_sdl() {
   local name="$1" url="$2" source="$src_dir/$1" build="$src_dir/$1-build"
   shift 2
   if [ ! -f "$sdl_prefix/.${name}.installed" ]; then
+    local build_started="$(seconds_now)"
     download "$url" "$src_dir/$name.tar.gz"
     rm -rf "$source" "$build" "$source.tmp"; mkdir -p "$source.tmp" "$build"
     extract_tar "$src_dir/$name.tar.gz" "$source.tmp"
@@ -99,6 +103,7 @@ build_sdl() {
     fi
     ( cd "$build"; CC="$zig_dir/zig cc" CXX="$zig_dir/zig c++" cmake -G Ninja "$source" -DCMAKE_AR="$bin_dir/zig-ar" -DCMAKE_RANLIB="$bin_dir/zig-ranlib" "${cmake_prefix_args[@]}" "$@"; cmake --build .; cmake --install . )
     touch "$sdl_prefix/.${name}.installed"
+    log "$name build and install completed in $(( $(seconds_now) - build_started ))s"
   fi
 }
 build_sdl SDL "https://github.com/libsdl-org/SDL/archive/refs/tags/release-$sdl_version.tar.gz" \

--- a/.air/cloud/startup.sh
+++ b/.air/cloud/startup.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# AIR Cloud workspace provisioning script (see FLEET_WORKSPACE_SETUP_SCRIPT).
+# Runs once per fresh sandbox, before the coding agent session starts.
+# Prepares Nix (with flakes) so `nix develop` / `just build|test|lint` work
+# for Architect without every task re-installing the toolchain from scratch.
+set -uo pipefail
+
+log() { printf '[air-startup] %s\n' "$*"; }
+
+if command -v nix >/dev/null 2>&1 && nix --version >/dev/null 2>&1; then
+  log "nix already present: $(nix --version)"
+else
+  log "installing Nix (Determinate installer, no-daemon single-user mode)"
+  if curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
+      | sh -s -- install linux --init none --no-confirm; then
+    log "nix-installer completed"
+  else
+    log "nix-installer exited non-zero; continuing to check whether nix is usable anyway"
+  fi
+fi
+
+NIX_BIN="$(command -v nix || true)"
+if [ -z "$NIX_BIN" ]; then
+  NIX_BIN=$(find /nix/store -maxdepth 4 -type f -path '*/bin/nix' 2>/dev/null | head -1)
+fi
+
+if [ -z "$NIX_BIN" ]; then
+  log "ERROR: no nix binary found after install attempt"
+else
+  # The no-daemon installer leaves /nix/var/nix owned by root, which blocks
+  # an unprivileged workspace user from running builds. Fix ownership when
+  # this script has the privilege to do so (root, or passwordless sudo).
+  if [ -d /nix ]; then
+    target_user="${SUDO_USER:-${USER:-$(id -un)}}"
+    if [ "$(id -u)" -eq 0 ]; then
+      chown -R "$target_user" /nix 2>&1 | tail -5 || true
+    elif sudo -n true 2>/dev/null; then
+      sudo -n chown -R "$target_user" /nix 2>&1 | tail -5 || true
+    else
+      log "not root and no passwordless sudo; leaving /nix ownership as-is"
+    fi
+  fi
+
+  NIX_CONF_DIR="${HOME:-/root}/.config/nix"
+  mkdir -p "$NIX_CONF_DIR"
+  grep -q '^experimental-features' "$NIX_CONF_DIR/nix.conf" 2>/dev/null \
+    || printf 'experimental-features = nix-command flakes\n' >> "$NIX_CONF_DIR/nix.conf"
+
+  log "verifying dev shell entry"
+  if [ -f "${FLEET_WORKSPACE_PROJECT_DIR:-.}/flake.nix" ]; then
+    ( cd "${FLEET_WORKSPACE_PROJECT_DIR:-.}" && "$NIX_BIN" develop --command zig version ) \
+      && log "dev shell OK" || log "dev shell entry failed (see above)"
+  fi
+fi
+
+# Best-effort: raise this repo's Codex sessions to the highest reasoning
+# effort. Only takes effect if config.toml is written before the Codex CLI
+# process starts, and only if no config.toml already exists (never clobber
+# an existing one, e.g. auth-related content).
+if [ -n "${CODEX_HOME:-}" ]; then
+  mkdir -p "$CODEX_HOME"
+  if [ ! -f "$CODEX_HOME/config.toml" ]; then
+    printf 'model_reasoning_effort = "xhigh"\n' > "$CODEX_HOME/config.toml"
+    log "wrote $CODEX_HOME/config.toml with model_reasoning_effort = xhigh"
+  elif ! grep -q 'model_reasoning_effort' "$CODEX_HOME/config.toml"; then
+    printf 'model_reasoning_effort = "xhigh"\n' >> "$CODEX_HOME/config.toml"
+    log "appended model_reasoning_effort = xhigh to existing $CODEX_HOME/config.toml"
+  else
+    log "$CODEX_HOME/config.toml already sets model_reasoning_effort; leaving it alone"
+  fi
+fi
+
+log "startup script finished"

--- a/justfile
+++ b/justfile
@@ -31,6 +31,9 @@ lint:
     while IFS= read -r -d '' file; do
         sh_files+=("$file")
     done < <(find scripts -type f -name '*.sh' -print0)
+    while IFS= read -r -d '' file; do
+        sh_files+=("$file")
+    done < <(find .air/cloud -type f -name '*.sh' -print0)
     if [ -f scripts/verify-setup.sh ]; then
         sh_files+=("scripts/verify-setup.sh")
     fi


### PR DESCRIPTION
## Summary
- replace the root-dependent Nix setup with a user-space bootstrap under `$HOME/.local`
- dynamically read the project Zig pin and SDL3 overlay version; install portable Zig, CMake, Ninja, just, ShellCheck, and Ruff
- build headless SDL3 and SDL_ttf from source with Zig's bundled C/C++ toolchain and vendored SDL_ttf dependencies
- persist PATH, SDL include paths, runtime library path, and the direct-network workaround in the login profile

Nix was abandoned because AIR Cloud sandboxes run as an unprivileged user and the existing `/nix` is root-owned; neither installation nor ownership repair is possible without sudo.

## Validation
- `zig build --summary all`: 20/20 steps succeeded
- `zig build test --summary all`: 20/20 steps succeeded; 373/374 tests passed; 1 skipped
- `just lint`: All checks passed; test registry passed; zwanzig found no issues

## Cold sandbox timing observed
- Zig download: 1s
- SDL3 build/install: 104s
- SDL3_ttf build/install: 87s

`zig build run` was intentionally not attempted because AIR Cloud is headless.