### PR TITLE
refactor: add environment accessor for Zig 0.16 prep

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -29,6 +29,12 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    const env_mod = b.createModule(.{
+        .root_source_file = b.path("src/env.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    control_mod.addImport("../env.zig", env_mod);
     mcp_mod.addImport("control", control_mod);
     const assets_mod = b.createModule(.{
         .root_source_file = b.path("assets/terminfo.zig"),

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -601,7 +601,7 @@ std.heap.GeneralPurposeAllocator. DebugAllocator is what
 GeneralPurposeAllocator already aliases in 0.15.2, so this is a rename."
 ```
 
-- [ ] **Step 13: Open the PR**
+- [x] **Step 13: Open the PR**
 
 Use the `managing-github` skill.
 

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -431,7 +431,7 @@ Zig 0.16 removes `std.posix.getenv` and `std.heap.GeneralPurposeAllocator`. `std
 - Consumes: nothing
 - Produces: `env.get(key: []const u8) ?[:0]const u8` — the exact return type `std.posix.getenv` had, so no call site needs any coercion change. Task 7 adds `env.init` and swaps the internals.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `src/env.zig` with only the test, so it fails to compile for the right reason:
 
@@ -458,7 +458,7 @@ test "get returns null for a variable that is not set" {
 }
 ```
 
-- [ ] **Step 2: Register the new file in the test registry**
+- [x] **Step 2: Register the new file in the test registry**
 
 Zig only collects tests from files reachable through `src/main.zig`'s `test` block. Add the import in alphabetical position:
 
@@ -469,12 +469,12 @@ Zig only collects tests from files reachable through `src/main.zig`'s `test` blo
     _ = @import("font.zig");
 ```
 
-- [ ] **Step 3: Run the test to verify it fails**
+- [x] **Step 3: Run the test to verify it fails**
 
 Run: `nix develop --command zig build test 2>&1 | tail -20`
 Expected: FAIL with `use of undeclared identifier 'get'`.
 
-- [ ] **Step 4: Write the minimal implementation**
+- [x] **Step 4: Write the minimal implementation**
 
 Add to `src/env.zig`, above the tests:
 
@@ -495,12 +495,12 @@ pub fn get(key: []const u8) ?[:0]const u8 {
 }
 ```
 
-- [ ] **Step 5: Run the test to verify it passes**
+- [x] **Step 5: Run the test to verify it passes**
 
 Run: `nix develop --command zig build test`
 Expected: exit 0. Run this unpiped.
 
-- [ ] **Step 6: Commit the module**
+- [x] **Step 6: Commit the module**
 
 ```bash
 nix develop --command zig fmt src/
@@ -508,7 +508,7 @@ git add src/env.zig src/main.zig
 git commit -m "feat(env): add process environment accessor module"
 ```
 
-- [ ] **Step 7: Route all 12 call sites through `env.get`**
+- [x] **Step 7: Route all 12 call sites through `env.get`**
 
 For each file, add the import next to the existing imports and replace the call. The return type is identical, so nothing else changes.
 
@@ -541,7 +541,7 @@ Then replace every `std.posix.getenv(` **and** every aliased `posix.getenv(` wit
 
 Leave `src/session/state.zig:770`'s `std.mem.sliceTo(home_z, 0)` exactly as it is. It is redundant but harmless, and removing it would be an unrelated change.
 
-- [ ] **Step 8: Verify no call site was missed**
+- [x] **Step 8: Verify no call site was missed**
 
 Use the alias-aware pattern — `std.posix.getenv` alone would report success while 11 aliased sites remain:
 
@@ -554,7 +554,7 @@ Expected: `23`.
 Run: `grep -rl 'env\.get(' src | wc -l`
 Expected: `11`.
 
-- [ ] **Step 9: Replace `GeneralPurposeAllocator` with `DebugAllocator`**
+- [x] **Step 9: Replace `GeneralPurposeAllocator` with `DebugAllocator`**
 
 `std.heap.GeneralPurposeAllocator` is merely an alias for `std.heap.DebugAllocator` in 0.15.2 (`heap.zig:26`) and is removed in 0.16.
 
@@ -573,7 +573,7 @@ Expected: `11`.
 Run: `grep -rn 'GeneralPurposeAllocator' src build.zig`
 Expected: no output.
 
-- [ ] **Step 10: Verify build, tests, and lint**
+- [x] **Step 10: Verify build, tests, and lint**
 
 Run: `nix develop --command zig build`
 Expected: exit 0.
@@ -589,7 +589,7 @@ Expected: exit 0.
 Run: `nix develop --command zig build run`
 Expected: the window opens. Confirm specifically that config loading worked (no "HomeNotFound" in the log), that the recent-folders overlay lists the home directory, and that `~` abbreviation still appears in the worktree overlay's paths — those are the three user-visible consumers of `env.get`.
 
-- [ ] **Step 12: Format and commit**
+- [x] **Step 12: Format and commit**
 
 ```bash
 nix develop --command zig fmt src/

--- a/src/app/control.zig
+++ b/src/app/control.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const posix = std.posix;
 const atomic = std.atomic;
+const env = @import("../env.zig");
 
 const log = std.log.scoped(.control);
 
@@ -275,7 +276,7 @@ const ControlRuntimeDir = struct {
 };
 
 fn controlRuntimeDirAlloc(allocator: std.mem.Allocator) !ControlRuntimeDir {
-    if (std.posix.getenv("XDG_RUNTIME_DIR")) |runtime_dir| {
+    if (env.get("XDG_RUNTIME_DIR")) |runtime_dir| {
         return .{
             .path = try allocator.dupe(u8, runtime_dir),
             .managed = false,
@@ -289,7 +290,7 @@ fn controlRuntimeDirAlloc(allocator: std.mem.Allocator) !ControlRuntimeDir {
 }
 
 fn fallbackControlRuntimeDirAlloc(allocator: std.mem.Allocator) ![]u8 {
-    if (std.posix.getenv("HOME")) |home| {
+    if (env.get("HOME")) |home| {
         if (builtin.os.tag == .macos) {
             return try std.fs.path.join(allocator, &.{ home, "Library", "Caches", "Architect", "runtime" });
         }

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const xev = @import("xev");
 const posix = std.posix;
+const env = @import("../env.zig");
 const app_state = @import("app_state.zig");
 const grid_layout = @import("grid_layout.zig");
 const grid_nav = @import("grid_nav.zig");
@@ -1407,7 +1408,7 @@ fn startQuitFlow(
 }
 
 pub fn run(log_dir_override: ?[]const u8) !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -1488,7 +1489,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
 
     // Initialize recent folders with home directory if empty
     if (persistence.recent_folders.items.len == 0) {
-        if (std.posix.getenv("HOME")) |home| {
+        if (env.get("HOME")) |home| {
             persistence.appendRecentFolder(allocator, home) catch |err| {
                 log.warn("failed to initialize recent folders with home: {}", .{err});
             };
@@ -1648,7 +1649,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
 
     std.debug.print("Grid cell terminal size: {d}x{d}; full size: {d}x{d}\n", .{ initial_sizes.grid.cols, initial_sizes.grid.rows, full_cols, full_rows });
 
-    const shell_path = std.posix.getenv("SHELL") orelse "/bin/zsh";
+    const shell_path = env.get("SHELL") orelse "/bin/zsh";
     std.debug.print("Starting with {d}x{d} grid: {s}\n", .{ grid.cols, grid.rows, shell_path });
 
     var cell_width_pixels = @divFloor(render_width, @as(c_int, @intCast(grid.cols)));

--- a/src/app/worktree.zig
+++ b/src/app/worktree.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const env = @import("../env.zig");
 const session_state = @import("../session/state.zig");
 
 const SessionState = session_state.SessionState;
@@ -43,7 +44,7 @@ pub fn changeSessionDirectory(session: *SessionState, allocator: std.mem.Allocat
 /// The repo subpath is relative to $HOME when possible, or the full path minus
 /// leading `/` otherwise, to avoid collisions between repos with the same basename.
 pub fn resolveWorktreeDir(allocator: std.mem.Allocator, repo_root: []const u8, name: []const u8, config_dir: ?[]const u8) ![]u8 {
-    const home = std.posix.getenv("HOME") orelse return error.HomeNotFound;
+    const home = env.get("HOME") orelse return error.HomeNotFound;
     const repo_subpath = repoSubpath(home, repo_root);
 
     const resolved_dir = try resolveConfigDir(allocator, home, config_dir);

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const fs = std.fs;
+const env = @import("env.zig");
 const toml = @import("toml");
 
 pub const min_grid_font_scale: f32 = 0.5;
@@ -540,7 +541,7 @@ pub const Persistence = struct {
     }
 
     pub fn getPersistencePath(allocator: std.mem.Allocator) ![]u8 {
-        const home = std.posix.getenv("HOME") orelse return error.HomeNotFound;
+        const home = env.get("HOME") orelse return error.HomeNotFound;
         return try fs.path.join(allocator, &[_][]const u8{ home, ".config", "architect", "persistence.toml" });
     }
 
@@ -804,7 +805,7 @@ pub const Config = struct {
     }
 
     pub fn getConfigPath(allocator: std.mem.Allocator) ![]u8 {
-        const home = std.posix.getenv("HOME") orelse return error.HomeNotFound;
+        const home = env.get("HOME") orelse return error.HomeNotFound;
         return try fs.path.join(allocator, &[_][]const u8{ home, ".config", "architect", "config.toml" });
     }
 

--- a/src/env.zig
+++ b/src/env.zig
@@ -1,0 +1,35 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+comptime {
+    if (builtin.os.tag == .windows) {
+        @compileError("env.zig is POSIX-only; Architect does not support Windows");
+    }
+}
+
+/// Process environment access.
+///
+/// Zig 0.16 removes `std.posix.getenv`, and `std.Io` exposes no environment
+/// surface, so environment reads cannot travel with the `io` context the way
+/// filesystem and clock reads do. Because the environment is process-global
+/// and immutable for Architect's lifetime — exactly what `std.posix.getenv`
+/// already assumed — it lives here instead of being threaded through every
+/// caller as a second context.
+///
+/// This is the only sanctioned module-level accessor in the codebase. The
+/// `io` context is never stored this way.
+pub fn get(key: []const u8) ?[:0]const u8 {
+    return std.posix.getenv(key);
+}
+
+test "get returns a value for a variable the process always has" {
+    // PATH is guaranteed present in every shell Architect is launched from,
+    // including the CI runners and the Nix dev shell.
+    const path = get("PATH");
+    try std.testing.expect(path != null);
+    try std.testing.expect(path.?.len > 0);
+}
+
+test "get returns null for a variable that is not set" {
+    try std.testing.expectEqual(@as(?[:0]const u8, null), get("ARCHITECT_DEFINITELY_NOT_SET_9f3a1c"));
+}

--- a/src/font_paths.zig
+++ b/src/font_paths.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const env = @import("env.zig");
 
 const log = std.log.scoped(.font_paths);
 
@@ -110,7 +111,7 @@ fn findSystemFont(allocator: std.mem.Allocator, font_family: []const u8, style: 
         "/Library/Fonts",
     };
 
-    const home = std.posix.getenv("HOME");
+    const home = env.get("HOME");
     const style_suffix = style;
 
     for (search_dirs) |dir| {

--- a/src/logging.zig
+++ b/src/logging.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const fs = std.fs;
 const posix = std.posix;
+const env = @import("env.zig");
 const time_c = @cImport({
     @cInclude("time.h");
 });
@@ -47,7 +48,7 @@ fn isEnabled(min_level: std.log.Level, level: std.log.Level) bool {
 }
 
 fn defaultLogDirectoryPath(allocator: std.mem.Allocator) ![]u8 {
-    const home = posix.getenv("HOME") orelse return error.HomeNotFound;
+    const home = env.get("HOME") orelse return error.HomeNotFound;
     if (builtin.os.tag == .macos) {
         return fs.path.join(allocator, &[_][]const u8{ home, "Library", "Logs", "Architect" });
     }

--- a/src/logging.zig
+++ b/src/logging.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const fs = std.fs;
-const posix = std.posix;
 const env = @import("env.zig");
 const time_c = @cImport({
     @cInclude("time.h");

--- a/src/main.zig
+++ b/src/main.zig
@@ -41,6 +41,7 @@ test {
     _ = @import("cli_args.zig");
     _ = @import("colors.zig");
     _ = @import("config.zig");
+    _ = @import("env.zig");
     _ = @import("font.zig");
     _ = @import("gfx/shimmer.zig");
     _ = @import("input/mapper.zig");

--- a/src/mcp/main.zig
+++ b/src/mcp/main.zig
@@ -16,7 +16,7 @@ const JsonRpcErrorCode = enum(i32) {
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     try run(gpa.allocator(), std.fs.File.stdin(), std.fs.File.stdout());
 }

--- a/src/session/notify.zig
+++ b/src/session/notify.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const posix = std.posix;
+const env = @import("../env.zig");
 const app_state = @import("../app/app_state.zig");
 const atomic = std.atomic;
 
@@ -47,7 +48,7 @@ pub const NotificationQueue = struct {
 pub const GetNotifySocketPathError = std.mem.Allocator.Error;
 
 pub fn getNotifySocketPath(allocator: std.mem.Allocator) GetNotifySocketPathError![:0]u8 {
-    const base = std.posix.getenv("XDG_RUNTIME_DIR") orelse "/tmp";
+    const base = env.get("XDG_RUNTIME_DIR") orelse "/tmp";
     const pid = std.c.getpid();
     const socket_name = try std.fmt.allocPrint(allocator, "architect_notify_{d}.sock", .{pid});
     defer allocator.free(socket_name);

--- a/src/session/state.zig
+++ b/src/session/state.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const posix = std.posix;
 const builtin = @import("builtin");
+const env = @import("../env.zig");
 const xev = @import("xev");
 const ghostty_vt = @import("ghostty-vt");
 const shell_mod = @import("../shell.zig");
@@ -766,7 +767,7 @@ pub const SessionState = struct {
             return;
         }
 
-        if (std.posix.getenv("HOME")) |home_z| {
+        if (env.get("HOME")) |home_z| {
             try self.replaceCwdPath(std.mem.sliceTo(home_z, 0));
         }
     }

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -3,6 +3,7 @@
 const std = @import("std");
 const assets = @import("assets");
 const posix = std.posix;
+const env = @import("env.zig");
 const pty_mod = @import("pty.zig");
 const libc = @cImport({
     @cInclude("stdlib.h");
@@ -636,7 +637,7 @@ const architect_zsh_login_script =
 ;
 
 fn setDefaultEnv(name: [:0]const u8, value: [:0]const u8) void {
-    if (posix.getenv(name) != null) return;
+    if (env.get(name) != null) return;
     if (libc.setenv(name, value, 1) != 0) {
         std.c._exit(1);
     }
@@ -655,7 +656,7 @@ pub fn ensureTerminfoSetup() void {
     terminfo_setup_done = true;
 
     // Install to ~/.cache/architect/terminfo
-    const home = posix.getenv("HOME") orelse {
+    const home = env.get("HOME") orelse {
         log.warn("HOME not set, cannot install terminfo, falling back to {s}", .{fallback_term});
         return;
     };
@@ -765,8 +766,8 @@ fn ensureArchitectCommandSetup() void {
     if (architect_command_setup_done) return;
     architect_command_setup_done = true;
 
-    const runtime_dir = posix.getenv("XDG_RUNTIME_DIR");
-    const home = posix.getenv("HOME");
+    const runtime_dir = env.get("XDG_RUNTIME_DIR");
+    const home = env.get("HOME");
     const base_dir_z: [:0]const u8 = if (runtime_dir) |dir|
         std.fmt.bufPrintZ(&architect_command_base_buf, "{s}/architect", .{dir}) catch |err| {
             log.warn("failed to format architect runtime path: {}", .{err});
@@ -934,7 +935,7 @@ fn configureZshPathInjection(shell_path: []const u8) void {
     setEnv("ARCHITECT_COMMAND_DIR", command_dir_z);
 
     const empty_zdotdir: [:0]const u8 = "";
-    const original_zdotdir = posix.getenv("ZDOTDIR") orelse empty_zdotdir;
+    const original_zdotdir = env.get("ZDOTDIR") orelse empty_zdotdir;
     setEnv("ARCHITECT_ZDOTDIR_ORIG", original_zdotdir);
 
     const base_dir_z = architect_command_base_z orelse return;
@@ -962,7 +963,7 @@ fn ensureArchitectCommandPath() void {
     const dir_z = architect_command_dir_z orelse return;
     const dir = std.mem.sliceTo(dir_z, 0);
 
-    const path_env = posix.getenv("PATH") orelse "";
+    const path_env = env.get("PATH") orelse "";
     const path_slice = std.mem.sliceTo(path_env, 0);
     if (pathContainsEntry(path_slice, dir)) return;
 
@@ -993,7 +994,7 @@ fn ensureArchitectCommandPath() void {
 }
 
 fn findExecutableInPath(name: []const u8) ?[:0]const u8 {
-    const path_env = posix.getenv("PATH") orelse return null;
+    const path_env = env.get("PATH") orelse return null;
     const path_env_slice = std.mem.sliceTo(path_env, 0);
     var it = std.mem.splitScalar(u8, path_env_slice, ':');
     while (it.next()) |dir| {
@@ -1073,7 +1074,7 @@ pub const Shell = struct {
 
             // Change to specified directory or home directory before spawning shell.
             // Try working_dir first, fall back to HOME.
-            const target_dir = working_dir orelse posix.getenv("HOME");
+            const target_dir = working_dir orelse env.get("HOME");
             if (target_dir) |dir| {
                 // zwanzig-disable: empty-catch-engine
                 // Errors are intentionally ignored: we're in a forked child process where
@@ -1094,7 +1095,7 @@ pub const Shell = struct {
 
         if (!warned_env_defaults) {
             warned_env_defaults = true;
-            if (posix.getenv("TERM") == null or posix.getenv("LANG") == null) {
+            if (env.get("TERM") == null or env.get("LANG") == null) {
                 log.warn("TERM/LANG missing in parent env; child shells will receive defaults ({s}, {s})", .{ fallback_term, default_lang });
             }
         }

--- a/src/ui/components/recent_folders_overlay.zig
+++ b/src/ui/components/recent_folders_overlay.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const c = @import("../../c.zig");
+const env = @import("../../env.zig");
 const colors = @import("../../colors.zig");
 const config = @import("../../config.zig");
 const geom = @import("../../geom.zig");
@@ -724,7 +725,7 @@ pub const RecentFoldersOverlayComponent = struct {
     }
 
     fn makeDisplayPath(allocator: std.mem.Allocator, path: []const u8) ![]const u8 {
-        const home = std.posix.getenv("HOME");
+        const home = env.get("HOME");
         if (home) |h| {
             if (std.mem.startsWith(u8, path, h)) {
                 const suffix = path[h.len..];

--- a/src/ui/components/worktree_overlay.zig
+++ b/src/ui/components/worktree_overlay.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const c = @import("../../c.zig");
+const env = @import("../../env.zig");
 const colors = @import("../../colors.zig");
 const geom = @import("../../geom.zig");
 const primitives = @import("../../gfx/primitives.zig");
@@ -637,7 +638,7 @@ pub const WorktreeOverlayComponent = struct {
             if (rel.len == 0) return self.allocator.dupe(u8, repository_root_label);
             return rel;
         }
-        const home = std.posix.getenv("HOME") orelse return self.allocator.dupe(u8, abs);
+        const home = env.get("HOME") orelse return self.allocator.dupe(u8, abs);
         if (std.mem.startsWith(u8, abs, home) and abs.len > home.len and abs[home.len] == '/') {
             return std.fmt.allocPrint(self.allocator, "~{s}", .{abs[home.len..]});
         }


### PR DESCRIPTION
## Issue
Prepare the environment-access and allocator portions of the staged Zig 0.16 migration (Task 3).

## Solution
- Add and register `src/env.zig` with the planned process-environment accessor and tests.
- Route all 23 `getenv` call sites across 11 files through `env.get`, including aliased `posix.getenv` calls in `shell.zig` and `logging.zig`.
- Rename both `GeneralPurposeAllocator` instances to `DebugAllocator`.
- Add the minimal build-graph alias required for the existing standalone MCP `control` module to resolve the plan-prescribed relative environment import.
- Check off only the completed Step 3 items in the migration plan.

## Context
This is the Zig 0.15.2-compatible preparation commit for the later Zig 0.16 toolchain flip. The environment accessor retains the exact `std.posix.getenv` return type. The MCP build-graph alias is necessary because Task 2 compiles `src/app/control.zig` as a separate module whose root otherwise rejects `../env.zig` as outside its module path.

## Test plan
- `zig build` — passed locally with directly installed Zig 0.15.2.
- `zig build test` — passed locally, run unpiped for the exit-code verdict.
- `just lint` — passed locally; test registry reports all 45 test files registered.
- `zig fmt --check src/` and `./scripts/check-test-registry.sh` — passed.
- The plan Step 3 manual check (run the app and exercise config loading, recent folders, and `~` path abbreviation) could not be performed in this Linux sandbox because it requires the SDL3/macOS UI. A human on macOS or CI with an appropriate runtime must perform/cover it; it is not being claimed as completed.