### PR TITLE
docs: record Zig 0.16.0 breakage inventory

### DIFF
--- a/docs/superpowers/plans/2026-08-28-zig-0-16-inventory.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-inventory.md
@@ -1,0 +1,167 @@
+# Zig 0.16.0 Migration Inventory
+
+Recorded 2026-08-28 from the `spike/zig-0-16-inventory` branch.
+
+## Environment
+
+- Host: Linux AIR Cloud sandbox, x86_64, kernel 6.17.0-1017-aws
+- Workspace: `/workspaces/architect`
+- Current toolchain: `zig version` -> `0.15.2`
+- Probe toolchain: `/tmp/zig016/zig version` -> `0.16.0`
+- SDL headers: `$SDL3_INCLUDE_PATH` and `$SDL3_TTF_INCLUDE_PATH`, both supplied by the AIR Cloud startup environment
+- `just`, ShellCheck, and Ruff were present. `pkg-config` was not installed, so SDL versions were not queried through pkg-config.
+- The 0.16 probe used isolated caches: `.tmp/zig-cache-016` and `.tmp/zig-cache-016/local`.
+- The plan's Nix-only `devShells.zig016` and `nix develop` steps were not run; this sandbox has no Nix.
+
+## Dependency hashes
+
+These hashes were printed by Zig 0.16.0's `zig fetch` for the exact URLs in the migration plan:
+
+| Dependency | URL | Verified hash |
+| --- | --- | --- |
+| ghostty | `https://github.com/ghostty-org/ghostty/archive/76e568b475fe88f5506be33ad1a684f3c1eae85e.tar.gz` | `ghostty-1.3.2-dev-5UdBCzxaYAWrMeK4x7Kpz8hshXz6zm_SB1KdCFoLB6Lf` |
+| libxev | `https://deps.files.ghostty.org/libxev-9ce8e8e6ff89e583258a7f8e7adeeeaeae8611bf.tar.gz` | `libxev-0.0.0-86vtcwIRFADbH4hk-EjROXxlrKIRPQdA41XiTSytYO-F` |
+| toml | `https://github.com/sam701/zig-toml/archive/8685923e32e8b8a795eb2715684236975a70faed.tar.gz` | `toml-0.3.0-bV14BRmKAQAWR0FT0KUKFwVJTImaFhWjSe6HfSMtNZOH` |
+| zwanzig | `https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.15.1.tar.gz` | `zwanzig-0.15.1-oiXZliOBGQA1fkoEDA6UxFdOv1ezRF5Jc9YY7uZnHjKe` |
+
+## Risk verdicts
+
+### Risk 1 — SDL3/SDL3_ttf `@cImport`: PASS
+
+The standalone Zig 0.16.0 probe included `SDL3/SDL.h` and `SDL3_ttf/SDL_ttf.h`, touched representative constants/types/function pointers, linked both SDL libraries, and ran successfully. The compiler emitted no diagnostics. The executable printed:
+
+```text
+32 128 13 133482551094496
+```
+
+The first invocation without an explicit library search path failed only because this sandbox does not add its SDL prefix to Zig's default linker paths:
+
+```text
+error: unable to find dynamic system library 'SDL3' using strategy 'paths_first'. searched paths:
+  /usr/local/lib/libSDL3.so
+  /usr/local/lib/libSDL3.a
+  /usr/lib/x86_64-linux-gnu/libSDL3.so
+  /usr/lib/x86_64-linux-gnu/libSDL3.a
+  /lib64/libSDL3.so
+  /lib64/libSDL3.a
+  /lib/libSDL3.so
+  /lib/libSDL3.a
+  /usr/lib64/libSDL3.so
+  /usr/lib64/libSDL3.a
+  /usr/lib/libSDL3.so
+  /usr/lib/libSDL3.a
+  /lib/x86_64-linux-gnu/libSDL3.so
+  /lib/x86_64-linux-gnu/libSDL3.a
+error: unable to find dynamic system library 'SDL3_ttf' using strategy 'paths_first'. searched paths:
+  /usr/local/lib/libSDL3_ttf.so
+  /usr/local/lib/libSDL3_ttf.a
+  /usr/lib/x86_64-linux-gnu/libSDL3_ttf.so
+  /usr/lib/x86_64-linux-gnu/libSDL3_ttf.a
+  /lib64/libSDL3_ttf.so
+  /lib64/libSDL3_ttf.a
+  /lib/libSDL3_ttf.so
+  /lib/libSDL3_ttf.a
+  /usr/lib64/libSDL3_ttf.so
+  /usr/lib64/libSDL3_ttf.a
+  /usr/lib/libSDL3_ttf.so
+  /usr/lib/libSDL3_ttf.a
+  /lib/x86_64-linux-gnu/libSDL3_ttf.so
+  /lib/x86_64-linux-gnu/libSDL3_ttf.a
+```
+
+Adding `-L"$SDL3_INCLUDE_PATH/../lib"` resolved that environment-only linker issue. There was no SDL header or Aro translate-c failure. **The migration was not stopped.**
+
+### Risk 2 — ghostty `main` and `ghostty-vt`: PASS
+
+With the four fresh hashes, Zig 0.16.0 resolved and compiled the ghostty snapshot and its generated dependencies, and the Architect command line included `-Mghostty-vt=.../src/lib_vt.zig`. The full build reached Architect's own source and ended with `38/43 steps succeeded (2 failed)`; there were no diagnostics about resolving `ghostty`, missing `ghostty-vt`, libxev, toml, or zwanzig.
+
+### Risk 3 — dependency hash format: PASS
+
+All four URLs were accepted by Zig 0.16.0 `zig fetch`, producing the hashes above. The unchanged Zwanzig v0.15.1 URL reproduced its existing hash.
+
+### Risk 4 — zig-toml API: PASS for the exercised surface
+
+The toml dependency resolved and compiled as part of the full build. A standalone Zig 0.16.0 compile of `src/config.zig` with the resolved toml module reached Architect's code and reported no toml parser/API diagnostic. It instead reported the expected unrelated standard-library changes:
+
+```text
+src/config.zig:326:64: error: missing struct field: items
+    terminal_entries: std.ArrayListUnmanaged(TerminalEntry) = .{},
+                                                              ~^~
+src/config.zig:326:64: note: missing struct field: capacity
+/tmp/zig016/lib/std/array_list.zig:576:12: note: struct declared here
+    return struct {
+           ^~~~~~
+src/config.zig:1181:37: error: no field or member function named 'realpathAlloc' in 'Io.Dir'
+    const tmp_path = try tmp_dir.dir.realpathAlloc(allocator, ".");
+                         ~~~~~~~~~~~^~~~~~~~~~~~~~
+/tmp/zig016/lib/std/Io/Dir.zig:1:1: note: struct declared here
+const Dir = @This();
+^~~~~
+src/config.zig:1273:37: error: no field or member function named 'realpathAlloc' in 'Io.Dir'
+    const tmp_path = try tmp_dir.dir.realpathAlloc(allocator, ".");
+                         ~~~~~~~~~~~^~~~~~~~~~~~~~
+/tmp/zig016/lib/std/Io/Dir.zig:1:1: note: struct declared here
+const Dir = @This()
+```
+
+The parser's `Parser`/result API was not reached by a failure.
+
+### Risk 5 — `std.Io.Writer` surface: PASS for the exercised surface
+
+The repository has 12 existing `std.Io` sites. No `std.Io.Writer` diagnostic appeared in the untouched-source full build or in a libc-enabled standalone Zig 0.16.0 compile of `src/logging.zig`; the latter reached only `@Type` and filesystem diagnostics. The Writer call sites therefore need no inventory blocker, though they will be rechecked during the migration's normal build/test work.
+
+## Untouched-source Zig 0.16.0 error inventory
+
+After the build-script-only compatibility patch needed to execute `build.zig`, the source tree was restored untouched and `zig build` was run with Zig 0.16.0. It produced 3 source diagnostics, grouped as follows:
+
+| Group | Count | Diagnostic |
+| --- | ---: | --- |
+| Logging callback type | 1 | `invalid builtin function: '@Type'` |
+| Main entrypoint argument API | 1 | `root source file struct 'process' has no member named 'argsAlloc'` |
+| MCP allocator API | 1 | `root source file struct 'heap' has no member named 'GeneralPurposeAllocator'` |
+| **Total source diagnostics** | **3** | |
+
+Verbatim compiler diagnostics:
+
+```text
+src/logging.zig:349:21: error: invalid builtin function: '@Type'
+    comptime scope: @Type(.enum_literal),
+                    ^~~~~~~~~~~~~~~~~~~~
+src/main.zig:16:33: error: root source file struct 'process' has no member named 'argsAlloc'
+    const argv = try std.process.argsAlloc(allocator);
+                     ~~~~~~~~~~~^~~~~~~~~~
+/tmp/zig016/lib/std/process.zig:1:1: note: struct declared here
+const builtin = @import("builtin");
+^
+referenced by:
+    callMain [inlined]: /tmp/zig016/lib/std/start.zig:698:59
+    callMainWithArgs [inlined]: /tmp/zig016/lib/std/start.zig:638:20
+    main: /tmp/zig016/lib/std/start.zig:663:28
+    1 reference(s) hidden; use '-freference-trace=4' to see more
+error: 2 compilation errors
+
+src/mcp/main.zig:19:23: error: root source file struct 'heap' has no member named 'GeneralPurposeAllocator'
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/zig016/lib/std/heap.zig:1:1: note: struct declared here
+const std = @import("std.zig");
+^
+referenced by:
+    callMain [inlined]: /tmp/zig016/lib/std/start.zig:737:30
+    callMainWithArgs [inlined]: /tmp/zig016/lib/std/start.zig:638:20
+    main: /tmp/zig016/lib/std/start.zig:663:28
+    1 reference(s) hidden; use '-freference-trace=4' to see more
+error: 1 compilation errors
+```
+
+The exact failed commands also showed all four resolved dependency modules and their source paths. No dependency-error line matched `ghostty`, `libxev`, `toml`, or `zwanzig`; the failures were exclusively in Architect source.
+
+## macOS SDK workaround
+
+Not testable in this Linux AIR Cloud sandbox; requires verification on a macOS host separately.
+
+The 0.16 shell was intentionally not created here, and no conclusion is drawn about arm64e SDK linking or `scripts/setup-macos-sdk-workaround.sh`. Task 14 must verify whether the workaround remains necessary on macOS.
+
+## Scope and cleanup
+
+Temporary changes to `build.zig.zon`, `build.zig`, and source files were used only for probing and were discarded. The kept changes are this inventory and the Step 1 checklist updates in `2026-08-28-zig-0-16-migration.md`.

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -239,7 +239,7 @@ Run: `nix develop --command just test`
 Run: `nix develop --command just lint`
 Expected: all pass. The spike must leave `main`'s toolchain untouched.
 
-- [ ] **Step 13: Open the inventory PR**
+- [x] **Step 13: Open the inventory PR**
 
 Use the `managing-github` skill. This PR contains one new doc and no code.
 

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -72,7 +72,7 @@ Nothing in the prep work is worth writing if the 0.16 dependency graph cannot re
 - Consumes: nothing
 - Produces: the four verified `build.zig.zon` dependency hashes used verbatim by Task 6; a decision on the macOS SDK workaround used by Task 14; a full `zig build` error inventory that later flip tasks check their progress against
 
-- [ ] **Step 1: Create a throwaway branch**
+- [x] **Step 1: Create a throwaway branch**
 
 ```bash
 git checkout main && git pull origin main
@@ -126,7 +126,7 @@ The cache redirect into `.tmp/` matters: the default cache locations may be read
 Run: `nix develop .#zig016 --command zig version`
 Expected: `0.16.0`
 
-- [ ] **Step 4: Regenerate all four dependency hashes**
+- [x] **Step 4: Regenerate all four dependency hashes**
 
 Edit `build.zig.zon` to set `.minimum_zig_version = "0.16.0"` and replace the four dependency URLs, then let `zig fetch` compute each hash. This is the step that answers Risk 3 (whether 0.16 accepts 0.15-era hash strings at all).
 
@@ -147,7 +147,7 @@ nix develop .#zig016 --command bash -c '
 
 Record each printed hash in the inventory doc. Expected: four hash strings of the form `<name>-<version>-<base64>`.
 
-- [ ] **Step 5: Answer Risk 1 — does `@cImport` on SDL3 still work?**
+- [x] **Step 5: Answer Risk 1 — does `@cImport` on SDL3 still work?**
 
 This is the highest-value question in the spike, and `src/c.zig` re-exports 224 symbols that depend on it. Isolate it from every other error class with a standalone probe rather than a full build:
 
@@ -181,7 +181,7 @@ nix develop .#zig016 --command bash -c '
 Expected on success: no output from the compiler, and `.tmp/cimport-probe/probe` exists.
 If it fails: record every diagnostic verbatim in the inventory doc. **Stop the whole migration here and report to the user** — a translate-c failure on SDL3 headers changes what this migration is, and the plan from Task 2 onward assumes `src/c.zig` keeps its shape.
 
-- [ ] **Step 6: Answer Risk 2 — does ghostty `main` resolve and expose `ghostty-vt`?**
+- [x] **Step 6: Answer Risk 2 — does ghostty `main` resolve and expose `ghostty-vt`?**
 
 ```bash
 nix develop .#zig016 --command bash -c 'zig build 2>&1 | tee .tmp/zig016-build-errors.txt' || true
@@ -190,7 +190,7 @@ grep -n "ghostty" .tmp/zig016-build-errors.txt || echo "no ghostty errors"
 
 Expected: errors in Architect's own source (`build.zig` first, since `std.fs.openDirAbsolute` and `std.posix.getenv` are gone), but **no** error about resolving the `ghostty` dependency or about `dep.module("ghostty-vt")` being absent. Any ghostty-resolution or ghostty-vt-API error is a blocker: record it and report to the user.
 
-- [ ] **Step 7: Answer Risk 4 — does zig-toml's `zig-0.16` branch match Architect's usage?**
+- [x] **Step 7: Answer Risk 4 — does zig-toml's `zig-0.16` branch match Architect's usage?**
 
 Once `build.zig` errors are patched enough for the compiler to reach `src/config.zig`, check the toml diagnostics specifically:
 
@@ -200,7 +200,7 @@ grep -n "toml" .tmp/zig016-build-errors.txt || echo "no toml errors"
 
 Record any parser API drift. Pay particular attention to whether `Parser`, `parseString`/`parseFile`, and the result type's `deinit` keep their shapes, since `CLAUDE.md` records two live hazards there: parser-owned maps must not outlive `result.deinit()`, and persisted map keys *and* values must both be duplicated.
 
-- [ ] **Step 8: Answer Risk 5 and produce the full error inventory**
+- [x] **Step 8: Answer Risk 5 and produce the full error inventory**
 
 Patch `build.zig` minimally (throwaway) until the compiler gets past it, then capture the complete error set for `src/`:
 
@@ -212,15 +212,15 @@ grep -o "error: [^\n]*" .tmp/zig016-build-errors.txt | sort | uniq -c | sort -rn
 
 Record the total count and the grouped breakdown. Note any `std.Io.Writer` diagnostics (Risk 5) at the 12 existing `std.Io.*` sites.
 
-- [ ] **Step 9: Answer the SDK-workaround question**
+- [x] **Step 9: Answer the SDK-workaround question**
 
 The `.#zig016` shell above deliberately omits `scripts/setup-macos-sdk-workaround.sh`. If Steps 5–8 linked successfully without it, record "0.16 linker does not need the arm64e SDK workaround on this host". If linking failed with arm64e/SDK diagnostics, record the diagnostics and the conclusion that the workaround must stay. Task 14 consumes this.
 
-- [ ] **Step 10: Write the inventory doc**
+- [x] **Step 10: Write the inventory doc**
 
 Create `docs/superpowers/plans/2026-08-28-zig-0-16-inventory.md` containing: the environment used; the four verified hashes; the Risk 1–5 verdicts with verbatim diagnostics; the grouped error inventory from Step 8; and the SDK-workaround conclusion.
 
-- [ ] **Step 11: Discard every source patch, keep only the inventory**
+- [x] **Step 11: Discard every source patch, keep only the inventory**
 
 ```bash
 git stash list
@@ -232,7 +232,7 @@ git commit -m "docs: record Zig 0.16.0 breakage inventory from spike"
 
 Expected: `git status --short` shows only the inventory doc. `flake.nix`, `build.zig.zon`, `build.zig`, and `src/` are all clean.
 
-- [ ] **Step 12: Verify 0.15.2 is still green on this branch**
+- [x] **Step 12: Verify 0.15.2 is still green on this branch**
 
 Run: `nix develop --command just build`
 Run: `nix develop --command just test`

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -212,7 +212,7 @@ grep -o "error: [^\n]*" .tmp/zig016-build-errors.txt | sort | uniq -c | sort -rn
 
 Record the total count and the grouped breakdown. Note any `std.Io.Writer` diagnostics (Risk 5) at the 12 existing `std.Io.*` sites.
 
-- [x] **Step 9: Answer the SDK-workaround question**
+- [ ] **Step 9: Answer the SDK-workaround question** — not testable on this Linux AIR Cloud sandbox; genuinely unanswered, needs a macOS host (see inventory doc's "macOS SDK workaround" section). Task 14 must resolve this before it can proceed.
 
 The `.#zig016` shell above deliberately omits `scripts/setup-macos-sdk-workaround.sh`. If Steps 5–8 linked successfully without it, record "0.16 linker does not need the arm64e SDK workaround on this host". If linking failed with arm64e/SDK diagnostics, record the diagnostics and the conclusion that the workaround must stay. Task 14 consumes this.
 


### PR DESCRIPTION
## Summary

- record the four Zig 0.16.0 dependency hashes
- prove SDL3/SDL3_ttf @cImport and ghostty-vt dependency resolution under Zig 0.16.0
- capture the untouched-source error inventory and macOS SDK caveat
- update the Step 1 checklist

## Verification

- Zig 0.15.2: `zig build`
- Zig 0.15.2: `zig build test`
- Zig 0.15.2: `just lint`

This is a docs-only spike. The macOS SDK workaround question is explicitly not testable in the Linux AIR Cloud sandbox and requires separate macOS verification.