### PR TITLE
feat(clock): add time and sleep accessor module

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -34,7 +34,13 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    const clock_mod = b.createModule(.{
+        .root_source_file = b.path("src/clock.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
     control_mod.addImport("../env.zig", env_mod);
+    control_mod.addImport("../clock.zig", clock_mod);
     mcp_mod.addImport("control", control_mod);
     const assets_mod = b.createModule(.{
         .root_source_file = b.path("assets/terminfo.zig"),

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -963,9 +963,14 @@ pub fn run(allocator: std.mem.Allocator, options: RunOptions) !RunResult {
     var stderr_buf: std.ArrayList(u8) = .empty;
     errdefer stderr_buf.deinit(allocator);
 
-    errdefer child.kill() catch |err| {
-        std.log.scoped(.proc).warn("failed to stop child after output failure: {}", .{err});
-    };
+    errdefer {
+        _ = child.kill() catch |kill_err| switch (kill_err) {
+            error.AlreadyTerminated => _ = child.wait() catch |wait_err| {
+                std.log.scoped(.proc).warn("failed to reap child after output failure: {}", .{wait_err});
+            },
+            else => std.log.scoped(.proc).warn("failed to stop child after output failure: {}", .{kill_err}),
+        };
+    }
 
     try child.collectOutput(allocator, &stdout_buf, &stderr_buf, options.max_output_bytes);
     const term = try child.wait();
@@ -984,6 +989,9 @@ pub fn run(allocator: std.mem.Allocator, options: RunOptions) !RunResult {
 /// Spawns `argv`, waits for it, and discards its output.
 pub fn spawnDetached(allocator: std.mem.Allocator, argv: []const []const u8) !Term {
     var child = std.process.Child.init(argv, allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Ignore;
+    child.stderr_behavior = .Ignore;
     return fromStdTerm(try child.spawnAndWait());
 }
 ```
@@ -996,6 +1004,10 @@ at the flip regardless. Making it explicit here means it is exercised and
 tested under 0.15.2 rather than arriving unnoticed with the toolchain bump.
 Neither `gh pr list` nor `git diff` reads stdin, so no observable behavior
 changes — but verify the manual checks in Step 14 rather than assuming.
+
+Second-review correction: retain the existing zombie-reaping cleanup for
+`AlreadyTerminated` and explicitly ignore `spawnDetached` standard streams,
+preserving the pre-migration process-lifecycle and stdio behavior.
 
 - [x] **Step 5: Run the tests to verify they pass**
 

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -625,7 +625,7 @@ Zig 0.16 removes `std.time.timestamp`, `milliTimestamp`, `nanoTimestamp`, and `s
 
   Task 7 prefixes each with an `io: std.Io` parameter and keeps the names and return types unchanged.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `src/clock.zig` with only the tests:
 
@@ -667,7 +667,7 @@ test "sleepNanos advances the monotonic reading by at least the requested span" 
 }
 ```
 
-- [ ] **Step 2: Register the new file in the test registry**
+- [x] **Step 2: Register the new file in the test registry**
 
 In `src/main.zig`'s `test` block, in alphabetical position:
 
@@ -677,12 +677,12 @@ In `src/main.zig`'s `test` block, in alphabetical position:
     _ = @import("colors.zig");
 ```
 
-- [ ] **Step 3: Run the tests to verify they fail**
+- [x] **Step 3: Run the tests to verify they fail**
 
 Run: `nix develop --command zig build test 2>&1 | tail -20`
 Expected: FAIL with `use of undeclared identifier 'nowSeconds'`.
 
-- [ ] **Step 4: Write the minimal implementation**
+- [x] **Step 4: Write the minimal implementation**
 
 Add to `src/clock.zig`, above the tests:
 
@@ -715,12 +715,12 @@ pub fn sleepNanos(nanoseconds: u64) void {
 }
 ```
 
-- [ ] **Step 5: Run the tests to verify they pass**
+- [x] **Step 5: Run the tests to verify they pass**
 
 Run: `nix develop --command zig build test`
 Expected: exit 0. Run this unpiped.
 
-- [ ] **Step 6: Commit the module**
+- [x] **Step 6: Commit the module**
 
 ```bash
 nix develop --command zig fmt src/
@@ -728,7 +728,7 @@ git add src/clock.zig src/main.zig
 git commit -m "feat(clock): add time and sleep accessor module"
 ```
 
-- [ ] **Step 7: Route the 13 timestamp sites through `clock`**
+- [x] **Step 7: Route the 13 timestamp sites through `clock`**
 
 Add `const clock = @import("clock.zig");` (or `@import("../clock.zig")` in `src/app/`, `src/session/`; `@import("../../clock.zig")` under `src/ui/components/`) and replace each call:
 
@@ -750,7 +750,7 @@ Add `const clock = @import("clock.zig");` (or `@import("../clock.zig")` in `src/
 
 Note: `src/app/control.zig` is compiled into the separate `control` module for the MCP binary as well as into the main binary, so its import must resolve from `src/app/` — use `@import("../clock.zig")`.
 
-- [ ] **Step 8: Route the 14 sleep sites through `clock`**
+- [x] **Step 8: Route the 14 sleep sites through `clock`**
 
 | Site | Replace with |
 | --- | --- |
@@ -771,7 +771,7 @@ Note: `src/app/control.zig` is compiled into the separate `control` module for t
 
 `std.time.ns_per_ms` and friends are compile-time constants that survive into 0.16 — leave them alone.
 
-- [ ] **Step 9: Verify no call site was missed**
+- [x] **Step 9: Verify no call site was missed**
 
 Run: `grep -rn 'std\.time\.\(milliTimestamp\|nanoTimestamp\|timestamp\)' src`
 Expected: no output.
@@ -779,7 +779,7 @@ Expected: no output.
 Run: `grep -rn 'std\.Thread\.sleep' src`
 Expected: no output.
 
-- [ ] **Step 10: Verify build, tests, and lint**
+- [x] **Step 10: Verify build, tests, and lint**
 
 Run: `nix develop --command zig build`
 Expected: exit 0.
@@ -794,7 +794,7 @@ Expected: exit 0.
 
 Timestamps drive animation and log rotation, which no unit test covers. Run: `nix develop --command zig build run` and confirm: the layout expand/collapse animation still runs smoothly (not instant, not frozen) — that exercises `layout.zig:94`; the log file under the log directory carries correct ISO-8601 timestamps — that exercises `logging.zig:197`; and quitting with a busy session still shows the shimmer overlay for its normal duration rather than hanging or returning instantly — that exercises the `runtime.zig` quit sleeps.
 
-- [ ] **Step 12: Format and commit**
+- [x] **Step 12: Format and commit**
 
 ```bash
 nix develop --command zig fmt src/

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -829,7 +829,7 @@ This task and Task 4 belong to the same PR (Prep 3).
 
   Task 7 prefixes both functions with an `io: std.Io` parameter and swaps the internals.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `src/proc.zig` with only the tests. These use `/bin/sh`, which is present on both macOS and Linux:
 
@@ -887,7 +887,7 @@ test "spawnDetached waits for the child and returns its term" {
 }
 ```
 
-- [ ] **Step 2: Register the new file in the test registry**
+- [x] **Step 2: Register the new file in the test registry**
 
 In `src/main.zig`'s `test` block, in alphabetical position:
 
@@ -897,12 +897,12 @@ In `src/main.zig`'s `test` block, in alphabetical position:
     _ = @import("pty.zig");
 ```
 
-- [ ] **Step 3: Run the tests to verify they fail**
+- [x] **Step 3: Run the tests to verify they fail**
 
 Run: `nix develop --command zig build test 2>&1 | tail -20`
 Expected: FAIL with `use of undeclared identifier 'run'`.
 
-- [ ] **Step 4: Write the minimal implementation**
+- [x] **Step 4: Write the minimal implementation**
 
 Add to `src/proc.zig`, above the tests:
 
@@ -997,12 +997,12 @@ tested under 0.15.2 rather than arriving unnoticed with the toolchain bump.
 Neither `gh pr list` nor `git diff` reads stdin, so no observable behavior
 changes — but verify the manual checks in Step 14 rather than assuming.
 
-- [ ] **Step 5: Run the tests to verify they pass**
+- [x] **Step 5: Run the tests to verify they pass**
 
 Run: `nix develop --command zig build test`
 Expected: exit 0. Run this unpiped.
 
-- [ ] **Step 6: Commit the module**
+- [x] **Step 6: Commit the module**
 
 ```bash
 nix develop --command zig fmt src/
@@ -1013,7 +1013,7 @@ run() ignores stdin because 0.16's std.process.run hardcodes that; landing
 it now means the change is tested under the current toolchain."
 ```
 
-- [ ] **Step 7: Convert `src/os/open.zig`**
+- [x] **Step 7: Convert `src/os/open.zig`**
 
 `openUrlThread` spawns and waits, discarding output. Replace the body:
 
@@ -1030,7 +1030,7 @@ fn openUrlThread(ctx: *ThreadContext) void {
 
 Add `const proc = @import("../proc.zig");` to the imports.
 
-- [ ] **Step 8: Convert `src/app/runtime.zig:2958`**
+- [x] **Step 8: Convert `src/app/runtime.zig:2958`**
 
 The `open -t <config_path>` invocation also discards output:
 
@@ -1042,7 +1042,7 @@ The `open -t <config_path>` invocation also discards output:
 
 Preserve whatever the surrounding error handling currently does; if the existing code already logs, keep the same message and level.
 
-- [ ] **Step 9: Convert `src/ui/components/pr_dropdown_fetch.zig`**
+- [x] **Step 9: Convert `src/ui/components/pr_dropdown_fetch.zig`**
 
 This is the collect-output shape. Replace the whole spawn-collect-wait sequence in `runGhPrList` with a single `proc.run` call, keeping every existing log message and `FetchResult` branch:
 
@@ -1075,7 +1075,7 @@ Then update the term switch at line 62 to the lowercase tag:
 
 Add `const proc = @import("../../proc.zig");` to the imports.
 
-- [ ] **Step 10: Convert `src/ui/components/diff_overlay.zig`**
+- [x] **Step 10: Convert `src/ui/components/diff_overlay.zig`**
 
 Change the field type at line 125:
 
@@ -1091,7 +1091,7 @@ Replace the `Child.init` block at line 550 with `proc.run`, and update the term 
 
 Add `const proc = @import("../../proc.zig");` to the imports. Read the surrounding 40 lines before editing so the existing error branches and buffer ownership are preserved exactly.
 
-- [ ] **Step 11: Convert the `src/shell.zig` test**
+- [x] **Step 11: Convert the `src/shell.zig` test**
 
 Lines 1183-1188 run `tic` in a test. Replace with:
 
@@ -1102,7 +1102,7 @@ Lines 1183-1188 run `tic` in a test. Replace with:
 
 Add `const proc = @import("proc.zig");` to the imports.
 
-- [ ] **Step 12: Verify no call site was missed**
+- [x] **Step 12: Verify no call site was missed**
 
 Run: `grep -rn 'std\.process\.Child' src`
 Expected: only `src/proc.zig` (the wrapper's own internals).
@@ -1110,7 +1110,7 @@ Expected: only `src/proc.zig` (the wrapper's own internals).
 Run: `grep -rn '\.Exited\|\.Signal\b\|\.Stopped\b' src | grep -v 'src/proc.zig'`
 Expected: no output.
 
-- [ ] **Step 13: Verify build, tests, and lint**
+- [x] **Step 13: Verify build, tests, and lint**
 
 Run: `nix develop --command zig build`
 Expected: exit 0.
@@ -1125,7 +1125,7 @@ Expected: exit 0.
 
 Run: `nix develop --command zig build run`, then: press ⌘P to open the PR dropdown in a git repo with open pull requests and confirm the list populates (exercises `pr_dropdown_fetch.zig`); open the diff overlay and confirm the diff renders (exercises `diff_overlay.zig`); click a URL in terminal output and confirm it opens in the browser (exercises `os/open.zig`); trigger "open config" and confirm the editor launches (exercises `runtime.zig:2958`). Also confirm the PR dropdown shows its "gh not found" state when `gh` is absent from `PATH` — that branch is the one most likely to be broken by the error-mapping change.
 
-- [ ] **Step 15: Format and commit**
+- [x] **Step 15: Format and commit**
 
 ```bash
 nix develop --command zig fmt src/
@@ -1137,7 +1137,7 @@ replacing them with std.process.spawn/run, which need an io context.
 proc.Term uses 0.16's lowercase tag names so caller switches are final."
 ```
 
-- [ ] **Step 16: Open the Prep 3 PR**
+- [x] **Step 16: Open the Prep 3 PR**
 
 Use the `managing-github` skill. This PR contains Task 4 and Task 5.
 

--- a/src/app/control.zig
+++ b/src/app/control.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const posix = std.posix;
 const atomic = std.atomic;
+const clock = @import("../clock.zig");
 const env = @import("../env.zig");
 
 const log = std.log.scoped(.control);
@@ -402,7 +403,7 @@ fn controlThreadMain(ctx: ControlContext) !void {
     while (!ctx.stop.load(.seq_cst)) {
         const conn_fd = posix.accept(fd, null, null, 0) catch |err| switch (err) {
             error.WouldBlock => {
-                std.Thread.sleep(std.time.ns_per_ms * 10);
+                clock.sleepNanos(std.time.ns_per_ms * 10);
                 continue;
             },
             else => {
@@ -578,11 +579,11 @@ fn readLineFromFdWithTimeout(
     var buffer: std.ArrayList(u8) = .empty;
     errdefer buffer.deinit(allocator);
 
-    const deadline_ms = if (timeout_ms) |ms| std.time.milliTimestamp() + ms else null;
+    const deadline_ms = if (timeout_ms) |ms| clock.nowMillis() + ms else null;
     var tmp: [512]u8 = undefined;
     while (true) {
         if (deadline_ms) |deadline| {
-            const now = std.time.milliTimestamp();
+            const now = clock.nowMillis();
             if (now >= deadline) return error.TimedOut;
 
             const remaining_ms = deadline - now;

--- a/src/app/layout.zig
+++ b/src/app/layout.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const app_state = @import("app_state.zig");
+const clock = @import("../clock.zig");
 const c = @import("../c.zig");
 const font_mod = @import("../font.zig");
 const ghostty_vt = @import("ghostty-vt");
@@ -91,7 +92,7 @@ pub fn calculateHoveredSession(
         },
         .Full, .PanningLeft, .PanningRight, .PanningUp, .PanningDown => anim_state.focused_session,
         .Expanding, .Collapsing => {
-            const rect = anim_state.getCurrentRect(std.time.milliTimestamp());
+            const rect = anim_state.getCurrentRect(clock.nowMillis());
             if (mouse_x >= rect.x and mouse_x < rect.x + rect.w and
                 mouse_y >= rect.y and mouse_y < rect.y + rect.h)
             {

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -6,6 +6,7 @@ const xev = @import("xev");
 const posix = std.posix;
 const clock = @import("../clock.zig");
 const env = @import("../env.zig");
+const proc = @import("../proc.zig");
 const app_state = @import("app_state.zig");
 const grid_layout = @import("grid_layout.zig");
 const grid_nav = @import("grid_nav.zig");
@@ -2955,16 +2956,15 @@ pub fn run(log_dir_override: ?[]const u8) !void {
                     defer allocator.free(config_path);
                     if (config.ui.show_hotkey_feedback) ui.showHotkey("⌘,", now);
 
-                    const result = switch (builtin.os.tag) {
-                        .macos => blk: {
-                            var child = std.process.Child.init(&.{ "open", "-t", config_path }, allocator);
-                            break :blk child.spawn();
-                        },
-                        else => open_url.openUrl(allocator, config_path),
-                    };
-                    result catch |err| {
-                        std.debug.print("Failed to open config file: {}\n", .{err});
-                    };
+                    if (builtin.os.tag == .macos) {
+                        _ = proc.spawnDetached(allocator, &.{ "open", "-t", config_path }) catch |err| {
+                            std.debug.print("Failed to open config file: {}\n", .{err});
+                        };
+                    } else {
+                        open_url.openUrl(allocator, config_path) catch |err| {
+                            std.debug.print("Failed to open config file: {}\n", .{err});
+                        };
+                    }
                     ui.showToast("Opening config file", now);
                 } else |err| {
                     std.debug.print("Failed to get config path: {}\n", .{err});

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const xev = @import("xev");
 const posix = std.posix;
+const clock = @import("../clock.zig");
 const env = @import("../env.zig");
 const app_state = @import("app_state.zig");
 const grid_layout = @import("grid_layout.zig");
@@ -1246,20 +1247,20 @@ const QuitTeardownWorker = struct {
     fn runTask(task: *QuitTeardownTask) void {
         log.info("quit teardown: session {d} has foreground agent {s}", .{ task.session_idx, task.agent_kind.name() });
         sendExitSequence(task.pty_master, task.agent_kind);
-        std.Thread.sleep(quit_primary_wait_ms * std.time.ns_per_ms);
+        clock.sleepNanos(quit_primary_wait_ms * std.time.ns_per_ms);
 
         var fg_pgrp = foregroundPgrp(task.slavePathZ(), task.shell_pid);
         if (fg_pgrp != null) {
             log.debug("quit teardown: session {d} agent {s} still foreground after primary quit, retrying with interrupt", .{ task.session_idx, task.agent_kind.name() });
             sendExitSequence(task.pty_master, task.agent_kind);
-            std.Thread.sleep(quit_retry_wait_ms * std.time.ns_per_ms);
+            clock.sleepNanos(quit_retry_wait_ms * std.time.ns_per_ms);
             fg_pgrp = foregroundPgrp(task.slavePathZ(), task.shell_pid);
         }
 
         if (fg_pgrp) |pgrp| {
             log.debug("quit teardown: session {d} agent {s} did not exit gracefully, sending SIGTERM", .{ task.session_idx, task.agent_kind.name() });
             _ = std.c.kill(-pgrp, std.c.SIG.TERM);
-            std.Thread.sleep(quit_term_wait_ms * std.time.ns_per_ms);
+            clock.sleepNanos(quit_term_wait_ms * std.time.ns_per_ms);
         } else {
             log.debug("quit teardown: session {d} agent {s} exited gracefully", .{ task.session_idx, task.agent_kind.name() });
         }
@@ -1334,7 +1335,7 @@ fn sendExitSequence(master_fd: posix.fd_t, agent_kind: session_state.AgentKind) 
             return;
         };
         if (idx + 1 < sequence.len) {
-            std.Thread.sleep(220 * std.time.ns_per_ms);
+            clock.sleepNanos(220 * std.time.ns_per_ms);
         }
     }
     log.debug("quit teardown: wrote exit command for agent {s}", .{agent_kind.name()});
@@ -1358,7 +1359,7 @@ fn drainQuitCaptureOutput(tasks: []const QuitTeardownTask, sessions: []const *Se
         last_capture_lengths[idx] = sessions[task.session_idx].quitCaptureBytes().len;
     }
 
-    const start_ns = std.time.nanoTimestamp();
+    const start_ns = clock.nowNanos();
     var last_growth_ns = start_ns;
 
     while (true) {
@@ -1375,13 +1376,13 @@ fn drainQuitCaptureOutput(tasks: []const QuitTeardownTask, sessions: []const *Se
             last_capture_lengths[idx] = new_len;
         }
 
-        const now_ns = std.time.nanoTimestamp();
+        const now_ns = clock.nowNanos();
         if (saw_growth) {
             last_growth_ns = now_ns;
         }
 
         if (!shouldContinueQuitCaptureDrain(start_ns, last_growth_ns, now_ns)) break;
-        std.Thread.sleep(quit_capture_drain_poll_ns);
+        clock.sleepNanos(quit_capture_drain_poll_ns);
     }
 }
 
@@ -1852,8 +1853,8 @@ pub fn run(log_dir_override: ?[]const u8) !void {
     var next_frame_wait: FrameWaitDecision = .none;
     while (running) {
         var next_event = waitForNextFrame(next_frame_wait);
-        const frame_start_ns: i128 = std.time.nanoTimestamp();
-        const now = std.time.milliTimestamp();
+        const frame_start_ns: i128 = clock.nowNanos();
+        const now = clock.nowMillis();
         if (relaunch_trace_frames > 0) {
             log.info("frame trace start mode={s} grid_resizing={} grid={d}x{d}", .{
                 @tagName(anim_state.mode),
@@ -3412,7 +3413,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
                 log.info("frame trace after render", .{});
             }
             metrics_mod.increment(.frame_count);
-            last_render_ns = std.time.nanoTimestamp();
+            last_render_ns = clock.nowNanos();
         }
 
         if (relaunch_trace_frames > 0) {
@@ -3425,13 +3426,13 @@ pub fn run(log_dir_override: ?[]const u8) !void {
             window_close_suppress_countdown -= 1;
         }
 
-        const frame_end_ns: i128 = std.time.nanoTimestamp();
+        const frame_end_ns: i128 = clock.nowNanos();
         const frame_ns = frame_end_ns - frame_start_ns;
         next_frame_wait = computeFrameWaitDecision(is_idle, sdl.vsync_enabled, frame_ns);
     }
 
     if (builtin.os.tag == .macos) {
-        const now = std.time.milliTimestamp();
+        const now = clock.nowMillis();
         for (sessions) |session| {
             session.updateCwd(now);
         }

--- a/src/clock.zig
+++ b/src/clock.zig
@@ -1,0 +1,62 @@
+const std = @import("std");
+
+/// Wall-clock and elapsed-time reads.
+///
+/// Zig 0.16 removes `std.time.timestamp`, `std.time.milliTimestamp`,
+/// `std.time.nanoTimestamp`, and `std.Thread.sleep`, replacing them with
+/// `std.Io` clock operations that need an `io` context. Centralizing
+/// the reads here keeps that context change out of 27 scattered call sites.
+///
+/// All three reads use the real (wall) clock, matching what the `std.time`
+/// functions did. `nowNanos` is used for frame pacing, which would be better
+/// served by a monotonic clock, but switching it is a behavior change and is
+/// deliberately out of scope for the toolchain migration.
+pub fn nowSeconds() i64 {
+    return std.time.timestamp();
+}
+
+pub fn nowMillis() i64 {
+    return std.time.milliTimestamp();
+}
+
+pub fn nowNanos() i128 {
+    return std.time.nanoTimestamp();
+}
+
+pub fn sleepNanos(nanoseconds: u64) void {
+    std.Thread.sleep(nanoseconds);
+}
+
+test "the three clock reads agree on the same instant" {
+    const secs = nowSeconds();
+    const millis = nowMillis();
+    const nanos = nowNanos();
+
+    // All three read the same wall clock, so they must agree once scaled
+    // down to seconds. A one-second tolerance absorbs a tick landing
+    // between the reads.
+    try std.testing.expectApproxEqAbs(
+        @as(f64, @floatFromInt(secs)),
+        @as(f64, @floatFromInt(@divTrunc(millis, std.time.ms_per_s))),
+        1.0,
+    );
+    try std.testing.expectApproxEqAbs(
+        @as(f64, @floatFromInt(secs)),
+        @as(f64, @floatFromInt(@divTrunc(nanos, std.time.ns_per_s))),
+        1.0,
+    );
+}
+
+test "nowSeconds returns a plausible wall-clock time" {
+    // 2026-01-01T00:00:00Z. Guards against a clock source that returns
+    // uptime or zero instead of Unix time.
+    try std.testing.expect(nowSeconds() > 1_767_225_600);
+}
+
+test "sleepNanos advances the monotonic reading by at least the requested span" {
+    const requested_ns: u64 = 5 * std.time.ns_per_ms;
+    const before = nowNanos();
+    sleepNanos(requested_ns);
+    const elapsed = nowNanos() - before;
+    try std.testing.expect(elapsed >= requested_ns);
+}

--- a/src/logging.zig
+++ b/src/logging.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const fs = std.fs;
+const clock = @import("clock.zig");
 const env = @import("env.zig");
 const time_c = @cImport({
     @cInclude("time.h");
@@ -150,7 +151,7 @@ fn rotateLocked(s: *LoggerState) !void {
 
     var active_path_buf: [fs.max_path_bytes]u8 = undefined;
     const active_path = try buildPath(&active_path_buf, directory_path, active_log_filename);
-    const now_secs = std.time.timestamp();
+    const now_secs = clock.nowSeconds();
     var suffix_buf: [32]u8 = undefined;
     const suffix = try rotationSuffix(now_secs, &suffix_buf);
 
@@ -194,7 +195,7 @@ fn writeRecordLocked(
     if (!force_write and !isEnabled(s.min_level, level)) return;
 
     var timestamp_buf: [32]u8 = undefined;
-    const timestamp = try timestampToLocalIso8601(std.time.timestamp(), &timestamp_buf);
+    const timestamp = try timestampToLocalIso8601(clock.nowSeconds(), &timestamp_buf);
 
     var line_buf: [8192]u8 = undefined;
     const line = blk: {

--- a/src/main.zig
+++ b/src/main.zig
@@ -39,6 +39,7 @@ test {
     _ = @import("app/terminal_actions.zig");
     _ = @import("app/terminal_history.zig");
     _ = @import("cli_args.zig");
+    _ = @import("clock.zig");
     _ = @import("colors.zig");
     _ = @import("config.zig");
     _ = @import("env.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -50,6 +50,7 @@ test {
     _ = @import("metrics.zig");
     _ = @import("pty.zig");
     _ = @import("platform/sdl.zig");
+    _ = @import("proc.zig");
     _ = @import("render/renderer.zig");
     _ = @import("session/notify.zig");
     _ = @import("session/pty_reader.zig");

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const proc = @import("../proc.zig");
 
 const log = std.log.scoped(.open);
 
@@ -56,8 +57,7 @@ pub fn openUrl(_: std.mem.Allocator, url: []const u8) OpenError!void {
 fn openUrlThread(ctx: *ThreadContext) void {
     defer ctx.deinit();
 
-    var child = std.process.Child.init(&ctx.argv, ctx.allocator);
-    _ = child.spawnAndWait() catch |err| {
+    _ = proc.spawnDetached(ctx.allocator, &ctx.argv) catch |err| {
         log.warn("failed to open URL '{s}': {}", .{ ctx.url, err });
         return;
     };

--- a/src/proc.zig
+++ b/src/proc.zig
@@ -1,0 +1,133 @@
+const std = @import("std");
+
+/// Child-process execution.
+///
+/// Zig 0.16 reduces `std.process.Child` to `kill` and `wait`, moving creation
+/// to `std.process.spawn(io, ...)` and the collect-output pattern to
+/// `std.process.run(gpa, io, ...)`. Both need an `io` context. Centralizing the
+/// two shapes Architect actually uses keeps that change out of the call
+/// sites.
+///
+/// `Term` mirrors `std.process.Child.Term` but is declared here with 0.16's
+/// lowercase tag names, so callers' `switch` arms do not change at the
+/// toolchain bump.
+pub const Term = union(enum) {
+    exited: u8,
+    signal: u32,
+    stopped: u32,
+    unknown: u32,
+};
+
+pub const RunResult = struct {
+    term: Term,
+    /// Caller owns this memory.
+    stdout: []u8,
+    /// Caller owns this memory.
+    stderr: []u8,
+};
+
+pub const RunOptions = struct {
+    argv: []const []const u8,
+    cwd: ?[]const u8 = null,
+    max_output_bytes: usize = 4 * 1024 * 1024,
+};
+
+fn fromStdTerm(term: std.process.Child.Term) Term {
+    return switch (term) {
+        .Exited => |code| .{ .exited = code },
+        .Signal => |sig| .{ .signal = sig },
+        .Stopped => |sig| .{ .stopped = sig },
+        .Unknown => |code| .{ .unknown = code },
+    };
+}
+
+/// Runs `argv` to completion, collecting stdout and stderr.
+pub fn run(allocator: std.mem.Allocator, options: RunOptions) !RunResult {
+    var child = std.process.Child.init(options.argv, allocator);
+    child.cwd = options.cwd;
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+
+    try child.spawn();
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    errdefer stdout_buf.deinit(allocator);
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    errdefer stderr_buf.deinit(allocator);
+
+    errdefer {
+        _ = child.kill() catch |err| {
+            std.log.scoped(.proc).warn("failed to stop child after output failure: {}", .{err});
+        };
+    }
+
+    try child.collectOutput(allocator, &stdout_buf, &stderr_buf, options.max_output_bytes);
+    const term = try child.wait();
+
+    const stdout_slice = try stdout_buf.toOwnedSlice(allocator);
+    errdefer allocator.free(stdout_slice);
+    const stderr_slice = try stderr_buf.toOwnedSlice(allocator);
+
+    return .{
+        .term = fromStdTerm(term),
+        .stdout = stdout_slice,
+        .stderr = stderr_slice,
+    };
+}
+
+/// Spawns `argv`, waits for it, and discards its output.
+pub fn spawnDetached(allocator: std.mem.Allocator, argv: []const []const u8) !Term {
+    var child = std.process.Child.init(argv, allocator);
+    return fromStdTerm(try child.spawnAndWait());
+}
+
+test "run collects stdout and reports a zero exit" {
+    const allocator = std.testing.allocator;
+    const result = try run(allocator, .{
+        .argv = &.{ "/bin/sh", "-c", "printf hello" },
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    try std.testing.expectEqualStrings("hello", result.stdout);
+    try std.testing.expectEqual(Term{ .exited = 0 }, result.term);
+}
+
+test "run separates stderr from stdout and reports a nonzero exit" {
+    const allocator = std.testing.allocator;
+    const result = try run(allocator, .{
+        .argv = &.{ "/bin/sh", "-c", "printf out; printf err 1>&2; exit 3" },
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    try std.testing.expectEqualStrings("out", result.stdout);
+    try std.testing.expectEqualStrings("err", result.stderr);
+    try std.testing.expectEqual(Term{ .exited = 3 }, result.term);
+}
+
+test "run honors cwd" {
+    const allocator = std.testing.allocator;
+    const result = try run(allocator, .{
+        .argv = &.{ "/bin/sh", "-c", "pwd" },
+        .cwd = "/",
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    try std.testing.expectEqualStrings("/\n", result.stdout);
+}
+
+test "run surfaces a missing executable as an error rather than a term" {
+    const allocator = std.testing.allocator;
+    try std.testing.expectError(error.FileNotFound, run(allocator, .{
+        .argv = &.{"/nonexistent/architect-test-binary"},
+    }));
+}
+
+test "spawnDetached waits for the child and returns its term" {
+    const allocator = std.testing.allocator;
+    const term = try spawnDetached(allocator, &.{ "/bin/sh", "-c", "exit 7" });
+    try std.testing.expectEqual(Term{ .exited = 7 }, term);
+}

--- a/src/proc.zig
+++ b/src/proc.zig
@@ -57,8 +57,11 @@ pub fn run(allocator: std.mem.Allocator, options: RunOptions) !RunResult {
     errdefer stderr_buf.deinit(allocator);
 
     errdefer {
-        _ = child.kill() catch |err| {
-            std.log.scoped(.proc).warn("failed to stop child after output failure: {}", .{err});
+        _ = child.kill() catch |kill_err| switch (kill_err) {
+            error.AlreadyTerminated => _ = child.wait() catch |wait_err| {
+                std.log.scoped(.proc).warn("failed to reap child after output failure: {}", .{wait_err});
+            },
+            else => std.log.scoped(.proc).warn("failed to stop child after output failure: {}", .{kill_err}),
         };
     }
 
@@ -79,6 +82,9 @@ pub fn run(allocator: std.mem.Allocator, options: RunOptions) !RunResult {
 /// Spawns `argv`, waits for it, and discards its output.
 pub fn spawnDetached(allocator: std.mem.Allocator, argv: []const []const u8) !Term {
     var child = std.process.Child.init(argv, allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Ignore;
+    child.stderr_behavior = .Ignore;
     return fromStdTerm(try child.spawnAndWait());
 }
 

--- a/src/session/notify.zig
+++ b/src/session/notify.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const posix = std.posix;
+const clock = @import("../clock.zig");
 const env = @import("../env.zig");
 const app_state = @import("../app/app_state.zig");
 const atomic = std.atomic;
@@ -200,7 +201,7 @@ pub fn startNotifyThread(
             while (!ctx.stop.load(.seq_cst)) {
                 const conn_fd = posix.accept(fd, null, null, 0) catch |err| switch (err) {
                     error.WouldBlock => {
-                        std.Thread.sleep(std.time.ns_per_ms * 10);
+                        clock.sleepNanos(std.time.ns_per_ms * 10);
                         continue;
                     },
                     else => {

--- a/src/session/pty_reader.zig
+++ b/src/session/pty_reader.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const posix = std.posix;
 const atomic = std.atomic;
+const clock = @import("../clock.zig");
 const grid_layout = @import("../app/grid_layout.zig");
 
 const log = std.log.scoped(.pty_reader);
@@ -271,13 +272,13 @@ fn run(ctx: ReaderContext) void {
                 full_buffer_retry_ns
             else
                 @as(u64, @intCast(poll_timeout_ms)) * std.time.ns_per_ms;
-            std.Thread.sleep(retry_ns);
+            clock.sleepNanos(retry_ns);
             continue;
         }
 
         const ready = posix.poll(pollfds[0..snapshot.count], poll_timeout_ms) catch |err| {
             log.debug("poll failed: {}", .{err});
-            std.Thread.sleep(poll_error_backoff_ns);
+            clock.sleepNanos(poll_error_backoff_ns);
             continue;
         };
         if (ready == 0) continue;
@@ -303,7 +304,7 @@ fn waitForBufferBytes(buffer: *PtyOutputBuffer, timeout_ms: u64) bool {
     var waited_ms: u64 = 0;
     while (waited_ms < timeout_ms) : (waited_ms += 5) {
         if (bufferHasBytes(buffer)) return true;
-        std.Thread.sleep(5 * std.time.ns_per_ms);
+        clock.sleepNanos(5 * std.time.ns_per_ms);
     }
     return bufferHasBytes(buffer);
 }
@@ -529,7 +530,7 @@ test "PtyReader thread drains a pipe into the buffer and posts one wake" {
     try std.testing.expectEqual(@as(usize, 1), wake_count.load(.seq_cst));
 
     _ = try posix.write(fds[1], "pong");
-    std.Thread.sleep(300 * std.time.ns_per_ms);
+    clock.sleepNanos(300 * std.time.ns_per_ms);
     try std.testing.expectEqual(@as(usize, 1), wake_count.load(.seq_cst));
 
     var out: [16]u8 = undefined;
@@ -567,6 +568,6 @@ test "PtyReader.retire prevents any further reads of the fd" {
 
     reader.retire(fds[0]);
     _ = try posix.write(fds[1], "after");
-    std.Thread.sleep(300 * std.time.ns_per_ms);
+    clock.sleepNanos(300 * std.time.ns_per_ms);
     try std.testing.expect(!bufferHasBytes(buffer));
 }

--- a/src/session/state.zig
+++ b/src/session/state.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const posix = std.posix;
 const builtin = @import("builtin");
+const clock = @import("../clock.zig");
 const env = @import("../env.zig");
 const xev = @import("xev");
 const ghostty_vt = @import("ghostty-vt");
@@ -642,7 +643,7 @@ pub const SessionState = struct {
             }
             const was_synchronized_output = self.synchronizedOutputActive();
             try stream.nextSlice(self.output_buf[0..n]);
-            const processed_at_ms = std.time.milliTimestamp();
+            const processed_at_ms = clock.nowMillis();
             self.updateSynchronizedOutputState(was_synchronized_output, processed_at_ms);
             self.markDirty();
 
@@ -1166,7 +1167,7 @@ test "checkAlive skips waitpid polling when a process watcher owns exit detectio
     }
     defer _ = std.c.waitpid(pid, null, 0);
     // Give the forked child a moment to exit and become reapable.
-    std.Thread.sleep(50 * std.time.ns_per_ms);
+    clock.sleepNanos(50 * std.time.ns_per_ms);
 
     const pipe_fds = try posix.pipe();
     // pty.deinit() only closes the master fd; close the slave ourselves.

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -3,6 +3,7 @@
 const std = @import("std");
 const assets = @import("assets");
 const posix = std.posix;
+const clock = @import("clock.zig");
 const env = @import("env.zig");
 const pty_mod = @import("pty.zig");
 const libc = @cImport({
@@ -1127,7 +1128,7 @@ pub const Shell = struct {
                     if (waited_ns >= max_wait_ns) {
                         return if (written > 0) written else err;
                     }
-                    std.Thread.sleep(backoff_ns);
+                    clock.sleepNanos(backoff_ns);
                     waited_ns += backoff_ns;
                     continue;
                 },

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -5,6 +5,7 @@ const assets = @import("assets");
 const posix = std.posix;
 const clock = @import("clock.zig");
 const env = @import("env.zig");
+const proc = @import("proc.zig");
 const pty_mod = @import("pty.zig");
 const libc = @cImport({
     @cInclude("stdlib.h");
@@ -1182,12 +1183,8 @@ test "bundled terminfo compiles to legacy short-int format" {
 
     const tic_path = findExecutableInPath("tic") orelse return error.SkipZigTest;
 
-    var child = std.process.Child.init(&.{ tic_path, "-x", "-o", tmp_path, src_path }, allocator);
-    child.stdin_behavior = .Ignore;
-    child.stdout_behavior = .Ignore;
-    child.stderr_behavior = .Ignore;
-    const term = try child.spawnAndWait();
-    try testing.expectEqual(std.process.Child.Term{ .Exited = 0 }, term);
+    const term = try proc.spawnDetached(allocator, &.{ tic_path, "-x", "-o", tmp_path, src_path });
+    try testing.expectEqual(proc.Term{ .exited = 0 }, term);
 
     // tic stores the compiled entry in either `78/xterm-ghostty` (hashed,
     // modern ncurses default) or `x/xterm-ghostty` (legacy single-char), so try

--- a/src/ui/components/diff_overlay.zig
+++ b/src/ui/components/diff_overlay.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const c = @import("../../c.zig");
 const geom = @import("../../geom.zig");
+const proc = @import("../../proc.zig");
 const primitives = @import("../../gfx/primitives.zig");
 const types = @import("../types.zig");
 const UiComponent = @import("../component.zig").UiComponent;
@@ -122,7 +123,7 @@ const Cache = struct {
 const GitResult = struct {
     stdout: []u8,
     stderr: []u8,
-    term: std.process.Child.Term,
+    term: proc.Term,
 };
 
 pub const DiffOverlayComponent = struct {
@@ -547,55 +548,23 @@ pub const DiffOverlayComponent = struct {
     }
 
     fn runGitCommand(self: *DiffOverlayComponent, cwd: []const u8, argv: []const []const u8) !GitResult {
-        var child = std.process.Child.init(argv, self.allocator);
-        child.cwd = cwd;
-        child.stdout_behavior = .Pipe;
-        child.stderr_behavior = .Pipe;
-
-        child.spawn() catch |err| {
-            log.warn("failed to spawn git command: {}", .{err});
-            return error.SpawnFailed;
-        };
-
-        var stdout = std.ArrayList(u8).initCapacity(self.allocator, 1024) catch |err| {
-            log.warn("failed to allocate stdout buffer: {}", .{err});
-            return error.OutputAllocFailed;
-        };
-        errdefer stdout.deinit(self.allocator);
-        var stderr = std.ArrayList(u8).initCapacity(self.allocator, 256) catch |err| {
-            log.warn("failed to allocate stderr buffer: {}", .{err});
-            return error.OutputAllocFailed;
-        };
-        errdefer stderr.deinit(self.allocator);
-
-        child.collectOutput(self.allocator, &stdout, &stderr, max_output_bytes) catch |err| {
-            log.warn("failed to collect git command output: {}", .{err});
-            const terminate = child.kill() catch |kill_err| switch (kill_err) {
-                error.AlreadyTerminated => child.wait() catch |wait_err| {
-                    log.warn("failed to wait on git command: {}", .{wait_err});
-                    return error.WaitFailed;
-                },
-                else => {
-                    log.warn("failed to terminate git command: {}", .{kill_err});
-                    return error.TerminateFailed;
-                },
-            };
-            _ = terminate;
+        const result = proc.run(self.allocator, .{
+            .argv = argv,
+            .cwd = cwd,
+            .max_output_bytes = max_output_bytes,
+        }) catch |err| {
+            log.warn("failed to run git command: {}", .{err});
             return switch (err) {
                 error.StdoutStreamTooLong, error.StderrStreamTooLong => error.OutputTooLarge,
+                error.OutOfMemory => error.OutputAllocFailed,
                 else => error.ReadFailed,
             };
         };
 
-        const term = child.wait() catch |err| {
-            log.warn("failed to wait on git command: {}", .{err});
-            return error.WaitFailed;
-        };
-
         return .{
-            .stdout = try stdout.toOwnedSlice(self.allocator),
-            .stderr = try stderr.toOwnedSlice(self.allocator),
-            .term = term,
+            .stdout = result.stdout,
+            .stderr = result.stderr,
+            .term = result.term,
         };
     }
 
@@ -609,7 +578,7 @@ pub const DiffOverlayComponent = struct {
 
     fn gitExitErrorText(_: *DiffOverlayComponent, result: GitResult) ?[]const u8 {
         return switch (result.term) {
-            .Exited => |code| if (code == 0)
+            .exited => |code| if (code == 0)
                 null
             else if (result.stderr.len > 0)
                 result.stderr

--- a/src/ui/components/pr_dropdown_fetch.zig
+++ b/src/ui/components/pr_dropdown_fetch.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const model = @import("pr_dropdown_model.zig");
+const proc = @import("../../proc.zig");
 
 const log = std.log.scoped(.pr_dropdown);
 pub const gh_output_log_preview_limit: usize = 2 * 1024;
@@ -15,12 +16,10 @@ pub fn runGhPrList(allocator: std.mem.Allocator, cwd: []const u8) model.FetchRes
         "--state", "open",   "--limit",
         "30",      "--json", "number,title,headRefName",
     };
-    var child = std.process.Child.init(&argv, allocator);
-    child.cwd = cwd;
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
-
-    child.spawn() catch |err| {
+    const result = proc.run(allocator, .{
+        .argv = &argv,
+        .cwd = cwd,
+    }) catch |err| {
         if (err == error.FileNotFound) {
             log.err("gh CLI not found while listing pull requests: cwd={s}", .{cwd});
             return model.FetchResult{
@@ -32,38 +31,15 @@ pub fn runGhPrList(allocator: std.mem.Allocator, cwd: []const u8) model.FetchRes
         log.err("failed to launch gh while listing pull requests: cwd={s} error={s}", .{ cwd, @errorName(err) });
         return buildFetchError(allocator, "Failed to launch gh: {s}", .{@errorName(err)});
     };
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
 
-    var stdout_buf = std.ArrayList(u8).initCapacity(allocator, 4096) catch {
-        log.err("failed to allocate gh stdout buffer: cwd={s}", .{cwd});
-        _ = child.kill() catch |err| log.warn("failed to stop gh after stdout allocation failure: {}", .{err});
-        return buildFetchError(allocator, "Out of memory reading gh output", .{});
-    };
-    defer stdout_buf.deinit(allocator);
-    var stderr_buf = std.ArrayList(u8).initCapacity(allocator, 256) catch {
-        log.err("failed to allocate gh stderr buffer: cwd={s}", .{cwd});
-        _ = child.kill() catch |err| log.warn("failed to stop gh after stderr allocation failure: {}", .{err});
-        return buildFetchError(allocator, "Out of memory reading gh output", .{});
-    };
-    defer stderr_buf.deinit(allocator);
-
-    child.collectOutput(allocator, &stdout_buf, &stderr_buf, 4 * 1024 * 1024) catch |err| {
-        log.err("failed to collect gh output: cwd={s} error={s}", .{ cwd, @errorName(err) });
-        _ = child.kill() catch |kill_err| log.warn("failed to stop gh after output failure: {}", .{kill_err});
-        _ = child.wait() catch |wait_err| log.warn("failed to reap gh after output failure: {}", .{wait_err});
-        return buildFetchError(allocator, "Failed to read gh output: {s}", .{@errorName(err)});
-    };
-
-    const term = child.wait() catch |err| {
-        log.err("failed to wait for gh: cwd={s} error={s}", .{ cwd, @errorName(err) });
-        return buildFetchError(allocator, "Failed to wait for gh: {s}", .{@errorName(err)});
-    };
-
-    switch (term) {
-        .Exited => |code| {
+    switch (result.term) {
+        .exited => |code| {
             if (code != 0) {
-                const stderr_msg = std.mem.trim(u8, stderr_buf.items, " \t\r\n");
+                const stderr_msg = std.mem.trim(u8, result.stderr, " \t\r\n");
                 log.err("gh pr list failed: cwd={s} exit_code={d}", .{ cwd, code });
-                logGhOutputPreview("stderr", stderr_buf.items);
+                logGhOutputPreview("stderr", result.stderr);
                 if (stderr_msg.len > 0) {
                     return buildFetchError(allocator, "gh exited {d}: {s}", .{ code, stderr_msg });
                 }
@@ -76,15 +52,15 @@ pub fn runGhPrList(allocator: std.mem.Allocator, cwd: []const u8) model.FetchRes
         },
     }
 
-    const result = parseGhJson(allocator, stdout_buf.items);
-    if (result.status == .failed) {
+    const fetch_result = parseGhJson(allocator, result.stdout);
+    if (fetch_result.status == .failed) {
         log.err("gh PR list processing failed: cwd={s} error={s}", .{
             cwd,
-            result.error_message orelse "unknown parsing error",
+            fetch_result.error_message orelse "unknown parsing error",
         });
-        logGhOutputPreview("stdout", stdout_buf.items);
+        logGhOutputPreview("stdout", result.stdout);
     }
-    return result;
+    return fetch_result;
 }
 
 fn logGhOutputPreview(comptime stream_name: []const u8, bytes: []const u8) void {


### PR DESCRIPTION
## Issue
Complete Task 4 of the staged Zig 0.16 migration plan: centralize the 13 timestamp reads and 14 sleep calls while retaining Zig 0.15.2 compatibility.

Continue the same Prep 3 PR with Task 5: centralize subprocess execution while retaining Zig 0.15.2 compatibility.

## Solution
- Add `src/clock.zig` with wall-clock and sleep accessors plus focused tests.
- Register the new test file in `src/main.zig`.
- Route all specified timestamp and sleep call sites through `clock`.
- Add the clock module to the standalone MCP control module in `build.zig`, required because `src/app/control.zig` imports `../clock.zig` and is compiled as its own module.
- Add `src/proc.zig` with `run` and `spawnDetached` wrappers, focused subprocess tests, and the lowercase `proc.Term` representation required by the Zig 0.16 migration.
- Register `proc.zig` in the test registry and route URL opening, config-editor launch, PR listing, diff execution, and shell terminfo compilation through it.
- Mark completed items under Steps 4 and 5 in the migration plan.

## Context
This is the third prep commit sequence for the migration. The wrappers intentionally retain `std.time` and `std.Thread.sleep` internals until the later Zig 0.16 `std.Io` conversion. No behavior change is intended.

The subprocess wrapper intentionally sets `stdin_behavior = .Ignore`, matching the behavior hardcoded by Zig 0.16 `std.process.run`; neither `gh pr list` nor `git diff` reads stdin.

## Test plan
- `zig build` — passed with directly installed Zig 0.15.2.
- `zig build test` — passed unpiped with directly installed Zig 0.15.2.
- `just lint` — passed, including test registry validation.
- `zig fmt src/` and `git diff --check` — passed.
- Timestamp/sleep inventory checks — no old call sites remain outside `src/clock.zig`.
- Subprocess inventory checks — no `std.process.Child` call sites remain outside `src/proc.zig`, and no uppercase term tags remain at callers.
- Nix is unavailable in this Linux sandbox, so the equivalent directly installed Zig/just commands were used; CI with the project Nix environment is authoritative for that environment.
- The plan Step 11 manual/macOS-only verification was not performed: layout animation smoothness, ISO-8601 log output/rotation, and quit shimmer timing require a human on a supported graphical/macOS environment (or suitable CI coverage). These are explicitly left for follow-up verification and are not claimed here.
- Step 5 Step 14 manual verification was not performed in this Linux sandbox: run `zig build run` in a repository with open pull requests and confirm ⌘P populates the PR dropdown; open the diff overlay and confirm the diff renders; click a terminal URL and confirm it opens in the browser; trigger open config and confirm the editor launches; and remove `gh` from `PATH` to confirm the PR dropdown shows its missing-`gh` state.