### PR TITLE
build: migrate Architect to Zig 0.16.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 **Name:** Architect
 **Description:** A terminal multiplexer and AI-assisted coding environment built on SDL3 and Zig. Architect lets developers run multiple terminal sessions in a tiled layout, annotate diffs, and integrate Claude agents directly into their workflow.
-**Stack:** Zig 0.15, SDL3, ghostty-vt (terminal emulation), Nix dev shell, `just` task runner
+**Stack:** Zig 0.16, SDL3, ghostty-vt (terminal emulation), Nix dev shell, `just` task runner
 **Status:** Active development
 
 ## Build & Run
@@ -180,10 +180,17 @@ const result = grid_row * GRID_COLS + grid_col;  // usize, works correctly
 ### Naming collisions in large render functions
 - When hoisting shared locals (e.g., `cursor`) to wider scopes inside long functions, avoid re-declaring them later with the same name. Zig treats this as shadowing and fails compilation. Prefer a single binding per logical value or choose distinct names for nested scopes to prevent "local constant shadows" errors.
 
-### Zig 0.15 collection API differences
-- `std.ArrayList(T)`: Zig 0.15 only provides `initCapacity(allocator, n)`, not `init()`. When initializing, use a reasonable capacity estimate (e.g., 8 or 16) rather than 0—`initCapacity(allocator, 0)` still allocates and is wasteful. For truly lazy allocation, use `.empty` and pass the allocator on each operation. Methods like `append` require the allocator argument (`list.append(allocator, item)`).
-- `std.fmt.allocPrintZ` is unavailable; create a null-terminated buffer manually: allocate `len+1`, copy bytes, set the last byte to 0, and slice as `buf[0..len :0]`.
-- For writers, `toml.serialize` expects `*std.Io.Writer`. Use `std.Io.Writer.Allocating.init(allocator)` (or `initCapacity`) and pass `&writer.writer`; read bytes with `writer.written()`.
+### Zig 0.16 API notes
+- `std.ArrayList(T)` is the unmanaged list: init with `.empty` (or `initCapacity`), and pass the allocator to each method (`list.append(allocator, item)`). `std.ArrayListUnmanaged` is a deprecated alias — do not use it.
+- `std.fs` retains only `path`, `max_path_bytes`, `max_name_bytes`, and the base64 alphabets. Every filesystem operation moved to `std.Io.Dir` / `std.Io.File` and takes an `io` argument. Two irregularities to remember: `Dir.renameAbsolute(old, new, io)` takes `io` **last**, and `makeDirAbsolute`/`makePath` were renamed to `createDirAbsolute`/`createDirPath` rather than merely gaining a parameter.
+- `std.time` retains only its duration constants. Timestamps come from `clock.zig`, which wraps `std.Io.Timestamp.now(io, .real)`. The clock enum tags are `real`, `awake`, `boot`, `cpu_process`, `cpu_thread`.
+- `std.Thread.spawn`/`join`/`detach` survive; `std.Thread.Mutex`, `Condition`, `Pool`, `WaitGroup`, and `sleep` do not. Use `std.Io.Mutex` / `std.Io.Condition`, initialized with `.init` (not `.{}`), and prefer `lockUncancelable`/`waitUncancelable` — Architect has no cancellation model, so a fallible lock adds error paths with no correct recovery.
+- `std.process.Child` keeps only `kill(io)` and `wait(io)`. Creation is `std.process.spawn(io, opts)`; the collect-output pattern is `std.process.run(gpa, io, opts)`. `Child.Term` tags are lowercase (`.exited`, `.signal`, `.stopped`, `.unknown`) and `signal` carries `std.posix.SIG`, not `u32`. Use `src/proc.zig` for the application process helpers.
+- Link and include configuration lives on `std.Build.Module`, not `std.Build.Step.Compile`. `link_libc` is a Module field, settable in `b.createModule`.
+- `std.posix.getenv` is gone. Read the environment through `src/env.zig`.
+
+### Inventory greps for std API migrations
+`const fs = std.fs;` and `const posix = std.posix;` aliases hide call sites from a `std.`-qualified grep — this cost real time during the 0.16 migration. Always match `\b(std\.)?fs\.` and `\b(std\.)?posix\.`. When excluding survivors, put the underscore in the character class: `fs\.[A-Za-z]+` truncates `fs.max_path_bytes` to `fs.max` and lets it slip past the filter.
 
 ### Loop boundary conditions
 When iterating over slices with index arithmetic, use `< len` not `<= len`:
@@ -209,7 +216,7 @@ The `<= len` pattern is only correct when `pos` represents a position *after* pr
 - User config lives in `~/.config/architect/config.toml`. Maintain compatibility or add migrations when changing config shape.
 - `just` commands mirror zig builds (`just build`, `just run`, `just test`, `just ci`); use them when adjusting CI scripts or docs.
 - Shells spawn as login shells (`zsh -l`), so login profiles (`/etc/zprofile`, `~/.zprofile`) are sourced; nix-darwin `environment.shellAliases` end up in the generated `/etc/zprofile`, which is the place to check when aliases or env values are missing inside Architect.
-- On macOS hosts where `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk` is arm64e-only, the Nix dev shell auto-applies a Zig 0.15.2 workaround: it points `DEVELOPER_DIR` at a fake developer dir backed by `MacOSX15.4.sdk` and installs an `xcrun` shim inside that fake developer tree so `zig build`, Ghostty's Apple SDK discovery, and unrelated tools that still invoke `/usr/bin/xcrun` keep working. Remove it once Zig's fix for https://codeberg.org/ziglang/zig/issues/31756 is no longer needed here.
+- On macOS hosts where `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk` is arm64e-only, the Nix dev shell retains the Zig 0.16.0 workaround: it points `DEVELOPER_DIR` at a fake developer dir backed by `MacOSX15.4.sdk` and installs an `xcrun` shim inside that fake developer tree so `zig build`, Ghostty's Apple SDK discovery, and unrelated tools that still invoke `/usr/bin/xcrun` keep working. Keep it until a macOS host confirms the upstream fix for https://codeberg.org/ziglang/zig/issues/31756 makes it unnecessary.
 - Shared UI/render utilities live in `src/geom.zig` (Rect + point containment), `src/anim/easing.zig` (easing), `src/gfx/primitives.zig` (rounded/thick borders), and `src/gfx/shimmer.zig` (busy shimmer used by the quit overlay); reuse them instead of duplicating helpers.
 - The UI overlay pipeline is centralized in `src/ui/`—`UiRoot` receives events before `main`'s switch, runs per-frame `update`, drains `UiAction`s, and renders after the scene; register new components there rather than adding more UI logic to `main.zig`.
 - Reusable marquee text rendering lives in `src/ui/components/marquee_label.zig`; use it instead of re-implementing scroll logic.
@@ -219,9 +226,11 @@ The `<= len` pattern is only correct when `pos` represents a position *after* pr
 - Overlays built on `ExpandingOverlay` must gate keyboard input and toggles on `state.isOpenOrOpening()`, never on `state == .Open`: the expand animation lasts ~200 ms, and keys typed during it otherwise fall through to the focused terminal.
 - Static text badges (the collapsed `⌘O`/`⌘T`/`⌘?` overlay hints) must use `src/ui/components/glyph_badge.zig`. Never create-render-destroy an SDL texture within a single frame: destroying a texture that was queued for rendering forces SDL's Metal backend to flush the command queue and block on drawable acquisition (up to ~1 s under load). Cache textures and invalidate on font/theme changes.
 - Cursor rendering: set the cursor's background color during the per-cell background pass and render the glyph on top; avoid drawing a separate cursor rectangle after text rendering, which hides the underlying glyph.
-- ghostty-vt defaults: `Terminal.Options.max_scrollback` is 10_000 bytes and `0` disables scrollback entirely; set it explicitly when you expect deeper history. Ghostty's app sets 10 MB via `scrollback-limit` in Config.zig; upstream currently doesn't support unlimited scrollback. Use bytes, not lines, when sizing scrollback.
+- ghostty-vt defaults: `Terminal.Options.max_scrollback_bytes` is 10_000 bytes and `0` disables scrollback entirely; set it explicitly when you expect deeper history. Ghostty's app sets 10 MB via `scrollback-limit` in Config.zig; upstream currently doesn't support unlimited scrollback. Use bytes, not lines, when sizing scrollback.
 
 ## Architecture Invariants (agent instructions)
+- `io: std.Io` is threaded explicitly, as a struct field immediately after `allocator` or a parameter immediately after `allocator`. Never store it in a module-level variable. Structs whose threads outlive the spawner must store their own copy.
+- `src/env.zig` is the only sanctioned module-level accessor in the codebase, because `std.Io` exposes no environment surface and the process environment is global and immutable. Do not add others.
 - Route UI input/rendering through `UiRoot` only; do not add new UI event branches or rendering in `main.zig` or `renderer.zig`.
 - Keep scene rendering (`renderer.zig`) focused on terminals/scene overlays; UI components belong in `src/ui/components/` and render after `renderer.render(...)`.
 - Do not store UI state or UI textures in session structs or `app_state.zig`; UI state must live inside UI components or UI-managed assets.

--- a/build.zig
+++ b/build.zig
@@ -100,12 +100,12 @@ pub fn build(b: *std.Build) void {
         }
     }
 
-    if (b.graph.env_map.get("SDL3_INCLUDE_PATH")) |sdl3_include| {
+    if (b.graph.environ_map.get("SDL3_INCLUDE_PATH")) |sdl3_include| {
         exe_mod.addIncludePath(.{ .cwd_relative = sdl3_include });
         const lib_path = b.fmt("{s}/../lib", .{sdl3_include});
         exe_mod.addLibraryPath(.{ .cwd_relative = lib_path });
     }
-    if (b.graph.env_map.get("SDL3_TTF_INCLUDE_PATH")) |sdl3_ttf_include| {
+    if (b.graph.environ_map.get("SDL3_TTF_INCLUDE_PATH")) |sdl3_ttf_include| {
         exe_mod.addIncludePath(.{ .cwd_relative = sdl3_ttf_include });
         const ttf_lib_path = b.fmt("{s}/../lib", .{sdl3_ttf_include});
         exe_mod.addLibraryPath(.{ .cwd_relative = ttf_lib_path });
@@ -159,7 +159,7 @@ pub fn build(b: *std.Build) void {
 // Prefer the active developer selection over hardcoded SDK locations so
 // macOS SDK overrides in the dev shell stay local to the environment.
 fn findSdkRoot(b: *std.Build) ?[]const u8 {
-    if (b.graph.env_map.get("SDKROOT")) |sdk_root| {
+    if (b.graph.environ_map.get("SDKROOT")) |sdk_root| {
         return sdk_root;
     }
 
@@ -167,7 +167,7 @@ fn findSdkRoot(b: *std.Build) ?[]const u8 {
         return sdk_root;
     }
 
-    if (findXcrunSdkRoot(b.allocator)) |sdk_root| {
+    if (findXcrunSdkRoot(b.allocator, b.graph.io)) |sdk_root| {
         return sdk_root;
     }
 
@@ -177,7 +177,7 @@ fn findSdkRoot(b: *std.Build) ?[]const u8 {
     };
 
     for (candidates) |candidate| {
-        if (sdkExists(candidate)) {
+        if (sdkExists(b.graph.io, candidate)) {
             return candidate;
         }
     }
@@ -186,14 +186,14 @@ fn findSdkRoot(b: *std.Build) ?[]const u8 {
 }
 
 fn findDeveloperDirSdkRoot(b: *std.Build) ?[]const u8 {
-    const developer_dir = b.graph.env_map.get("DEVELOPER_DIR") orelse return null;
+    const developer_dir = b.graph.environ_map.get("DEVELOPER_DIR") orelse return null;
     const candidates = [_][]const u8{
         b.fmt("{s}/SDKs/MacOSX.sdk", .{developer_dir}),
         b.fmt("{s}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk", .{developer_dir}),
     };
 
     for (candidates) |candidate| {
-        if (sdkExists(candidate)) {
+        if (sdkExists(b.graph.io, candidate)) {
             return candidate;
         }
     }
@@ -201,15 +201,14 @@ fn findDeveloperDirSdkRoot(b: *std.Build) ?[]const u8 {
     return null;
 }
 
-fn findXcrunSdkRoot(allocator: std.mem.Allocator) ?[]const u8 {
-    const result = std.process.Child.run(.{
-        .allocator = allocator,
+fn findXcrunSdkRoot(allocator: std.mem.Allocator, io: std.Io) ?[]const u8 {
+    const result = std.process.run(allocator, io, .{
         .argv = &.{ "xcrun", "--sdk", "macosx", "--show-sdk-path" },
     }) catch return null;
     defer allocator.free(result.stderr);
 
     switch (result.term) {
-        .Exited => |code| if (code != 0) {
+        .exited => |code| if (code != 0) {
             allocator.free(result.stdout);
             return null;
         },
@@ -219,7 +218,7 @@ fn findXcrunSdkRoot(allocator: std.mem.Allocator) ?[]const u8 {
         },
     }
 
-    const trimmed = std.mem.trimRight(u8, result.stdout, "\r\n");
+    const trimmed = std.mem.trimEnd(u8, result.stdout, "\r\n");
     if (trimmed.len == 0) {
         allocator.free(result.stdout);
         return null;
@@ -232,10 +231,10 @@ fn findXcrunSdkRoot(allocator: std.mem.Allocator) ?[]const u8 {
     return allocator.dupe(u8, trimmed) catch null;
 }
 
-fn sdkExists(path: []const u8) bool {
-    if (std.fs.openDirAbsolute(path, .{})) |dir_const| {
+fn sdkExists(io: std.Io, path: []const u8) bool {
+    if (std.Io.Dir.openDirAbsolute(io, path, .{})) |dir_const| {
         var dir = dir_const;
-        dir.close();
+        dir.close(io);
         return true;
     } else |_| {
         return false;

--- a/build.zig
+++ b/build.zig
@@ -39,8 +39,14 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    const posix_util_mod = b.createModule(.{
+        .root_source_file = b.path("src/posix_util.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
     control_mod.addImport("../env.zig", env_mod);
     control_mod.addImport("../clock.zig", clock_mod);
+    control_mod.addImport("../posix_util.zig", posix_util_mod);
     mcp_mod.addImport("control", control_mod);
     const assets_mod = b.createModule(.{
         .root_source_file = b.path("assets/terminfo.zig"),

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,19 +2,19 @@
     .name = .architect,
     .version = "0.1.0",
     .fingerprint = 0x3a466a9634a65f7c,
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .ghostty = .{
-            .url = "https://github.com/ghostty-org/ghostty/archive/refs/tags/v1.3.1.tar.gz",
-            .hash = "ghostty-1.3.1-5UdBCwYm-gQeBa4bu1-sMooCQS4KVriv5wWSIJ_sI-Cb",
+            .url = "https://github.com/ghostty-org/ghostty/archive/76e568b475fe88f5506be33ad1a684f3c1eae85e.tar.gz",
+            .hash = "ghostty-1.3.2-dev-5UdBCzxaYAWrMeK4x7Kpz8hshXz6zm_SB1KdCFoLB6Lf",
         },
         .libxev = .{
-            .url = "https://deps.files.ghostty.org/libxev-34fa50878aec6e5fa8f532867001ab3c36fae23e.tar.gz",
-            .hash = "libxev-0.0.0-86vtc4IcEwCqEYxEYoN_3KXmc6A9VLcm22aVImfvecYs",
+            .url = "https://deps.files.ghostty.org/libxev-9ce8e8e6ff89e583258a7f8e7adeeeaeae8611bf.tar.gz",
+            .hash = "libxev-0.0.0-86vtcwIRFADbH4hk-EjROXxlrKIRPQdA41XiTSytYO-F",
         },
         .toml = .{
-            .url = "https://github.com/sam701/zig-toml/archive/cf50bd59c6276fb2b6d34b8d71d35486eecc719c.tar.gz",
-            .hash = "toml-0.3.0-bV14Bd-EAQBKoXhpYft303BtA2vgLNlxntUCIWgRUl46",
+            .url = "https://github.com/sam701/zig-toml/archive/8685923e32e8b8a795eb2715684236975a70faed.tar.gz",
+            .hash = "toml-0.3.0-bV14BRmKAQAWR0FT0KUKFwVJTImaFhWjSe6HfSMtNZOH",
         },
         .zwanzig = .{
             .url = "https://github.com/forketyfork/zwanzig/archive/refs/tags/v0.15.1.tar.gz",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,7 +45,7 @@ graph TD
     end
 
     subgraph Shared Utilities
-        SHARED["geom, colors, dpi, config,<br/>logging, url_matcher, metrics, os/open"]
+        SHARED["geom, colors, dpi, config, env, clock, proc,<br/>logging, url_matcher, metrics, os/open"]
     end
 
     MAIN --> RT
@@ -91,6 +91,7 @@ Platform    Session    Rendering    UI Overlay
 **Invariants:**
 - Session, Rendering, and UI Overlay layers never import from each other directly. All cross-layer communication flows through the Application layer or shared types.
 - UI components communicate with the application exclusively via the `UiAction` queue (never direct state mutation).
+- `main(init: std.process.Init)` passes `init.io` to `runtime.run(io, ...)`, which threads it through the application, session, and UI layers. I/O-owning structs store it beside their allocator; worker contexts copy it when their thread outlives the spawner.
 - Background threads are intentionally limited to four cases: the notification socket listener (`session/notify.zig`), the local control socket listener (`app/control.zig`), the PTY reader (`session/pty_reader.zig`), and a quit-time agent-teardown worker in `app/runtime.zig`. They communicate completion/state back to the main thread through thread-safe primitives. The notification listener, control listener, and PTY reader also post a custom SDL wake event after queueing work or draining PTY bytes, so the frame loop breaks out of `SDL_WaitEventTimeout(...)` promptly during both idle and active-frame pacing. The PTY reader polls the master fds of all spawned sessions with a ~100ms timeout and, when one becomes readable, drains it into that session's mutex-guarded ring buffer (`PtyOutputBuffer`, 1 MiB) — so producer processes are never backpressured by render pacing, and DEC-2026 sync windows close in the buffer as fast as the producer writes them. Sessions register their fd+buffer on spawn and retire it during teardown; reads happen only under the registry mutex, so `retire()` returning guarantees the reader can no longer touch the fd or buffer. The main thread's `processOutput` consumes from the buffer (VT parsing stays main-thread-only) and clears a shared `wake_pending` flag at the top of each frame; the reader posts at most one SDL wake event per frame via that flag.
 - Shutdown order is UI-first for teardown dependencies: `UiRoot.deinit()` runs before session teardown so components that reference sessions are released while session memory is still valid.
 - Runtime uses a one-shot teardown guard around UI cleanup so mixed `errdefer`/`defer` error unwind paths cannot deinitialize `UiRoot` twice.
@@ -99,7 +100,7 @@ Platform    Session    Rendering    UI Overlay
 - Font reload paths are transactional: acquire both replacement fonts first, then swap and destroy old fonts, so a partial reload failure cannot leave deinit hooks pointing at already-freed font resources.
 - Window-resize scale handling follows a single ordered path (`reload-if-needed`, then `resize`) to keep behavior consistent between changed-scale and unchanged-scale events.
 - Terminal resizes use Ghostty's minimal flow: a single `ioctl(master, TIOCSWINSZ)` on the PTY master, which the kernel pairs with a SIGWINCH to the foreground process group of the slave's controlling terminal. Each session is sized independently. The focused session in `.Full`/`.Expanding`/`.Collapsing` mode (and additionally the previous session during a panning transition) is sized to the full-window cell count; every other session stays at grid-cell size. Grid↔full view toggle therefore reflows exactly one session — the one the user actually zoomed — instead of every session in the workspace. Window resize, font size change, and grid layout change all flow through the same per-session dispatch (`fullSetForMode` in `app/runtime.zig`, `applyTerminalResize` with `Sizes`/`FullSet` in `app/layout.zig`). Grid sizing accounts for the user's grid font scale and the reserved CWD-bar space when computing tile cell count. When an application enables DEC mode 40 and switches DECCOLM (`\e[?3h`/`\e[?3l`), `applyTerminalResize` preserves the ghostty-vt logical 80/132-column width while the Architect layout target column count is unchanged; row and pixel-size changes still update the terminal model, and DEC 2048 in-band size reports use that logical model size with the latest pixel fields. A target column-count change resets the model to the computed grid/full size. While DEC mode 2026 (`\e[?2026h`) is active for a session, the renderer reuses the last cached texture for that session via `synchronizedOutputHoldsCache` in `render/renderer.zig` instead of refreshing from the in-progress vt model, so reflows from agents like Codex appear as one atomic frame change rather than a top-to-bottom rescroll. The hold is dropped when the cached composition mismatches the requested one (an overlay or wave needs to bake into the next frame) or when the app sends the closing `\e[?2026l`; the next frame after the close refreshes once and snaps to the final state. A timeout-based safety net in `session/state.zig` force-clears the mode if a session leaves `\e[?2026h` set without ever closing it. Beyond that per-batch 2026 hold, a resize is not hidden or animated in any way: the repaint an app performs in response to SIGWINCH renders live, frame by frame, exactly as it does in Ghostty. Agents differ widely in how they answer a resize — Claude repaints in a single burst that is over within tens of milliseconds, while codex erases its scrollback and re-prints its transcript tail as a paced multi-second stream — and that difference is the agent's behavior to own, not the terminal's to conceal. Architect deliberately carries no resize-settle hold, freeze, or sweep-reveal transition: an earlier implementation froze the pre-resize texture until output went quiet and then swept the new layout in, which cost a mandatory ~1.8 s of animation on every grid↔full toggle (a 400 ms silence debounce plus a 1400 ms sweep) to hide a repaint that fast agents had already finished, and which re-triggered on ordinary scrollback output because "a large output chunk shortly after a resize" cannot distinguish a repaint wave from the user simply scrolling. Showing the truth immediately is both simpler and more honest about what the app is doing.
-- Shared Utilities (`geom`, `colors`, `dpi`, `config`, `logging`, `metrics`, etc.) may be imported by any layer but never import from layers above them.
+- Shared Utilities (`geom`, `colors`, `dpi`, `config`, `env`, `clock`, `proc`, `logging`, `metrics`, etc.) may be imported by any layer but never import from layers above them. `env.zig` is the process-environment accessor, `clock.zig` supplies I/O-aware timestamps and sleep, and `proc.zig` wraps I/O-aware process execution.
 - **Exception:** `app/*` modules may import `c.zig` directly for SDL type definitions used in input handling. This is a pragmatic shortcut for FFI constants, not a general license to depend on the Platform layer.
 
 ## Rules for New Code
@@ -133,6 +134,19 @@ These patterns are mandatory for all new code. They are derived from the archite
 | Add external control of app state   | `app/control.zig` + a runtime drain handler in `app/runtime.zig` |
 
 ## Data Flow
+
+### I/O Carrier
+
+```
+main(init: std.process.Init)
+    | init.io
+    v
+runtime.run(io, ...)
+    | explicit parameter or stored field
+    +--> application and session layers
+    +--> UI components that perform I/O
+    +--> copied into worker-thread contexts
+```
 
 ### Frame Loop (per frame, ~16ms active / ~50ms idle)
 
@@ -434,9 +448,9 @@ Rotate: rename active file to architect-<UTC timestamp>.log and continue in new 
 
 | Module | Responsibility | Public API (key functions/types) | Dependencies |
 |--------|---------------|----------------------------------|--------------|
-| `main.zig` | Thin entrypoint + global logging hook registration | `main()`, `std_options.logFn` | `app/runtime`, `logging` |
-| `mcp/main.zig` | Separate `architect-mcp` stdio MCP server. Handles JSON-RPC lifecycle methods and exposes the single `spawn_session` tool. | `main()`, `run()` | `app/control` module import, std |
-| `app/runtime.zig` | Application lifetime, frame loop, session spawning, config persistence, logging lifecycle/view-transition markers | `run()`, frame loop internals | `platform/sdl`, `session/state`, `render/renderer`, `ui/root`, `config`, `logging`, all `app/*` modules |
+| `main.zig` | Thin entrypoint + global logging hook registration | `main(init: std.process.Init)`, `std_options.logFn` | `app/runtime`, `logging` |
+| `mcp/main.zig` | Separate `architect-mcp` stdio MCP server. Handles JSON-RPC lifecycle methods and exposes the single `spawn_session` tool. | `main(init: std.process.Init)`, `run()` | `app/control` module import, std |
+| `app/runtime.zig` | Application lifetime, frame loop, session spawning, config persistence, logging lifecycle/view-transition markers | `run(io, ...)`, frame loop internals | `platform/sdl`, `session/state`, `render/renderer`, `ui/root`, `config`, `logging`, all `app/*` modules |
 | `app/control.zig` | Local control channel shared by the app and `architect-mcp`: spawn request schema, discovery file, Unix socket listener, request queue, and response serialization | `SpawnRequest`, `SpawnResponse`, `SpawnQueue`, `startControlThread()`, `connectAndSendSpawnRequest()` | std (socket, thread, JSON) |
 | `app/terminal_history.zig` | Extract focused terminal scrollback + viewport text, strip ANSI escape sequences, convert OSC 133 prompt markers into reader-friendly prompt marker lines, and extract agent session IDs from PTY output for resumption | `extractSessionText()`, `extractTerminalText()`, `stripAnsiAlloc()`, `extractAgentSessionId()`, `buildResumeCommand()` | `session/state`, `ghostty-vt`, std |
 | `app/*` (app_state, layout, ui_host, grid_nav, grid_layout, input_keys, input_text, terminal_actions, worktree) | Application logic decomposed by concern: state enums, grid sizing, UI snapshot building, navigation, input encoding, clipboard and submitted-paste construction, worktree commands (with configurable external directory and post-create init) | `ViewMode`, `AnimationState`, `SessionStatus`, `buildUiHost()`, `applyTerminalResize()`, `encodeKey()`, `pasteText()`, `buildSubmittedPaste()`, `clearTerminal()`, `resolveWorktreeDir()` | `geom`, `anim/easing`, `ui/types`, `ui/session_view_state`, `colors`, `input/mapper`, `session/state`, `c` |
@@ -450,6 +464,7 @@ Rotate: rename active file to architect-<UTC timestamp>.log and continue in new 
 | `render/renderer.zig` | Scene rendering: terminals, borders, animations, terminal scrollbar painting, first-launch onboarding hint | `render()`, `RenderCache`, per-session texture management | `font`, `font_cache`, `gfx/*`, `anim/easing`, `app/app_state`, `ui/components/scrollbar`, `c` |
 | `font.zig` + `font_cache.zig` | Font rendering, HarfBuzz shaping, glyph LRU cache, shared font cache | `Font`, `openFont()`, `renderGlyph()`, `FontCache`, `getOrCreate()` | `font_paths`, `c` (SDL3_ttf) |
 | `gfx/*` (box_drawing, primitives) | Procedural box-drawing characters (U+2500-U+257F), rounded/thick border helpers, bezier arrow rendering | `renderBoxDrawing()`, `drawRoundedRect()`, `drawThickBorder()`, `fillRoundedRect()`, `renderBezierArrow()` | `c` |
+| `env.zig`, `clock.zig`, `proc.zig` | Process-environment access, I/O-aware timestamps/sleep, and I/O-aware process execution helpers | `get()`, `now*()`, `sleepNanos()`, `run()`, `spawnDetached()` | std |
 | `ui/root.zig` | UI component registry, z-index dispatch, action drain | `UiRoot`, `register()`, `handleEvent()`, `update()`, `render()`, `needsFrame()` | `ui/component`, `ui/types` |
 | `ui/component.zig` | UI component vtable interface | `UiComponent`, `VTable` (handleEvent, update, render, hitTest, wantsFrame, deinit) | `ui/types`, `c` |
 | `ui/types.zig` | Shared UI type definitions | `UiHost`, `UiAction`, `UiActionQueue`, `UiAssets`, `SessionUiInfo` | `app/app_state`, `colors`, `font`, `geom` |

--- a/docs/development.md
+++ b/docs/development.md
@@ -25,15 +25,15 @@ This document covers local setup, build/test commands, and release steps.
    direnv allow
    ```
 
-   On macOS hosts where the active `MacOSX.sdk` only exposes `arm64e` targets, Zig 0.15.2 can fail during native Darwin linking with errors such as `undefined symbol: __availability_version_check`. The upstream tracker for this regression is https://codeberg.org/ziglang/zig/issues/31756.
+   On macOS hosts where the active `MacOSX.sdk` only exposes `arm64e` targets, the Zig 0.16.0 dev shell retains a workaround for native Darwin linking errors such as `undefined symbol: __availability_version_check`. The upstream tracker for this regression is https://codeberg.org/ziglang/zig/issues/31756.
 
    The dev shell works around that by exposing `MacOSX15.4.sdk` through a fake `DEVELOPER_DIR` whose `usr/bin/xcrun` is a narrow shim for `xcrun --sdk macosx --show-sdk-path`. `build.zig` also resolves framework paths through `DEVELOPER_DIR` and `xcrun` before it falls back to hardcoded SDK locations, so the workaround does not need to force `SDKROOT`. Keeping the shim inside the fake developer tree means tools like `git` can still invoke `/usr/bin/xcrun` without tripping over the overridden `DEVELOPER_DIR`.
 
-   Remove this workaround once Architect no longer uses Zig 0.15.2, or once Zig handles the arm64e-only macOS SDK stubs correctly. If the active `MacOSX.sdk/usr/lib/libSystem.tbd` advertises `arm64-macos` again, the shell hook becomes a no-op.
+   Keep this workaround until a macOS host confirms that Zig handles the arm64e-only SDK stubs correctly. If the active `MacOSX.sdk/usr/lib/libSystem.tbd` advertises `arm64-macos` again, the shell hook becomes a no-op.
 
 3. Verify the environment:
    ```bash
-   zig version  # Should show 0.15.2+ (compatible with ghostty-vt)
+   zig version  # Should show 0.16.0+ (compatible with ghostty-vt)
    just --list  # Show available commands
    ```
 

--- a/docs/ghostty-vt-notes.md
+++ b/docs/ghostty-vt-notes.md
@@ -14,9 +14,8 @@
 ## Build Requirements
 
 ### Zig Version
-- Minimum Zig version: **0.15.1** (example code)
-- Ghostty main requires: **0.15.2**
 - Use the version specified in the consuming project's `build.zig.zon`
+- Architect currently requires: **0.16.0**
 
 ### Dependencies
 

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -1366,7 +1366,7 @@ the migration."
   - `proc.run(allocator: std.mem.Allocator, io: std.Io, options: RunOptions) !RunResult`, `proc.spawnDetached(allocator: std.mem.Allocator, io: std.Io, argv: []const []const u8) !Term`
   - `proc.Term` is unchanged (`exited`/`signal`/`stopped`/`unknown`, `signal: u32`)
 
-- [ ] **Step 1: Convert `src/main.zig` to take `std.process.Init`**
+- [x] **Step 1: Convert `src/main.zig` to take `std.process.Init`**
 
 `std.process.Init` supplies `io`, `gpa`, `arena`, and `environ_map`; `std.process.argsAlloc` is gone and arguments arrive through `init.minimal.args`.
 
@@ -1394,7 +1394,7 @@ Add `const env = @import("env.zig");` to the imports.
 
 If `std.process.Args.Iterator`'s exact method name differs from `next()`, read `lib/std/process/Args.zig` in the 0.16 lib directory (`$(dirname $(readlink -f $(which zig)))/../lib/std/process/Args.zig`) and use the real name. Do not guess.
 
-- [ ] **Step 2: Convert `src/mcp/main.zig`**
+- [x] **Step 2: Convert `src/mcp/main.zig`**
 
 ```zig
 pub fn main(init: std.process.Init) !void {
@@ -1406,7 +1406,7 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, stdin_file: std.Io.File, st
 
 `init.gpa` replaces the `DebugAllocator` entirely, so the `var gpa` / `defer _ = gpa.deinit()` lines are deleted.
 
-- [ ] **Step 3: Convert `src/env.zig` internals**
+- [x] **Step 3: Convert `src/env.zig` internals**
 
 ```zig
 var process_environ: ?std.process.Environ = null;
@@ -1426,7 +1426,7 @@ pub fn get(key: []const u8) ?[:0]const u8 {
 
 The panic is deliberate: a read before initialization is a programming error with no correct recovery, and returning `null` would silently hide it.
 
-- [ ] **Step 4: Fix `src/env.zig`'s tests for the new initialization requirement**
+- [x] **Step 4: Fix `src/env.zig`'s tests for the new initialization requirement**
 
 The tests call `get` without a `main`, so they must initialize first. The test binary's environment is reachable through `std.process.Environ`:
 
@@ -1452,7 +1452,7 @@ test "get returns null for a variable that is not set" {
 
 `.global` is the process-wide environ block; confirm the exact spelling against `lib/std/process/Environ.zig:35` (`pub const GlobalBlock`) in the installed 0.16 lib directory and use whatever constructor it actually provides. Do not guess.
 
-- [ ] **Step 5: Convert `src/clock.zig` internals**
+- [x] **Step 5: Convert `src/clock.zig` internals**
 
 ```zig
 pub fn nowSeconds(io: std.Io) i64 {
@@ -1480,7 +1480,7 @@ pub fn sleepNanos(io: std.Io, nanoseconds: u64) void {
 
 `Timestamp.nanoseconds` is `i96`; `toNanoseconds()` returns `i96`, which widens losslessly to the `i128` callers expect.
 
-- [ ] **Step 6: Update `src/clock.zig`'s tests to pass `io`**
+- [x] **Step 6: Update `src/clock.zig`'s tests to pass `io`**
 
 Tests need their own `Io`. Create one per test:
 
@@ -1524,7 +1524,7 @@ test "sleepNanos advances the clock by at least the requested span" {
 }
 ```
 
-- [ ] **Step 7: Convert `src/proc.zig` internals**
+- [x] **Step 7: Convert `src/proc.zig` internals**
 
 `std.process.run` covers the collect-output shape exactly, including `cwd` and output limits. `std.process.spawn` plus `Child.wait` covers the spawn-and-wait shape.
 
@@ -1563,7 +1563,7 @@ pub fn spawnDetached(allocator: std.mem.Allocator, io: std.Io, argv: []const []c
 
 `spawnDetached` keeps its `allocator` parameter (discarded) so the four call sites do not change shape; drop the parameter only if a reviewer asks.
 
-- [ ] **Step 8: Update `src/proc.zig`'s tests to pass `io`**
+- [x] **Step 8: Update `src/proc.zig`'s tests to pass `io`**
 
 Prefix each test with the same `std.Io.Threaded` setup shown in Step 6 and thread `io` into every `run` / `spawnDetached` call. For example:
 
@@ -1584,14 +1584,14 @@ test "run collects stdout and reports a zero exit" {
 }
 ```
 
-- [ ] **Step 9: Verify the error class shrank**
+- [x] **Step 9: Verify the error class shrank**
 
 Run: `nix develop --command bash -c 'zig build 2>&1 | tee .tmp/flip-errors.txt' || true`
 
 Run: `grep -nE 'argsAlloc|GeneralPurposeAllocator|std\.time\.(timestamp|milliTimestamp|nanoTimestamp)|std\.Thread\.sleep' .tmp/flip-errors.txt`
 Expected: no output. The entry-point, allocator, time, and sleep error classes are gone; the remaining errors are missing-`io` errors at the call sites Tasks 8–12 fix.
 
-- [ ] **Step 10: Commit**
+- [x] **Step 10: Commit**
 
 ```bash
 nix develop --command zig fmt src/

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -2020,6 +2020,8 @@ nix develop --command bash -c 'echo "$(dirname "$(readlink -f "$(which zig)")")/
 
 Never guess an API shape. If a diagnostic is not obviously mechanical, stop and report it rather than inventing a workaround.
 
+Reviewed: log rotation intentionally uses `Dir.renamePreserve`; POSIX file-to-file rename does not return `PathAlreadyExists`, so this makes the existing suffix retry avoid archive clobbering without changing successful rotation semantics.
+
 - [x] **Step 2: Normalize the deprecated ArrayList alias**
 
 0.16 keeps `std.ArrayListUnmanaged` as a deprecated alias for `std.ArrayList`, so these four sites compile but should not stay. `CLAUDE.md` mandates the `std.ArrayList` spelling:

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -1885,11 +1885,11 @@ The remaining 19 source sites.
 - Consumes: `io` threaded in by Tasks 8 and 9
 - Produces: no `fs.` filesystem calls remain anywhere in `src/`
 
-- [ ] **Step 1: Convert each file using the mapping table**
+- [x] **Step 1: Convert each file using the mapping table**
 
 All sites in these files use the `std.fs.`-qualified spelling, so `grep -n 'std\.fs\.' <file>` enumerates them. Use `self.io` inside component methods (Task 9 added the field) and the function's `io` parameter in free functions.
 
-- [ ] **Step 2: Verify no filesystem call remains anywhere**
+- [x] **Step 2: Verify no filesystem call remains anywhere**
 
 Run: `grep -rnE '\b(std\.)?fs\.[A-Za-z_]+' src build.zig | grep -vE 'fs\.(path|max_path_bytes|max_name_bytes)'`
 Expected: no output.
@@ -1897,14 +1897,14 @@ Expected: no output.
 Run: `grep -rn 'std\.fs\.File\|std\.fs\.Dir' src build.zig`
 Expected: no output.
 
-- [ ] **Step 3: Verify the error class shrank**
+- [x] **Step 3: Verify the error class shrank**
 
 Run: `nix develop --command bash -c 'zig build 2>&1 | tee .tmp/flip-errors.txt' || true`
 
 Run: `grep -cE 'Mutex|Condition' .tmp/flip-errors.txt`
 Expected: the only remaining errors are mutex and condition errors, so this count equals the total error count from `grep -c 'error:'`.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 nix develop --command zig fmt src/

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -2154,7 +2154,7 @@ git commit -m "build: resolve the macOS SDK workaround for Zig 0.16.0"
 - Consumes: the completed migration
 - Produces: documentation consistent with the 0.16 codebase
 
-- [ ] **Step 1: Update `CLAUDE.md`**
+- [x] **Step 1: Update `CLAUDE.md`**
 
 `AGENTS.md` is a symlink to `CLAUDE.md`, so edit only `CLAUDE.md`.
 
@@ -2189,26 +2189,26 @@ Add to the Architecture Invariants section:
 
 Update the repo note about the macOS SDK workaround to match whatever Task 14 concluded.
 
-- [ ] **Step 2: Update `docs/ARCHITECTURE.md`**
+- [x] **Step 2: Update `docs/ARCHITECTURE.md`**
 
 Document the three new shared-utility modules alongside the existing `src/geom.zig` / `src/anim/easing.zig` / `src/gfx/primitives.zig` tier, and the `io` carrier data flow from `main(init)` through `runtime.run` into the session and UI layers. Read the existing document's structure first and follow it rather than appending a new section at the end.
 
-- [ ] **Step 3: Update `docs/development.md`**
+- [x] **Step 3: Update `docs/development.md`**
 
 Update the Zig version and any setup instructions that name 0.15.2.
 
-- [ ] **Step 4: Check `README.md` and `docs/perf-debugging.md`**
+- [x] **Step 4: Check `README.md` and `docs/perf-debugging.md`**
 
 Run: `grep -n '0\.15' README.md docs/perf-debugging.md docs/configuration.md docs/ai-integration.md`
 
 Update every hit. If there are none, leave the files alone — do not edit them to look busy.
 
-- [ ] **Step 5: Verify no stale version references remain**
+- [x] **Step 5: Verify no stale version references remain**
 
 Run: `grep -rn '0\.15\.2\|Zig 0\.15' --exclude-dir=.git --exclude-dir=.tmp --exclude-dir=zig-out --exclude-dir=.zig-cache .`
 Expected: only `docs/superpowers/specs/2026-08-28-zig-0-16-migration-design.md`, `docs/superpowers/plans/2026-08-28-zig-0-16-migration.md`, and `docs/superpowers/plans/2026-08-28-zig-0-16-inventory.md`, which document the migration and should retain their historical references.
 
-- [ ] **Step 6: Verify the whole pipeline**
+- [x] **Step 6: Verify the whole pipeline**
 
 Run: `nix develop --command just ci`
 Expected: exit 0. This runs build, test, and lint in sequence.
@@ -2235,7 +2235,7 @@ Automated checks cannot reach any of Architect's rendering, terminal, or subproc
 
 Record any discrepancy as a migration defect and fix it before proceeding.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add -A

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -1614,7 +1614,7 @@ env, clock, and proc now take the io context that Zig 0.16 requires."
 - Consumes: `clock.*(io, ...)`, `proc.*(allocator, io, ...)` from Task 7
 - Produces: every struct in these files that owns an `allocator` field also owns an `io: std.Io` field, placed immediately after it; every function that takes an `allocator` parameter and reaches a `clock`, `proc`, or filesystem call also takes `io: std.Io` immediately after it. `runtime.run(io: std.Io, log_dir_override: ?[]const u8) !void`.
 
-- [ ] **Step 1: Widen `runtime.run`**
+- [x] **Step 1: Widen `runtime.run`**
 
 ```zig
 pub fn run(io: std.Io, log_dir_override: ?[]const u8) !void {
@@ -1622,7 +1622,7 @@ pub fn run(io: std.Io, log_dir_override: ?[]const u8) !void {
 
 Task 7 Step 1 already calls it this way.
 
-- [ ] **Step 2: Add the `io` field to every struct that owns an `allocator`**
+- [x] **Step 2: Add the `io` field to every struct that owns an `allocator`**
 
 The convention, applied uniformly: `io` goes immediately after `allocator`, and every `init` that takes an allocator takes `io` immediately after it. For example, in `src/session/state.zig`:
 
@@ -1637,7 +1637,7 @@ pub const SessionState = struct {
 
 (place `io` next to wherever `allocator` already sits in each struct — do not reorder the other fields)
 
-- [ ] **Step 3: Thread `io` into thread-context structs**
+- [x] **Step 3: Thread `io` into thread-context structs**
 
 Spawned threads outlive their spawner's stack frame, so `io` must be *stored*, not borrowed. Every context struct passed to `std.Thread.spawn` gains an `io` field. The affected spawn sites are `src/app/control.zig:355`, `src/app/runtime.zig:1232`, `src/app/runtime.zig:1306`, `src/session/notify.zig:260`, `src/session/pty_reader.zig:261`, `src/ui/components/pr_dropdown.zig:584`, and `src/os/open.zig:47`.
 
@@ -1652,7 +1652,7 @@ Spawned threads outlive their spawner's stack frame, so `io` must be *stored*, n
 
 `std.Io` is a fat pointer (vtable plus userdata) and the `std.Io.Threaded` instance it points at lives for the whole process, so storing a copy per context is safe.
 
-- [ ] **Step 4: Widen the `clock` call sites**
+- [x] **Step 4: Widen the `clock` call sites**
 
 All 27 sites from Task 4 now need `io` as the first argument. Where the enclosing function is a method on a struct that gained an `io` field in Step 2, use `self.io`; otherwise use the function's new `io` parameter. For example `src/app/layout.zig:94`:
 
@@ -1666,7 +1666,7 @@ and `src/session/state.zig:644`:
             const processed_at_ms = clock.nowMillis(self.io);
 ```
 
-- [ ] **Step 5: Widen the `proc` call sites in this layer**
+- [x] **Step 5: Widen the `proc` call sites in this layer**
 
 `src/app/runtime.zig:2958`:
 
@@ -1685,14 +1685,14 @@ and `src/session/state.zig:644`:
     try testing.expectEqual(proc.Term{ .exited = 0 }, term);
 ```
 
-- [ ] **Step 6: Verify the error class shrank**
+- [x] **Step 6: Verify the error class shrank**
 
 Run: `nix develop --command bash -c 'zig build 2>&1 | tee .tmp/flip-errors.txt' || true`
 
 Run: `grep -nE 'clock\.(now|sleep)|proc\.(run|spawnDetached)' .tmp/flip-errors.txt`
 Expected: no output. Remaining errors should be filesystem and mutex errors only, plus UI-layer `io` plumbing.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 nix develop --command zig fmt src/

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -1215,7 +1215,7 @@ Every filesystem transformation in Tasks 6, 10, and 11 comes from this table, ve
 - Consumes: the four verified hashes from Task 1
 - Produces: a `build.zig` that 0.16 can execute, so the compiler reaches `src/`
 
-- [ ] **Step 1: Bump the toolchain in `flake.nix`**
+- [x] **Step 1: Bump the toolchain in `flake.nix`**
 
 ```nix
             zig.packages.${system}."0.16.0"
@@ -1223,7 +1223,7 @@ Every filesystem transformation in Tasks 6, 10, and 11 comes from this table, ve
 
 Leave the macOS SDK workaround block alone for now; Task 14 handles it.
 
-- [ ] **Step 2: Bump `build.zig.zon`**
+- [x] **Step 2: Bump `build.zig.zon`**
 
 Use the hashes recorded in `docs/superpowers/plans/2026-08-28-zig-0-16-inventory.md` from Task 1 Step 4. Do not invent hashes; if the inventory is missing any, re-run `zig fetch` for that URL.
 
@@ -1261,7 +1261,7 @@ Use the hashes recorded in `docs/superpowers/plans/2026-08-28-zig-0-16-inventory
 
 The `zwanzig` URL is unchanged — v0.15.1's `src/compat.zig` already supports 0.16.0 — but its hash must still be regenerated if 0.16 changed the hash format.
 
-- [ ] **Step 3: Rename the build graph's env map**
+- [x] **Step 3: Rename the build graph's env map**
 
 `std.Build.Graph.env_map` is `environ_map` in 0.16. Task 2 already routed all four reads through the graph, so this is a mechanical rename of four occurrences in `build.zig`:
 
@@ -1272,7 +1272,7 @@ The `zwanzig` URL is unchanged — v0.15.1's `src/compat.zig` already supports 0
 Run: `grep -c 'b\.graph\.environ_map\.get' build.zig`
 Expected: `4`.
 
-- [ ] **Step 4: Convert `build.zig`'s filesystem and subprocess calls**
+- [x] **Step 4: Convert `build.zig`'s filesystem and subprocess calls**
 
 `sdkExists` uses `std.fs.openDirAbsolute` and `findXcrunSdkRoot` uses `std.process.Child.run`. Both need `io`, which comes from `b.graph.io`. Thread it as a parameter rather than reaching for a global:
 
@@ -1320,12 +1320,12 @@ fn sdkExists(io: std.Io, path: []const u8) bool {
 
 Note the `Term` tag is now lowercase `.exited`. Update the three callers to pass `io`: `findSdkRoot` becomes `findSdkRoot(b)` still (it has `b`, so it uses `b.graph.io` internally and passes it down), `findDeveloperDirSdkRoot(b)` likewise, and each `sdkExists(candidate)` call becomes `sdkExists(b.graph.io, candidate)`, with `findXcrunSdkRoot(b.allocator)` becoming `findXcrunSdkRoot(b.allocator, b.graph.io)`.
 
-- [ ] **Step 5: Verify `build.zig` itself compiles under 0.16**
+- [x] **Step 5: Verify `build.zig` itself compiles under 0.16**
 
 Run: `nix develop --command bash -c 'zig build --help > /dev/null'`
 Expected: exit 0. This executes the build script without building the project, isolating build-script errors from source errors. If it fails, the diagnostics are all in `build.zig` — fix them before continuing.
 
-- [ ] **Step 6: Confirm dependency resolution and capture the source error baseline**
+- [x] **Step 6: Confirm dependency resolution and capture the source error baseline**
 
 Run: `nix develop --command bash -c 'zig build 2>&1 | tee .tmp/flip-errors.txt' || true`
 
@@ -1335,7 +1335,7 @@ Expected: no output. Any dependency-resolution error here is a Task 1 regression
 Run: `grep -c 'error:' .tmp/flip-errors.txt`
 Expected: a large number, all pointing into `src/`. Record it; later tasks compare against it.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add flake.nix build.zig.zon build.zig

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -1923,7 +1923,7 @@ git commit -m "refactor(ui): move component filesystem calls to std.Io.Dir"
 - Consumes: `io` available as a field on every struct that owns a mutex (Tasks 8 and 9)
 - Produces: no `std.Thread.Mutex` or `std.Thread.Condition` remains. `SpawnCompletion.complete(io, response)` and `SpawnCompletion.wait(io)` gain an `io` parameter, so their callers in `src/app/control.zig` and `src/app/runtime.zig` must pass one.
 
-- [ ] **Step 1: Change the declarations**
+- [x] **Step 1: Change the declarations**
 
 `std.Io.Mutex` and `std.Io.Condition` initialize with `.init`, not `.{}` — a default-initialized `.{}` will not compile because both carry non-defaulted atomic state. For each of the eight declarations:
 
@@ -1935,7 +1935,7 @@ git commit -m "refactor(ui): move component filesystem calls to std.Io.Dir"
     condition: std.Io.Condition = .init,
 ```
 
-- [ ] **Step 2: Add `io` to every lock, unlock, and wait**
+- [x] **Step 2: Add `io` to every lock, unlock, and wait**
 
 Use the uncancelable variants. `Io.Mutex.lock` and `Io.Condition.wait` return `Cancelable!void`, and Architect never requests cancellation, so making every lock site fallible would add `catch` blocks with no correct recovery — which `CLAUDE.md`'s error-handling rule forbids resolving with a bare `catch`. `lockUncancelable` and `waitUncancelable` are total functions.
 
@@ -1975,7 +1975,7 @@ Apply the same pattern to `SpawnQueue` (`src/app/control.zig:123`), `LoggerState
 
 `src/session/pty_reader.zig`'s mutexes are on the hot path between the PTY reader thread and the frame loop, so keep the critical sections exactly as narrow as they are today — do not widen a `defer unlock` to cover more work than the original.
 
-- [ ] **Step 3: Verify no thread synchronization primitive remains**
+- [x] **Step 3: Verify no thread synchronization primitive remains**
 
 Run: `grep -rn 'std\.Thread\.\(Mutex\|Condition\)' src`
 Expected: no output.
@@ -1983,7 +1983,7 @@ Expected: no output.
 Run: `grep -rn '\.lock()\|\.unlock()\|\.wait(&' src`
 Expected: no output — every call now takes `io`.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 nix develop --command zig fmt src/

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -1790,7 +1790,7 @@ git commit -m "refactor(ui): thread io through the components that need it"
 - Consumes: `io` threaded in by Task 8; `std.Io.Dir` / `std.Io.File` per the mapping table
 - Produces: no `fs.` filesystem calls remain in these files
 
-- [ ] **Step 1: Note the alias hazard before you start**
+- [x] **Step 1: Note the alias hazard before you start**
 
 `src/config.zig:2` and `src/logging.zig:3` declare `const fs = std.fs;`, and `src/session/state.zig:9` does too. A grep for `std.fs.` will miss every site in those files. Update the aliases first so the compiler finds the sites for you:
 
@@ -1802,7 +1802,7 @@ const File = std.Io.File;
 
 `fs.path.*` and `fs.max_path_bytes` survive in 0.16, so the `fs` alias stays for those uses only.
 
-- [ ] **Step 2: Convert `src/config.zig`**
+- [x] **Step 2: Convert `src/config.zig`**
 
 **Check the toml drift finding first.** `src/config.zig` is the only consumer of the `toml` dependency, which moved to an untagged branch in Task 6. Read the Risk 4 verdict in `docs/superpowers/plans/2026-08-28-zig-0-16-inventory.md` before editing. If the parser API drifted, fix that in this step and be careful of the two hazards `CLAUDE.md` records: parser-owned maps must not outlive `result.deinit()`, and persisted map keys *and* values must both be duplicated into your own storage. A use-after-free here is a segfault at config load, not a compile error.
 
@@ -1822,13 +1822,13 @@ Every `defer file.close()` becomes `defer file.close(io)`, and every `defer dir.
 
 The two test sites need their own `io`; add the `std.Io.Threaded` setup from Task 7 Step 6 to each.
 
-- [ ] **Step 3: Convert `src/logging.zig`**
+- [x] **Step 3: Convert `src/logging.zig`**
 
 Line 133 `Dir.createFileAbsolute(io, active_path, .{ ... })` — keep the existing flags struct verbatim. Line 166 `Dir.renameAbsolute(active_path, archive_path, io)` — **`io` goes last here**, unlike every other call in this table. Line 274 `Dir.cwd().createDirPath(io, raw_directory_path)`. Line 275 `Dir.cwd().realPathFileAlloc(io, raw_directory_path, allocator)` — note the argument order differs from 0.15's `realpathAlloc(allocator, path)`. Line 387 `Dir.openFileAbsolute(io, active_path, .{})`. Lines 483 and 524 `Dir.openDirAbsolute(io, ..., .{ .iterate = true })`, and their iterator loops become `while (try it.next(io)) |entry|`. Lines 507 and 510 `Dir.cwd().deleteTree(io, relative_dir)`. The `file: ?fs.File` field at line 23 becomes `file: ?File`, and the `openActiveLogFile` return type at line 130 becomes `!struct { file: File, size: u64 }`.
 
 `LoggerState` is shared across threads behind a mutex, so it must store `io` as a field rather than receive it per call — the log functions are called from `std.log`'s handler, which has no place to pass one.
 
-- [ ] **Step 4: Convert `src/mcp/main.zig`**
+- [x] **Step 4: Convert `src/mcp/main.zig`**
 
 Task 7 already changed `main`, `run`, and the `stdin`/`stdout` types. The remaining work is the read loop and the writes. `File.read` is gone:
 
@@ -1844,27 +1844,27 @@ and every `stdout_file.writeAll(bytes)` becomes:
 
 Thread `io` into `handleMessage` and `writeJsonRpcError` alongside their existing `allocator` parameters.
 
-- [ ] **Step 5: Convert `src/shell.zig`**
+- [x] **Step 5: Convert `src/shell.zig`**
 
 Sixteen sites, all `std.fs.`-qualified so grep finds them: `std.fs.makeDirAbsolute` becomes `std.Io.Dir.createDirAbsolute(io, path, .default_dir)` at lines 674, 685, 694, 705, 786, 800, 850; `std.fs.createFileAbsolute` becomes `std.Io.Dir.createFileAbsolute(io, path, flags)` at lines 717, 813, 1176. Keep every existing `catch |err| switch (err)` block exactly as-is — the error sets are compatible. Run `grep -n 'std\.fs\.' src/shell.zig` after editing and convert whatever remains that is not `std.fs.path.*` or `std.fs.max_path_bytes`.
 
-- [ ] **Step 6: Convert `src/font_paths.zig` and `src/app/control.zig`**
+- [x] **Step 6: Convert `src/font_paths.zig` and `src/app/control.zig`**
 
 Six and five sites respectively, all `std.fs.`-qualified. Apply the mapping table. `src/app/control.zig` is compiled into both the main binary and the `control` module for `architect-mcp`, so its `io` must arrive as a parameter or stored field, never from `src/main.zig`.
 
-- [ ] **Step 7: Verify no filesystem call remains in these six files**
+- [x] **Step 7: Verify no filesystem call remains in these six files**
 
 Run: `for f in src/shell.zig src/config.zig src/mcp/main.zig src/logging.zig src/font_paths.zig src/app/control.zig; do echo "== $f"; grep -nE '\b(std\.)?fs\.[A-Za-z_]+' "$f" | grep -vE 'fs\.(path|max_path_bytes|max_name_bytes)'; done`
 Expected: no lines under any file heading.
 
-- [ ] **Step 8: Verify the error class shrank**
+- [x] **Step 8: Verify the error class shrank**
 
 Run: `nix develop --command bash -c 'zig build 2>&1 | tee .tmp/flip-errors.txt' || true`
 
 Run: `grep -nE 'src/(shell|config|logging|font_paths|mcp/main|app/control)\.zig' .tmp/flip-errors.txt | grep -vE 'Mutex|Condition'`
 Expected: no output.
 
-- [ ] **Step 9: Commit**
+- [x] **Step 9: Commit**
 
 ```bash
 nix develop --command zig fmt src/

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -1718,11 +1718,11 @@ Expected: no output.
 - Consumes: `clock.*(io, ...)`, `proc.*(allocator, io, ...)` from Task 7; `io` available in `src/app/runtime.zig` from Task 8
 - Produces: each of the six components carries an `io: std.Io` field immediately after its `allocator` field, set from its `init`'s new `io` parameter; `runGhPrList(allocator: std.mem.Allocator, io: std.Io, cwd: []const u8) model.FetchResult`
 
-- [ ] **Step 1: Add the `io` field and `init` parameter to each of the six components**
+- [x] **Step 1: Add the `io` field and `init` parameter to each of the six components**
 
 The convention matches Task 8 Step 2: `io` sits immediately after `allocator` in the struct, and `init` takes `io` immediately after its allocator parameter. Do not reorder any other field. Update each component's `init` call in `src/app/runtime.zig` to pass `io`.
 
-- [ ] **Step 2: Thread `io` into the PR dropdown's fetch thread context**
+- [x] **Step 2: Thread `io` into the PR dropdown's fetch thread context**
 
 `src/ui/components/pr_dropdown.zig:584` spawns a fetch thread whose context outlives the spawning stack frame, so the context struct must store its own `io` copy rather than borrow one:
 
@@ -1747,7 +1747,7 @@ and the `proc.run` call inside it becomes:
 
 Keep every existing `log.err` message and `model.FetchResult` branch exactly as Task 5 left them.
 
-- [ ] **Step 3: Widen the `diff_overlay.zig` subprocess call**
+- [x] **Step 3: Widen the `diff_overlay.zig` subprocess call**
 
 ```zig
     const result = proc.run(self.allocator, self.io, .{
@@ -1758,18 +1758,18 @@ Keep every existing `log.err` message and `model.FetchResult` branch exactly as 
 
 Read the surrounding 40 lines first and keep every existing error branch, and the consumers of the `term: proc.Term` field, unchanged.
 
-- [ ] **Step 4: Widen the PR dropdown's mutex operations**
+- [x] **Step 4: Widen the PR dropdown's mutex operations**
 
 `src/ui/components/pr_dropdown.zig:25` declares a mutex. Task 12 converts the declaration; here, only ensure `io` is reachable at each lock site — either as `self.io` or via the thread context from Step 2.
 
-- [ ] **Step 5: Verify the error class shrank**
+- [x] **Step 5: Verify the error class shrank**
 
 Run: `nix develop --command bash -c 'zig build 2>&1 | tee .tmp/flip-errors.txt' || true`
 
 Run: `grep -n 'src/ui/' .tmp/flip-errors.txt | grep -vE 'std\.fs|std\.Io\.(Dir|File)|Mutex|Condition'`
 Expected: no output. Remaining UI errors are filesystem and mutex errors, handled by Tasks 11 and 12.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 nix develop --command zig fmt src/

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -2007,7 +2007,7 @@ This is the first task in the flip whose gate is a fully green build.
 - Consumes: everything from Tasks 6–12
 - Produces: `zig build`, `zig build test`, and `just lint` all green under Zig 0.16.0
 
-- [ ] **Step 1: Drive the remaining errors to zero**
+- [x] **Step 1: Drive the remaining errors to zero**
 
 Run: `nix develop --command bash -c 'zig build 2>&1 | tee .tmp/flip-errors.txt' || true`
 Run: `grep -c 'error:' .tmp/flip-errors.txt`
@@ -2020,7 +2020,7 @@ nix develop --command bash -c 'echo "$(dirname "$(readlink -f "$(which zig)")")/
 
 Never guess an API shape. If a diagnostic is not obviously mechanical, stop and report it rather than inventing a workaround.
 
-- [ ] **Step 2: Normalize the deprecated ArrayList alias**
+- [x] **Step 2: Normalize the deprecated ArrayList alias**
 
 0.16 keeps `std.ArrayListUnmanaged` as a deprecated alias for `std.ArrayList`, so these four sites compile but should not stay. `CLAUDE.md` mandates the `std.ArrayList` spelling:
 
@@ -2032,31 +2032,31 @@ Replace each `std.ArrayListUnmanaged(T)` with `std.ArrayList(T)`. The type is id
 Run: `grep -rn 'ArrayListUnmanaged' src`
 Expected after: no output.
 
-- [ ] **Step 3: Verify the build**
+- [x] **Step 3: Verify the build**
 
 Run: `nix develop --command zig build`
 Expected: exit 0.
 
-- [ ] **Step 4: Verify the tests**
+- [x] **Step 4: Verify the tests**
 
 Run: `nix develop --command zig build test`
 Expected: exit 0. Run this unpiped — a pipe would mask a failing exit code.
 
 If any test fails, fix it. Do not weaken or delete a test to get green; a test that now fails is either a migration defect or a test that encoded a 0.15 implementation detail, and the two need different responses. If it is the latter, say so explicitly in the commit message.
 
-- [ ] **Step 5: Verify the test registry**
+- [x] **Step 5: Verify the test registry**
 
 Run: `nix develop --command ./scripts/check-test-registry.sh`
 Expected: exit 0. `src/env.zig`, `src/clock.zig`, and `src/proc.zig` were registered in Tasks 3–5; this confirms nothing regressed.
 
-- [ ] **Step 6: Verify lint, including Zwanzig under 0.16**
+- [x] **Step 6: Verify lint, including Zwanzig under 0.16**
 
 Run: `nix develop --command just lint`
 Expected: exit 0. This is also the live confirmation that zwanzig v0.15.1 builds and runs under Zig 0.16.0 — the `zig build lint` step compiles it from source with the host toolchain.
 
 If zwanzig fails to compile here, its `src/compat.zig` gate is the place to look; report the diagnostics rather than patching around them.
 
-- [ ] **Step 7: Commit the formatting churn separately**
+- [x] **Step 7: Commit the formatting churn separately**
 
 0.16's `zig fmt` may reformat files that 0.15.2 formatted differently. Keep it out of the substantive commits:
 
@@ -2068,7 +2068,7 @@ git commit -m "style: apply zig 0.16 formatting"
 
 If this produces an empty commit, skip it.
 
-- [ ] **Step 8: Verify formatting is stable**
+- [x] **Step 8: Verify formatting is stable**
 
 Run: `nix develop --command zig fmt --check src/`
 Expected: exit 0, no output.

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -2088,7 +2088,7 @@ Expected: exit 0, no output.
 - Consumes: the Task 1 Step 9 conclusion
 - Produces: either a removed workaround or an updated comment naming 0.16.0
 
-- [ ] **Step 1: Read the Task 1 conclusion**
+- [x] **Step 1: Read the Task 1 conclusion**
 
 Open `docs/superpowers/plans/2026-08-28-zig-0-16-inventory.md` and find the SDK-workaround verdict. Do not re-derive it.
 
@@ -2110,7 +2110,7 @@ Expected: only `scripts/setup-macos-sdk-workaround.sh` itself and any docs menti
 
 If nothing else references it, delete the script and remove the repo note about it from `CLAUDE.md` (Task 15 covers the doc edit). If the release workflow references it, leave the script and stop — that is a separate change.
 
-- [ ] **Step 2b: If Task 1 concluded the workaround is still needed — update its comment**
+- [x] **Step 2b: If Task 1 concluded the workaround is still needed — update its comment**
 
 ```nix
             # Zig 0.16.0 cannot link correctly against the arm64e-only macOS 26.4 SDK stubs.
@@ -2119,7 +2119,7 @@ If nothing else references it, delete the script and remove the repo note about 
             . "$project_root/scripts/setup-macos-sdk-workaround.sh"
 ```
 
-- [ ] **Step 3: Verify the shell still builds the project**
+- [x] **Step 3: Verify the shell still builds the project**
 
 Run: `nix develop --command zig build`
 Expected: exit 0.
@@ -2129,12 +2129,12 @@ Expected: exit 0. Run this unpiped.
 
 If removal broke linking, the Task 1 conclusion was wrong for this host. Restore the workaround, take branch 2b instead, and record the discrepancy in the inventory doc.
 
-- [ ] **Step 4: Verify the release build path**
+- [x] **Step 4: Verify the release build path**
 
 Run: `nix develop --command zig build -Doptimize=ReleaseFast`
 Expected: exit 0. Release builds use a different link configuration than Debug, and the SDK workaround affects linking specifically.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add flake.nix scripts/ 2>/dev/null

--- a/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
+++ b/docs/superpowers/plans/2026-08-28-zig-0-16-migration.md
@@ -2022,6 +2022,8 @@ Never guess an API shape. If a diagnostic is not obviously mechanical, stop and 
 
 Reviewed: log rotation intentionally uses `Dir.renamePreserve`; POSIX file-to-file rename does not return `PathAlreadyExists`, so this makes the existing suffix retry avoid archive clobbering without changing successful rotation semantics.
 
+Accepted: Ghostty's delegated handler reports only an undifferentiated `semantic_failure` flag, so every delegated failure, including OSC 8 hyperlink capacity exhaustion, is session-fatal. The old fine-grained hyperlink exemption cannot be recovered at that API boundary.
+
 - [x] **Step 2: Normalize the deprecated ArrayList alias**
 
 0.16 keeps `std.ArrayListUnmanaged` as a deprecated alias for `std.ArrayList`, so these four sites compile but should not stay. `CLAUDE.md` mandates the `std.ArrayList` spelling:

--- a/flake.lock
+++ b/flake.lock
@@ -34,24 +34,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1762363567,
@@ -91,6 +73,7 @@
       }
     },
     "systems_2": {
+      "flake": false,
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -108,17 +91,17 @@
     "zig": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1762475697,
-        "narHash": "sha256-eyDevGWfUuAINLBYbjes/a606GAL4n7/fDrQ2eu4drU=",
+        "lastModified": 1788179374,
+        "narHash": "sha256-/MFH9nPJQjZp2Q8MRUNd4d1BFR2B2y0XghlMoOF6pVo=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "1527d24b77d9bad2446380516f4b9cf2784d8815",
+        "rev": "be44434ca72b74fff53fc05dbbe59df028737e35",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
             just
             ruff
             shellcheck
-            zig.packages.${system}."0.15.2"
+            zig.packages.${system}."0.16.0"
             pkg-config
             gw
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -78,8 +78,8 @@
             # some dependency but we need to rely on system Xcode tools
             export PATH=$(echo "$PATH" | ${pkgs.gawk}/bin/awk -v RS=: -v ORS=: '$0 !~ /xcrun/ || $0 == "/usr/bin" {print}' | ${pkgs.gnused}/bin/sed 's/:$//')
 
-            # Zig 0.15.2 cannot link correctly against the arm64e-only macOS 26.4 SDK stubs.
-            # Remove this once we move off Zig 0.15.2 or the upstream fix lands.
+            # Zig 0.16.0 cannot link correctly against the arm64e-only macOS 26.4 SDK stubs.
+            # Remove this once the upstream fix lands.
             project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
             . "$project_root/scripts/setup-macos-sdk-workaround.sh"
           '');

--- a/scripts/setup-macos-sdk-workaround.sh
+++ b/scripts/setup-macos-sdk-workaround.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-# Work around Zig 0.15.2 failing to link against the macOS 26.4 SDK family,
+# Work around Zig 0.16.0 failing to link against the macOS 26.4 SDK family,
 # whose top-level libSystem.tbd no longer advertises arm64-macos.
 # Upstream tracker: https://codeberg.org/ziglang/zig/issues/31756
 #
-# Remove this once Architect no longer uses Zig 0.15.2, or once Zig's Darwin
-# SDK discovery/linker handles the arm64e-only stub layout correctly.
+# Remove this once Zig's Darwin SDK discovery/linker handles the arm64e-only
+# stub layout correctly and a macOS host has confirmed it.
 
 legacy_sdk="/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk"
 default_stub="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libSystem.tbd"
@@ -49,4 +49,4 @@ esac
 
 export DEVELOPER_DIR="$developer_dir"
 
-echo "Applied Zig 0.15.2 macOS SDK workaround using $legacy_sdk"
+echo "Applied Zig 0.16.0 macOS SDK workaround using $legacy_sdk"

--- a/src/app/control.zig
+++ b/src/app/control.zig
@@ -4,6 +4,7 @@ const posix = std.posix;
 const atomic = std.atomic;
 const clock = @import("../clock.zig");
 const env = @import("../env.zig");
+const posix_util = @import("../posix_util.zig");
 
 const log = std.log.scoped(.control);
 
@@ -123,7 +124,7 @@ pub const PendingSpawn = struct {
 
 pub const SpawnQueue = struct {
     mutex: std.Io.Mutex = .init,
-    items: std.ArrayListUnmanaged(PendingSpawn) = .empty,
+    items: std.ArrayList(PendingSpawn) = .empty,
 
     pub fn deinit(self: *SpawnQueue, allocator: std.mem.Allocator) void {
         self.items.deinit(allocator);
@@ -135,7 +136,7 @@ pub const SpawnQueue = struct {
         try self.items.append(allocator, item);
     }
 
-    pub fn drainAll(self: *SpawnQueue, io: std.Io) std.ArrayListUnmanaged(PendingSpawn) {
+    pub fn drainAll(self: *SpawnQueue, io: std.Io) std.ArrayList(PendingSpawn) {
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
         const items = self.items;
@@ -306,7 +307,12 @@ fn ensureControlRuntimeDir(io: std.Io, runtime_dir: ControlRuntimeDir) !void {
     if (!runtime_dir.managed) return;
 
     try std.Io.Dir.cwd().createDirPath(io, runtime_dir.path);
-    try posix.fchmodat(posix.AT.FDCWD, runtime_dir.path, 0o700, 0);
+    try std.Io.Dir.cwd().setFilePermissions(
+        io,
+        runtime_dir.path,
+        .fromMode(0o700),
+        .{},
+    );
 }
 
 fn controlDiscoveryFileNameAlloc(allocator: std.mem.Allocator) ![]u8 {
@@ -344,7 +350,7 @@ pub fn startControlThread(
     stop: *atomic.Value(bool),
     runtime_wake: ?RuntimeWake,
 ) std.Thread.SpawnError!std.Thread {
-    _ = std.posix.unlink(socket_path) catch |err| switch (err) {
+    _ = std.Io.Dir.cwd().deleteFile(io, socket_path) catch |err| switch (err) {
         error.FileNotFound => {},
         else => log.warn("failed to unlink control socket: {}", .{err}),
     };
@@ -362,7 +368,7 @@ pub fn startControlThread(
 }
 
 pub fn cleanupControlFiles(io: std.Io, socket_path: [:0]const u8, discovery_path: []const u8) void {
-    _ = std.posix.unlink(socket_path) catch |err| switch (err) {
+    _ = std.Io.Dir.cwd().deleteFile(io, socket_path) catch |err| switch (err) {
         error.FileNotFound => {},
         else => log.warn("failed to unlink control socket during cleanup: {}", .{err}),
     };
@@ -395,7 +401,7 @@ fn controlThreadMain(ctx: ControlContext) !void {
     const fd = server.socket.handle;
 
     const sock_path = std.mem.sliceTo(ctx.socket_path, 0);
-    std.posix.fchmodat(posix.AT.FDCWD, sock_path, 0o600, 0) catch |err| {
+    std.Io.Dir.cwd().setFilePermissions(ctx.io, sock_path, .fromMode(0o600), .{}) catch |err| {
         log.warn("failed to chmod control socket: {}", .{err});
     };
     writeDiscoveryFile(ctx.allocator, ctx.io, ctx.discovery_path, sock_path) catch |err| {
@@ -423,14 +429,14 @@ fn controlThreadMain(ctx: ControlContext) !void {
 }
 
 fn setFdNonBlocking(fd: posix.fd_t, context: []const u8) void {
-    const flags = posix.fcntl(fd, posix.F.GETFL, 0) catch |err| {
+    const flags = posix_util.fcntl(fd, posix.F.GETFL, 0) catch |err| {
         log.warn("failed to get {s} flags: {}", .{ context, err });
         return;
     };
 
     var o_flags: posix.O = @bitCast(@as(u32, @intCast(flags)));
     o_flags.NONBLOCK = true;
-    if (posix.fcntl(fd, posix.F.SETFL, @as(u32, @bitCast(o_flags)))) |_| {} else |err| {
+    if (posix_util.fcntl(fd, posix.F.SETFL, @as(u32, @bitCast(o_flags)))) |_| {} else |err| {
         log.warn("failed to set {s} non-blocking: {}", .{ context, err });
     }
 }
@@ -524,22 +530,24 @@ fn writeDiscoveryFile(allocator: std.mem.Allocator, io: std.Io, path: []const u8
     var dir = try std.Io.Dir.openDirAbsolute(io, dir_path, .{});
     defer dir.close(io);
 
+    var random_suffix: u64 = undefined;
+    std.Io.random(io, std.mem.asBytes(&random_suffix));
     const temp_name = try std.fmt.allocPrint(
         allocator,
         ".{s}.{x}.tmp",
-        .{ base_name, std.crypto.random.int(u64) },
+        .{ base_name, random_suffix },
     );
     defer allocator.free(temp_name);
 
     var file = try dir.createFile(io, temp_name, .{
         .exclusive = true,
-        .mode = 0o600,
+        .permissions = .fromMode(0o600),
     });
     var file_open = true;
     errdefer if (file_open) file.close(io);
     errdefer deleteTempDiscoveryFile(io, &dir, temp_name);
 
-    try posix.fchmod(file.handle, 0o600);
+    try file.setPermissions(io, .fromMode(0o600));
     try file.writeStreamingAll(io, payload);
     try file.sync(io);
     file.close(io);
@@ -606,6 +614,7 @@ fn readLineFromFdWithTimeout(
 
         const file: std.Io.File = .{ .handle = fd, .flags = .{ .nonblocking = true } };
         const n = file.readStreaming(io, &.{&tmp}) catch |err| switch (err) {
+            error.EndOfStream => break,
             error.WouldBlock => continue,
             else => return err,
         };
@@ -760,8 +769,8 @@ fn connectToNewestControlSocket(allocator: std.mem.Allocator, io: std.Io) !Contr
     return error.NoLiveControlSocket;
 }
 
-fn discoverControlCandidates(allocator: std.mem.Allocator, io: std.Io) !std.ArrayListUnmanaged(DiscoveryCandidate) {
-    var candidates: std.ArrayListUnmanaged(DiscoveryCandidate) = .empty;
+fn discoverControlCandidates(allocator: std.mem.Allocator, io: std.Io) !std.ArrayList(DiscoveryCandidate) {
+    var candidates: std.ArrayList(DiscoveryCandidate) = .empty;
     errdefer {
         for (candidates.items) |*candidate| candidate.deinit(allocator);
         candidates.deinit(allocator);
@@ -973,9 +982,9 @@ test "fallback control runtime directory does not use TMPDIR" {
 
 test "newestDiscoveryCandidateIndex picks the highest mtime" {
     const candidates = [_]DiscoveryCandidate{
-        .{ .socket_path = "/tmp/old.sock", .mtime = 10 },
-        .{ .socket_path = "/tmp/new.sock", .mtime = 30 },
-        .{ .socket_path = "/tmp/mid.sock", .mtime = 20 },
+        .{ .socket_path = "/tmp/old.sock", .mtime = .fromNanoseconds(10) },
+        .{ .socket_path = "/tmp/new.sock", .mtime = .fromNanoseconds(30) },
+        .{ .socket_path = "/tmp/mid.sock", .mtime = .fromNanoseconds(20) },
     };
 
     try std.testing.expectEqual(@as(usize, 1), newestDiscoveryCandidateIndex(&candidates));

--- a/src/app/control.zig
+++ b/src/app/control.zig
@@ -245,10 +245,10 @@ fn duplicateValidatedString(
     return try allocator.dupe(u8, value);
 }
 
-pub fn getControlSocketPath(allocator: std.mem.Allocator) ![:0]u8 {
-    var base = try controlRuntimeDirAlloc(allocator);
+pub fn getControlSocketPath(allocator: std.mem.Allocator, io: std.Io) ![:0]u8 {
+    var base = try controlRuntimeDirAlloc(allocator, io);
     defer base.deinit(allocator);
-    try ensureControlRuntimeDir(base);
+    try ensureControlRuntimeDir(io, base);
 
     const pid = std.c.getpid();
     const socket_name = try std.fmt.allocPrint(allocator, "architect_control_{d}.sock", .{pid});
@@ -256,10 +256,10 @@ pub fn getControlSocketPath(allocator: std.mem.Allocator) ![:0]u8 {
     return try std.fs.path.joinZ(allocator, &.{ base.path, socket_name });
 }
 
-pub fn getControlDiscoveryPath(allocator: std.mem.Allocator) ![]u8 {
-    var base = try controlRuntimeDirAlloc(allocator);
+pub fn getControlDiscoveryPath(allocator: std.mem.Allocator, io: std.Io) ![]u8 {
+    var base = try controlRuntimeDirAlloc(allocator, io);
     defer base.deinit(allocator);
-    try ensureControlRuntimeDir(base);
+    try ensureControlRuntimeDir(io, base);
 
     const file_name = try controlDiscoveryFileNameAlloc(allocator);
     defer allocator.free(file_name);
@@ -276,7 +276,8 @@ const ControlRuntimeDir = struct {
     }
 };
 
-fn controlRuntimeDirAlloc(allocator: std.mem.Allocator) !ControlRuntimeDir {
+fn controlRuntimeDirAlloc(allocator: std.mem.Allocator, io: std.Io) !ControlRuntimeDir {
+    _ = io;
     if (env.get("XDG_RUNTIME_DIR")) |runtime_dir| {
         return .{
             .path = try allocator.dupe(u8, runtime_dir),
@@ -301,7 +302,8 @@ fn fallbackControlRuntimeDirAlloc(allocator: std.mem.Allocator) ![]u8 {
     return try std.fmt.allocPrint(allocator, "/tmp/architect-{d}", .{posix.getuid()});
 }
 
-fn ensureControlRuntimeDir(runtime_dir: ControlRuntimeDir) !void {
+fn ensureControlRuntimeDir(io: std.Io, runtime_dir: ControlRuntimeDir) !void {
+    _ = io;
     if (!runtime_dir.managed) return;
 
     try std.fs.cwd().makePath(runtime_dir.path);
@@ -326,6 +328,7 @@ fn isOwnControlDiscoveryFileName(file_name: []const u8, prefix: []const u8) bool
 
 const ControlContext = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
     socket_path: [:0]const u8,
     discovery_path: []const u8,
     queue: *SpawnQueue,
@@ -335,6 +338,7 @@ const ControlContext = struct {
 
 pub fn startControlThread(
     allocator: std.mem.Allocator,
+    io: std.Io,
     socket_path: [:0]const u8,
     discovery_path: []const u8,
     queue: *SpawnQueue,
@@ -348,6 +352,7 @@ pub fn startControlThread(
 
     const ctx = ControlContext{
         .allocator = allocator,
+        .io = io,
         .socket_path = socket_path,
         .discovery_path = discovery_path,
         .queue = queue,
@@ -357,7 +362,8 @@ pub fn startControlThread(
     return try std.Thread.spawn(.{}, controlThreadMain, .{ctx});
 }
 
-pub fn cleanupControlFiles(socket_path: [:0]const u8, discovery_path: []const u8) void {
+pub fn cleanupControlFiles(io: std.Io, socket_path: [:0]const u8, discovery_path: []const u8) void {
+    _ = io;
     _ = std.posix.unlink(socket_path) catch |err| switch (err) {
         error.FileNotFound => {},
         else => log.warn("failed to unlink control socket during cleanup: {}", .{err}),
@@ -394,7 +400,7 @@ fn controlThreadMain(ctx: ControlContext) !void {
     std.posix.fchmodat(posix.AT.FDCWD, sock_path, 0o600, 0) catch |err| {
         log.warn("failed to chmod control socket: {}", .{err});
     };
-    writeDiscoveryFile(ctx.allocator, ctx.discovery_path, sock_path) catch |err| {
+    writeDiscoveryFile(ctx.allocator, ctx.io, ctx.discovery_path, sock_path) catch |err| {
         log.warn("failed to write control discovery file: {}", .{err});
     };
 
@@ -403,7 +409,7 @@ fn controlThreadMain(ctx: ControlContext) !void {
     while (!ctx.stop.load(.seq_cst)) {
         const conn_fd = posix.accept(fd, null, null, 0) catch |err| switch (err) {
             error.WouldBlock => {
-                clock.sleepNanos(std.time.ns_per_ms * 10);
+                clock.sleepNanos(ctx.io, std.time.ns_per_ms * 10);
                 continue;
             },
             else => {
@@ -412,7 +418,7 @@ fn controlThreadMain(ctx: ControlContext) !void {
             },
         };
         setFdNonBlocking(conn_fd, "control connection");
-        handleControlConnection(ctx.allocator, conn_fd, ctx.queue, ctx.runtime_wake);
+        handleControlConnection(ctx.allocator, ctx.io, conn_fd, ctx.queue, ctx.runtime_wake);
         posix.close(conn_fd);
     }
 }
@@ -432,11 +438,12 @@ fn setFdNonBlocking(fd: posix.fd_t, context: []const u8) void {
 
 fn handleControlConnection(
     allocator: std.mem.Allocator,
+    io: std.Io,
     conn_fd: posix.fd_t,
     queue: *SpawnQueue,
     runtime_wake: ?RuntimeWake,
 ) void {
-    const bytes = readLineFromFdWithTimeout(allocator, conn_fd, max_message_bytes, control_request_read_timeout_ms) catch |err| {
+    const bytes = readLineFromFdWithTimeout(allocator, io, conn_fd, max_message_bytes, control_request_read_timeout_ms) catch |err| {
         log.debug("failed to read control request: {}", .{err});
         writeControlResponse(conn_fd, .{ .failure = .{
             .code = .invalid_request,
@@ -508,7 +515,8 @@ pub fn parseErrorMessage(err: ParseSpawnRequestError) []const u8 {
     };
 }
 
-fn writeDiscoveryFile(allocator: std.mem.Allocator, path: []const u8, socket_path: []const u8) !void {
+fn writeDiscoveryFile(allocator: std.mem.Allocator, io: std.Io, path: []const u8, socket_path: []const u8) !void {
+    _ = io;
     const payload = try discoveryPayloadAlloc(allocator, socket_path);
     defer allocator.free(payload);
 
@@ -566,12 +574,13 @@ fn discoveryPayloadAlloc(allocator: std.mem.Allocator, socket_path: []const u8) 
     return try allocator.dupe(u8, out.written());
 }
 
-fn readLineFromFd(allocator: std.mem.Allocator, fd: posix.fd_t, max_bytes: usize) ![]u8 {
-    return try readLineFromFdWithTimeout(allocator, fd, max_bytes, null);
+fn readLineFromFd(allocator: std.mem.Allocator, io: std.Io, fd: posix.fd_t, max_bytes: usize) ![]u8 {
+    return try readLineFromFdWithTimeout(allocator, io, fd, max_bytes, null);
 }
 
 fn readLineFromFdWithTimeout(
     allocator: std.mem.Allocator,
+    io: std.Io,
     fd: posix.fd_t,
     max_bytes: usize,
     timeout_ms: ?i64,
@@ -579,11 +588,11 @@ fn readLineFromFdWithTimeout(
     var buffer: std.ArrayList(u8) = .empty;
     errdefer buffer.deinit(allocator);
 
-    const deadline_ms = if (timeout_ms) |ms| clock.nowMillis() + ms else null;
+    const deadline_ms = if (timeout_ms) |ms| clock.nowMillis(io) + ms else null;
     var tmp: [512]u8 = undefined;
     while (true) {
         if (deadline_ms) |deadline| {
-            const now = clock.nowMillis();
+            const now = clock.nowMillis(io);
             if (now >= deadline) return error.TimedOut;
 
             const remaining_ms = deadline - now;
@@ -688,9 +697,10 @@ pub fn controlResponseAlloc(allocator: std.mem.Allocator, response: SpawnRespons
 
 pub fn connectAndSendSpawnRequest(
     allocator: std.mem.Allocator,
+    io: std.Io,
     request: SpawnRequest,
 ) !OwnedSpawnResponse {
-    var connection = connectToNewestControlSocket(allocator) catch |err| switch (err) {
+    var connection = connectToNewestControlSocket(allocator, io) catch |err| switch (err) {
         error.NoControlDiscoveryFile => return staticFailure(.app_not_running, "Architect is not running"),
         error.NoLiveControlSocket => return staticFailure(.app_not_running, "Architect is not accepting control requests"),
         else => return err,
@@ -701,7 +711,7 @@ pub fn connectAndSendSpawnRequest(
     defer allocator.free(payload);
     try writeAllFd(connection.fd, payload);
 
-    const response_bytes = try readLineFromFd(allocator, connection.fd, max_message_bytes);
+    const response_bytes = try readLineFromFd(allocator, io, connection.fd, max_message_bytes);
     defer allocator.free(response_bytes);
     return try parseControlResponse(allocator, response_bytes);
 }
@@ -727,8 +737,8 @@ const DiscoveryCandidate = struct {
     }
 };
 
-fn connectToNewestControlSocket(allocator: std.mem.Allocator) !ControlConnection {
-    var candidates = try discoverControlCandidates(allocator);
+fn connectToNewestControlSocket(allocator: std.mem.Allocator, io: std.Io) !ControlConnection {
+    var candidates = try discoverControlCandidates(allocator, io);
     defer {
         for (candidates.items) |*candidate| candidate.deinit(allocator);
         candidates.deinit(allocator);
@@ -755,14 +765,14 @@ fn connectToNewestControlSocket(allocator: std.mem.Allocator) !ControlConnection
     return error.NoLiveControlSocket;
 }
 
-fn discoverControlCandidates(allocator: std.mem.Allocator) !std.ArrayListUnmanaged(DiscoveryCandidate) {
+fn discoverControlCandidates(allocator: std.mem.Allocator, io: std.Io) !std.ArrayListUnmanaged(DiscoveryCandidate) {
     var candidates: std.ArrayListUnmanaged(DiscoveryCandidate) = .empty;
     errdefer {
         for (candidates.items) |*candidate| candidate.deinit(allocator);
         candidates.deinit(allocator);
     }
 
-    var runtime_dir = try controlRuntimeDirAlloc(allocator);
+    var runtime_dir = try controlRuntimeDirAlloc(allocator, io);
     defer runtime_dir.deinit(allocator);
 
     var dir = std.fs.openDirAbsolute(runtime_dir.path, .{ .iterate = true }) catch |err| switch (err) {

--- a/src/app/control.zig
+++ b/src/app/control.zig
@@ -411,7 +411,7 @@ fn controlThreadMain(ctx: ControlContext) !void {
     setFdNonBlocking(fd, "control socket");
 
     while (!ctx.stop.load(.seq_cst)) {
-        const connection = server.accept(ctx.io) catch |err| switch (err) {
+        const conn_fd = posix_util.accept(fd) catch |err| switch (err) {
             error.WouldBlock => {
                 clock.sleepNanos(ctx.io, std.time.ns_per_ms * 10);
                 continue;
@@ -421,7 +421,6 @@ fn controlThreadMain(ctx: ControlContext) !void {
                 continue;
             },
         };
-        const conn_fd = connection.socket.handle;
         setFdNonBlocking(conn_fd, "control connection");
         handleControlConnection(ctx.allocator, ctx.io, conn_fd, ctx.queue, ctx.runtime_wake);
         _ = std.c.close(conn_fd);

--- a/src/app/control.zig
+++ b/src/app/control.zig
@@ -299,14 +299,13 @@ fn fallbackControlRuntimeDirAlloc(allocator: std.mem.Allocator) ![]u8 {
         return try std.fs.path.join(allocator, &.{ home, ".cache", "architect", "runtime" });
     }
 
-    return try std.fmt.allocPrint(allocator, "/tmp/architect-{d}", .{posix.getuid()});
+    return try std.fmt.allocPrint(allocator, "/tmp/architect-{d}", .{std.c.getuid()});
 }
 
 fn ensureControlRuntimeDir(io: std.Io, runtime_dir: ControlRuntimeDir) !void {
-    _ = io;
     if (!runtime_dir.managed) return;
 
-    try std.fs.cwd().makePath(runtime_dir.path);
+    try std.Io.Dir.cwd().createDirPath(io, runtime_dir.path);
     try posix.fchmodat(posix.AT.FDCWD, runtime_dir.path, 0o700, 0);
 }
 
@@ -314,12 +313,12 @@ fn controlDiscoveryFileNameAlloc(allocator: std.mem.Allocator) ![]u8 {
     return try std.fmt.allocPrint(
         allocator,
         "{s}{d}_{d}{s}",
-        .{ discovery_file_prefix, posix.getuid(), std.c.getpid(), discovery_file_suffix },
+        .{ discovery_file_prefix, std.c.getuid(), std.c.getpid(), discovery_file_suffix },
     );
 }
 
 fn controlDiscoveryFilePrefixAlloc(allocator: std.mem.Allocator) ![]u8 {
-    return try std.fmt.allocPrint(allocator, "{s}{d}_", .{ discovery_file_prefix, posix.getuid() });
+    return try std.fmt.allocPrint(allocator, "{s}{d}_", .{ discovery_file_prefix, std.c.getuid() });
 }
 
 fn isOwnControlDiscoveryFileName(file_name: []const u8, prefix: []const u8) bool {
@@ -363,12 +362,11 @@ pub fn startControlThread(
 }
 
 pub fn cleanupControlFiles(io: std.Io, socket_path: [:0]const u8, discovery_path: []const u8) void {
-    _ = io;
     _ = std.posix.unlink(socket_path) catch |err| switch (err) {
         error.FileNotFound => {},
         else => log.warn("failed to unlink control socket during cleanup: {}", .{err}),
     };
-    std.fs.deleteFileAbsolute(discovery_path) catch |err| switch (err) {
+    std.Io.Dir.deleteFileAbsolute(io, discovery_path) catch |err| switch (err) {
         error.FileNotFound => {},
         else => log.warn("failed to delete control discovery file: {}", .{err}),
     };
@@ -389,12 +387,11 @@ pub fn failPending(
 }
 
 fn controlThreadMain(ctx: ControlContext) !void {
-    const addr = try std.net.Address.initUnix(ctx.socket_path);
-    const fd = try posix.socket(posix.AF.UNIX, posix.SOCK.STREAM, 0);
-    defer posix.close(fd);
+    const address = try std.Io.net.UnixAddress.init(ctx.socket_path);
+    var server = try address.listen(ctx.io, .{ .kernel_backlog = 16 });
+    defer server.deinit(ctx.io);
 
-    try posix.bind(fd, &addr.any, addr.getOsSockLen());
-    try posix.listen(fd, 16);
+    const fd = server.socket.handle;
 
     const sock_path = std.mem.sliceTo(ctx.socket_path, 0);
     std.posix.fchmodat(posix.AT.FDCWD, sock_path, 0o600, 0) catch |err| {
@@ -407,7 +404,7 @@ fn controlThreadMain(ctx: ControlContext) !void {
     setFdNonBlocking(fd, "control socket");
 
     while (!ctx.stop.load(.seq_cst)) {
-        const conn_fd = posix.accept(fd, null, null, 0) catch |err| switch (err) {
+        const connection = server.accept(ctx.io) catch |err| switch (err) {
             error.WouldBlock => {
                 clock.sleepNanos(ctx.io, std.time.ns_per_ms * 10);
                 continue;
@@ -417,9 +414,10 @@ fn controlThreadMain(ctx: ControlContext) !void {
                 continue;
             },
         };
+        const conn_fd = connection.socket.handle;
         setFdNonBlocking(conn_fd, "control connection");
         handleControlConnection(ctx.allocator, ctx.io, conn_fd, ctx.queue, ctx.runtime_wake);
-        posix.close(conn_fd);
+        _ = std.c.close(conn_fd);
     }
 }
 
@@ -445,7 +443,7 @@ fn handleControlConnection(
 ) void {
     const bytes = readLineFromFdWithTimeout(allocator, io, conn_fd, max_message_bytes, control_request_read_timeout_ms) catch |err| {
         log.debug("failed to read control request: {}", .{err});
-        writeControlResponse(conn_fd, .{ .failure = .{
+        writeControlResponse(io, conn_fd, .{ .failure = .{
             .code = .invalid_request,
             .message = "invalid control request",
         } }) catch |write_err| {
@@ -456,7 +454,7 @@ fn handleControlConnection(
     defer allocator.free(bytes);
 
     var parsed = std.json.parseFromSlice(std.json.Value, allocator, bytes, .{}) catch {
-        writeControlResponse(conn_fd, .{ .failure = .{
+        writeControlResponse(io, conn_fd, .{ .failure = .{
             .code = .invalid_request,
             .message = "request is not valid JSON",
         } }) catch |write_err| {
@@ -467,7 +465,7 @@ fn handleControlConnection(
     defer parsed.deinit();
 
     var request = parseSpawnRequestFromValue(allocator, parsed.value) catch |err| {
-        writeControlResponse(conn_fd, .{ .failure = .{
+        writeControlResponse(io, conn_fd, .{ .failure = .{
             .code = .invalid_request,
             .message = parseErrorMessage(err),
         } }) catch |write_err| {
@@ -484,7 +482,7 @@ fn handleControlConnection(
     }) catch |err| {
         log.warn("failed to queue control request: {}", .{err});
         request.deinit(allocator);
-        writeControlResponse(conn_fd, .{ .failure = .{
+        writeControlResponse(io, conn_fd, .{ .failure = .{
             .code = .spawn_failed,
             .message = "failed to queue spawn request",
         } }) catch |write_err| {
@@ -498,7 +496,7 @@ fn handleControlConnection(
     }
 
     const response = completion.wait();
-    writeControlResponse(conn_fd, response) catch |err| {
+    writeControlResponse(io, conn_fd, response) catch |err| {
         log.debug("failed to write control response: {}", .{err});
     };
 }
@@ -516,15 +514,14 @@ pub fn parseErrorMessage(err: ParseSpawnRequestError) []const u8 {
 }
 
 fn writeDiscoveryFile(allocator: std.mem.Allocator, io: std.Io, path: []const u8, socket_path: []const u8) !void {
-    _ = io;
     const payload = try discoveryPayloadAlloc(allocator, socket_path);
     defer allocator.free(payload);
 
     const dir_path = std.fs.path.dirname(path) orelse return error.InvalidDiscoveryPath;
     const base_name = std.fs.path.basename(path);
 
-    var dir = try std.fs.openDirAbsolute(dir_path, .{});
-    defer dir.close();
+    var dir = try std.Io.Dir.openDirAbsolute(io, dir_path, .{});
+    defer dir.close(io);
 
     const temp_name = try std.fmt.allocPrint(
         allocator,
@@ -533,26 +530,26 @@ fn writeDiscoveryFile(allocator: std.mem.Allocator, io: std.Io, path: []const u8
     );
     defer allocator.free(temp_name);
 
-    var file = try dir.createFile(temp_name, .{
+    var file = try dir.createFile(io, temp_name, .{
         .exclusive = true,
         .mode = 0o600,
     });
     var file_open = true;
-    errdefer if (file_open) file.close();
-    errdefer deleteTempDiscoveryFile(&dir, temp_name);
+    errdefer if (file_open) file.close(io);
+    errdefer deleteTempDiscoveryFile(io, &dir, temp_name);
 
     try posix.fchmod(file.handle, 0o600);
-    try file.writeAll(payload);
-    try file.sync();
-    file.close();
+    try file.writeStreamingAll(io, payload);
+    try file.sync(io);
+    file.close(io);
     file_open = false;
 
-    try dir.rename(temp_name, base_name);
+    try dir.rename(temp_name, dir, base_name, io);
     log.info("wrote control discovery file {s} for socket {s}", .{ path, socket_path });
 }
 
-fn deleteTempDiscoveryFile(dir: *std.fs.Dir, temp_name: []const u8) void {
-    dir.deleteFile(temp_name) catch |err| switch (err) {
+fn deleteTempDiscoveryFile(io: std.Io, dir: *std.Io.Dir, temp_name: []const u8) void {
+    dir.deleteFile(io, temp_name) catch |err| switch (err) {
         error.FileNotFound => {},
         else => log.warn("failed to delete temporary control discovery file {s}: {}", .{ temp_name, err }),
     };
@@ -606,7 +603,8 @@ fn readLineFromFdWithTimeout(
             if (ready == 0) return error.TimedOut;
         }
 
-        const n = posix.read(fd, &tmp) catch |err| switch (err) {
+        const file: std.Io.File = .{ .handle = fd, .flags = .{ .nonblocking = true } };
+        const n = file.readStreaming(io, &.{&tmp}) catch |err| switch (err) {
             error.WouldBlock => continue,
             else => return err,
         };
@@ -626,21 +624,17 @@ fn readLineFromFdWithTimeout(
     return try buffer.toOwnedSlice(allocator);
 }
 
-fn writeAllFd(fd: posix.fd_t, bytes: []const u8) !void {
-    var written: usize = 0;
-    while (written < bytes.len) {
-        const n = try posix.write(fd, bytes[written..]);
-        if (n == 0) return error.WriteFailed;
-        written += n;
-    }
+fn writeAllFd(io: std.Io, fd: posix.fd_t, bytes: []const u8) !void {
+    const file: std.Io.File = .{ .handle = fd, .flags = .{ .nonblocking = true } };
+    try file.writeStreamingAll(io, bytes);
 }
 
-fn writeControlResponse(fd: posix.fd_t, response: SpawnResponse) !void {
+fn writeControlResponse(io: std.Io, fd: posix.fd_t, response: SpawnResponse) !void {
     var buffer: [512]u8 = undefined;
     var fbs = std.heap.FixedBufferAllocator.init(&buffer);
     const allocator = fbs.allocator();
     const payload = try controlResponseAlloc(allocator, response);
-    try writeAllFd(fd, payload);
+    try writeAllFd(io, fd, payload);
 }
 
 pub fn controlRequestAlloc(allocator: std.mem.Allocator, request: SpawnRequest) ![]u8 {
@@ -709,7 +703,7 @@ pub fn connectAndSendSpawnRequest(
 
     const payload = try controlRequestAlloc(allocator, request);
     defer allocator.free(payload);
-    try writeAllFd(connection.fd, payload);
+    try writeAllFd(io, connection.fd, payload);
 
     const response_bytes = try readLineFromFd(allocator, io, connection.fd, max_message_bytes);
     defer allocator.free(response_bytes);
@@ -721,7 +715,7 @@ const ControlConnection = struct {
     socket_path: []const u8,
 
     fn deinit(self: *ControlConnection, allocator: std.mem.Allocator) void {
-        posix.close(self.fd);
+        _ = std.c.close(self.fd);
         allocator.free(self.socket_path);
         self.* = undefined;
     }
@@ -729,7 +723,7 @@ const ControlConnection = struct {
 
 const DiscoveryCandidate = struct {
     socket_path: []const u8,
-    mtime: i128,
+    mtime: std.Io.Timestamp,
 
     fn deinit(self: *DiscoveryCandidate, allocator: std.mem.Allocator) void {
         allocator.free(self.socket_path);
@@ -749,13 +743,13 @@ fn connectToNewestControlSocket(allocator: std.mem.Allocator, io: std.Io) !Contr
     while (candidates.items.len > 0) {
         const idx = newestDiscoveryCandidateIndex(candidates.items);
         const candidate = candidates.items[idx];
-        const fd = connectControlSocket(candidate.socket_path) catch |err| {
+        const fd = connectControlSocket(io, candidate.socket_path) catch |err| {
             log.debug("failed to connect to discovered control socket {s}: {}", .{ candidate.socket_path, err });
             var removed = candidates.swapRemove(idx);
             removed.deinit(allocator);
             continue;
         };
-        errdefer posix.close(fd);
+        errdefer _ = std.c.close(fd);
         return .{
             .fd = fd,
             .socket_path = try allocator.dupe(u8, candidate.socket_path),
@@ -775,25 +769,25 @@ fn discoverControlCandidates(allocator: std.mem.Allocator, io: std.Io) !std.Arra
     var runtime_dir = try controlRuntimeDirAlloc(allocator, io);
     defer runtime_dir.deinit(allocator);
 
-    var dir = std.fs.openDirAbsolute(runtime_dir.path, .{ .iterate = true }) catch |err| switch (err) {
+    var dir = std.Io.Dir.openDirAbsolute(io, runtime_dir.path, .{ .iterate = true }) catch |err| switch (err) {
         error.FileNotFound => return candidates,
         else => return err,
     };
-    defer dir.close();
+    defer dir.close(io);
 
     const prefix = try controlDiscoveryFilePrefixAlloc(allocator);
     defer allocator.free(prefix);
 
     var iter = dir.iterate();
-    while (try iter.next()) |entry| {
+    while (try iter.next(io)) |entry| {
         if (entry.kind != .file) continue;
         if (!isOwnControlDiscoveryFileName(entry.name, prefix)) continue;
 
-        const stat = dir.statFile(entry.name) catch |err| {
+        const stat = dir.statFile(io, entry.name, .{}) catch |err| {
             log.debug("failed to stat control discovery file {s}: {}", .{ entry.name, err });
             continue;
         };
-        const discovery = dir.readFileAlloc(allocator, entry.name, max_message_bytes) catch |err| {
+        const discovery = dir.readFileAlloc(io, entry.name, allocator, .limited(max_message_bytes)) catch |err| {
             log.debug("failed to read control discovery file {s}: {}", .{ entry.name, err });
             continue;
         };
@@ -819,20 +813,17 @@ fn discoverControlCandidates(allocator: std.mem.Allocator, io: std.Io) !std.Arra
 fn newestDiscoveryCandidateIndex(candidates: []const DiscoveryCandidate) usize {
     var newest_idx: usize = 0;
     for (candidates[1..], 1..) |candidate, idx| {
-        if (candidate.mtime > candidates[newest_idx].mtime) {
+        if (candidate.mtime.nanoseconds > candidates[newest_idx].mtime.nanoseconds) {
             newest_idx = idx;
         }
     }
     return newest_idx;
 }
 
-fn connectControlSocket(socket_path: []const u8) !posix.fd_t {
-    const fd = try posix.socket(posix.AF.UNIX, posix.SOCK.STREAM, 0);
-    errdefer posix.close(fd);
-
-    const addr = try std.net.Address.initUnix(socket_path);
-    try posix.connect(fd, &addr.any, addr.getOsSockLen());
-    return fd;
+fn connectControlSocket(io: std.Io, socket_path: []const u8) !posix.fd_t {
+    const address = try std.Io.net.UnixAddress.init(socket_path);
+    const stream = try address.connect(io);
+    return stream.socket.handle;
 }
 
 fn staticFailure(code: SpawnErrorCode, message: []const u8) OwnedSpawnResponse {

--- a/src/app/control.zig
+++ b/src/app/control.zig
@@ -91,26 +91,26 @@ pub const RuntimeWake = struct {
 };
 
 pub const SpawnCompletion = struct {
-    mutex: std.Thread.Mutex = .{},
-    condition: std.Thread.Condition = .{},
+    mutex: std.Io.Mutex = .init,
+    condition: std.Io.Condition = .init,
     completed: bool = false,
     response: SpawnResponse = undefined,
 
-    pub fn complete(self: *SpawnCompletion, response: SpawnResponse) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+    pub fn complete(self: *SpawnCompletion, io: std.Io, response: SpawnResponse) void {
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         self.response = response;
         self.completed = true;
-        self.condition.signal();
+        self.condition.signal(io);
     }
 
-    pub fn wait(self: *SpawnCompletion) SpawnResponse {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+    pub fn wait(self: *SpawnCompletion, io: std.Io) SpawnResponse {
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         while (!self.completed) {
-            self.condition.wait(&self.mutex);
+            self.condition.waitUncancelable(io, &self.mutex);
         }
         return self.response;
     }
@@ -122,22 +122,22 @@ pub const PendingSpawn = struct {
 };
 
 pub const SpawnQueue = struct {
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = .init,
     items: std.ArrayListUnmanaged(PendingSpawn) = .empty,
 
     pub fn deinit(self: *SpawnQueue, allocator: std.mem.Allocator) void {
         self.items.deinit(allocator);
     }
 
-    pub fn push(self: *SpawnQueue, allocator: std.mem.Allocator, item: PendingSpawn) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+    pub fn push(self: *SpawnQueue, allocator: std.mem.Allocator, io: std.Io, item: PendingSpawn) !void {
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
         try self.items.append(allocator, item);
     }
 
-    pub fn drainAll(self: *SpawnQueue) std.ArrayListUnmanaged(PendingSpawn) {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+    pub fn drainAll(self: *SpawnQueue, io: std.Io) std.ArrayListUnmanaged(PendingSpawn) {
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
         const items = self.items;
         self.items = .empty;
         return items;
@@ -375,13 +375,14 @@ pub fn cleanupControlFiles(io: std.Io, socket_path: [:0]const u8, discovery_path
 pub fn failPending(
     queue: *SpawnQueue,
     allocator: std.mem.Allocator,
+    io: std.Io,
     code: SpawnErrorCode,
     message: []const u8,
 ) void {
-    var pending = queue.drainAll();
+    var pending = queue.drainAll(io);
     defer pending.deinit(allocator);
     for (pending.items) |*item| {
-        item.completion.complete(.{ .failure = .{ .code = code, .message = message } });
+        item.completion.complete(io, .{ .failure = .{ .code = code, .message = message } });
         item.request.deinit(allocator);
     }
 }
@@ -476,7 +477,7 @@ fn handleControlConnection(
     errdefer request.deinit(allocator);
 
     var completion = SpawnCompletion{};
-    queue.push(allocator, .{
+    queue.push(allocator, io, .{
         .request = request,
         .completion = &completion,
     }) catch |err| {
@@ -495,7 +496,7 @@ fn handleControlConnection(
         waker.notify();
     }
 
-    const response = completion.wait();
+    const response = completion.wait(io);
     writeControlResponse(io, conn_fd, response) catch |err| {
         log.debug("failed to write control response: {}", .{err});
     };
@@ -986,17 +987,17 @@ test "SpawnQueue drains queued requests" {
     defer queue.deinit(allocator);
 
     var completion = SpawnCompletion{};
-    try queue.push(allocator, .{
+    try queue.push(allocator, std.testing.io, .{
         .request = .{ .cwd = try allocator.dupe(u8, "/tmp") },
         .completion = &completion,
     });
 
-    var pending = queue.drainAll();
+    var pending = queue.drainAll(std.testing.io);
     defer pending.deinit(allocator);
     try std.testing.expectEqual(@as(usize, 1), pending.items.len);
     pending.items[0].request.deinit(allocator);
 
-    var empty = queue.drainAll();
+    var empty = queue.drainAll(std.testing.io);
     defer empty.deinit(allocator);
     try std.testing.expectEqual(@as(usize, 0), empty.items.len);
 }

--- a/src/app/layout.zig
+++ b/src/app/layout.zig
@@ -264,7 +264,7 @@ fn resizeTerminal(
     rows: u16,
     size: pty_mod.winsize,
 ) !void {
-    try terminal.resize(allocator, cols, rows);
+    try terminal.resize(allocator, .{ .cols = cols, .rows = rows });
     terminal.width_px = @intCast(size.ws_xpixel);
     terminal.height_px = @intCast(size.ws_ypixel);
     // Spec-allowed by DEC mode 2026: clear synchronized output on resize so the
@@ -337,7 +337,7 @@ const TestSessionFixture = struct {
     fn deinit(self: *TestSessionFixture, allocator: std.mem.Allocator) void {
         self.session.dead = true;
         self.session.deinit(allocator);
-        std.posix.close(self.slave_fd);
+        _ = std.c.close(self.slave_fd);
     }
 };
 
@@ -351,13 +351,13 @@ fn initSpawnedTestSession(
     const slave_fd = pty.slave;
     errdefer {
         pty.deinit();
-        std.posix.close(slave_fd);
+        _ = std.c.close(slave_fd);
     }
 
-    var terminal = try ghostty_vt.Terminal.init(allocator, .{
+    var terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{
         .cols = terminal_cols,
         .rows = terminal_rows,
-        .max_scrollback = 5,
+        .max_scrollback_bytes = 5,
     });
     errdefer terminal.deinit(allocator);
     terminal.width_px = @intCast(pty_size.ws_xpixel);
@@ -529,10 +529,10 @@ test "applyTerminalResize reports no change when the cell count already matches"
 test "terminal resize preserves prompt contents when shell does not redraw" {
     const allocator = std.testing.allocator;
 
-    var terminal = try ghostty_vt.Terminal.init(allocator, .{
+    var terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{
         .cols = 10,
         .rows = 3,
-        .max_scrollback = 5,
+        .max_scrollback_bytes = 5,
     });
     defer terminal.deinit(allocator);
 
@@ -561,10 +561,10 @@ test "terminal resize preserves prompt contents when shell does not redraw" {
 test "terminal resize clears semantic prompt when shell redraws prompt" {
     const allocator = std.testing.allocator;
 
-    var terminal = try ghostty_vt.Terminal.init(allocator, .{
+    var terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{
         .cols = 10,
         .rows = 3,
-        .max_scrollback = 5,
+        .max_scrollback_bytes = 5,
     });
     defer terminal.deinit(allocator);
 

--- a/src/app/layout.zig
+++ b/src/app/layout.zig
@@ -71,6 +71,7 @@ pub fn scaleEventToRender(event: *const c.SDL_Event, scale_x: f32, scale_y: f32)
 }
 
 pub fn calculateHoveredSession(
+    io: std.Io,
     mouse_x: c_int,
     mouse_y: c_int,
     anim_state: *const AnimationState,
@@ -92,7 +93,7 @@ pub fn calculateHoveredSession(
         },
         .Full, .PanningLeft, .PanningRight, .PanningUp, .PanningDown => anim_state.focused_session,
         .Expanding, .Collapsing => {
-            const rect = anim_state.getCurrentRect(clock.nowMillis());
+            const rect = anim_state.getCurrentRect(clock.nowMillis(io));
             if (mouse_x >= rect.x and mouse_x < rect.x + rect.w and
                 mouse_y >= rect.y and mouse_y < rect.y + rect.h)
             {
@@ -362,8 +363,9 @@ fn initSpawnedTestSession(
     terminal.width_px = @intCast(pty_size.ws_xpixel);
     terminal.height_px = @intCast(pty_size.ws_ypixel);
 
-    var session = try SessionState.init(allocator, 0, "/bin/zsh", pty_size, "sock", colors_mod.Theme.default(), null);
+    var session = try SessionState.init(allocator, std.testing.io, 0, "/bin/zsh", pty_size, "sock", colors_mod.Theme.default(), null);
     session.shell = .{
+        .io = std.testing.io,
         .pty = pty,
         .child_pid = 0,
     };

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -765,7 +765,7 @@ fn planExternalSpawnSlot(
     };
 }
 
-fn validateExternalSpawnCwd(cwd: []const u8) ?control.SpawnFailure {
+fn validateExternalSpawnCwd(io: std.Io, cwd: []const u8) ?control.SpawnFailure {
     if (!std.fs.path.isAbsolute(cwd)) {
         return .{
             .code = .invalid_cwd,
@@ -773,13 +773,13 @@ fn validateExternalSpawnCwd(cwd: []const u8) ?control.SpawnFailure {
         };
     }
 
-    var dir = std.fs.openDirAbsolute(cwd, .{}) catch {
+    var dir = std.Io.Dir.openDirAbsolute(io, cwd, .{}) catch {
         return .{
             .code = .invalid_cwd,
             .message = "cwd must be an existing directory",
         };
     };
-    dir.close();
+    dir.close(io);
     return null;
 }
 
@@ -892,7 +892,7 @@ fn handleExternalSpawnRequest(
     pending: *control.PendingSpawn,
 ) void {
     const allocator = context.allocator;
-    if (validateExternalSpawnCwd(pending.request.cwd)) |failure| {
+    if (validateExternalSpawnCwd(context.io, pending.request.cwd)) |failure| {
         pending.completion.complete(.{ .failure = failure });
         return;
     }
@@ -3682,9 +3682,9 @@ test "agentLabel reports the detected agent name or 'none'" {
 }
 
 test "validateExternalSpawnCwd accepts directories and rejects relative paths" {
-    try std.testing.expect(validateExternalSpawnCwd("/tmp") == null);
+    try std.testing.expect(validateExternalSpawnCwd(std.testing.io, "/tmp") == null);
 
-    const failure = validateExternalSpawnCwd("relative/path") orelse return error.TestUnexpectedResult;
+    const failure = validateExternalSpawnCwd(std.testing.io, "relative/path") orelse return error.TestUnexpectedResult;
     try std.testing.expectEqual(control.SpawnErrorCode.invalid_cwd, failure.code);
 }
 

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -80,6 +80,7 @@ const pending_session_send_timeout_ms: i64 = 10_000;
 
 const SpawnSessionContext = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
     sessions: []const *SessionState,
     grid: *GridLayout,
     anim_state: *AnimationState,
@@ -363,12 +364,13 @@ fn shouldSavePersistenceNow(dirty: bool, dirty_since_ms: i64, now_ms: i64) bool 
 fn savePersistenceIfDirty(
     persistence: *config_mod.Persistence,
     allocator: std.mem.Allocator,
+    io: std.Io,
     dirty: *bool,
     dirty_since_ms: *i64,
     now_ms: i64,
 ) void {
     if (!shouldSavePersistenceNow(dirty.*, dirty_since_ms.*, now_ms)) return;
-    persistence.save(allocator) catch |err| {
+    persistence.save(allocator, io) catch |err| {
         std.debug.print("Failed to save persistence: {}\n", .{err});
         return;
     };
@@ -1059,6 +1061,7 @@ fn swapTwoResources(
 
 const FontReloadContext = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
     renderer: *c.SDL_Renderer,
     shared_cache: *font_cache_mod.FontCache,
     ui_cache: *font_cache_mod.FontCache,
@@ -1090,6 +1093,7 @@ fn deinitFontResource(font: *font_mod.Font) void {
 
 fn reloadFontsForScale(
     allocator: std.mem.Allocator,
+    io: std.Io,
     renderer: *c.SDL_Renderer,
     shared_cache: *font_cache_mod.FontCache,
     ui_cache: *font_cache_mod.FontCache,
@@ -1101,6 +1105,7 @@ fn reloadFontsForScale(
 ) font_mod.Font.InitError!void {
     var ctx = FontReloadContext{
         .allocator = allocator,
+        .io = io,
         .renderer = renderer,
         .shared_cache = shared_cache,
         .ui_cache = ui_cache,
@@ -1138,6 +1143,7 @@ fn applyScaleChangeAndResize(
 
 const RuntimeScaleChangeContext = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
     renderer: *c.SDL_Renderer,
     shared_font_cache: *font_cache_mod.FontCache,
     ui_font_cache: *font_cache_mod.FontCache,
@@ -1162,6 +1168,7 @@ const RuntimeScaleChangeContext = struct {
 fn reloadRuntimeFontsForScaleChange(ctx: *RuntimeScaleChangeContext) font_mod.Font.InitError!void {
     try reloadFontsForScale(
         ctx.allocator,
+        ctx.io,
         ctx.renderer,
         ctx.shared_font_cache,
         ctx.ui_font_cache,
@@ -1225,6 +1232,7 @@ const QuitTeardownTask = struct {
 };
 
 const QuitTeardownWorker = struct {
+    io: std.Io,
     tasks: []QuitTeardownTask,
     done: *std.atomic.Value(bool),
 
@@ -1232,9 +1240,9 @@ const QuitTeardownWorker = struct {
         defer self.done.store(true, .seq_cst);
         var threads: [grid_layout.max_terminals]?std.Thread = [_]?std.Thread{null} ** grid_layout.max_terminals;
         for (self.tasks, 0..) |*task, idx| {
-            threads[idx] = std.Thread.spawn(.{}, runTask, .{task}) catch |err| blk: {
+            threads[idx] = std.Thread.spawn(.{}, runTask, .{ self.io, task }) catch |err| blk: {
                 log.warn("quit teardown: failed to spawn parallel task for session {d}: {}", .{ task.session_idx, err });
-                runTask(task);
+                runTask(self.io, task);
                 break :blk null;
             };
         }
@@ -1245,23 +1253,23 @@ const QuitTeardownWorker = struct {
         }
     }
 
-    fn runTask(task: *QuitTeardownTask) void {
+    fn runTask(io: std.Io, task: *QuitTeardownTask) void {
         log.info("quit teardown: session {d} has foreground agent {s}", .{ task.session_idx, task.agent_kind.name() });
-        sendExitSequence(task.pty_master, task.agent_kind);
-        clock.sleepNanos(quit_primary_wait_ms * std.time.ns_per_ms);
+        sendExitSequence(io, task.pty_master, task.agent_kind);
+        clock.sleepNanos(io, quit_primary_wait_ms * std.time.ns_per_ms);
 
         var fg_pgrp = foregroundPgrp(task.slavePathZ(), task.shell_pid);
         if (fg_pgrp != null) {
             log.debug("quit teardown: session {d} agent {s} still foreground after primary quit, retrying with interrupt", .{ task.session_idx, task.agent_kind.name() });
-            sendExitSequence(task.pty_master, task.agent_kind);
-            clock.sleepNanos(quit_retry_wait_ms * std.time.ns_per_ms);
+            sendExitSequence(io, task.pty_master, task.agent_kind);
+            clock.sleepNanos(io, quit_retry_wait_ms * std.time.ns_per_ms);
             fg_pgrp = foregroundPgrp(task.slavePathZ(), task.shell_pid);
         }
 
         if (fg_pgrp) |pgrp| {
             log.debug("quit teardown: session {d} agent {s} did not exit gracefully, sending SIGTERM", .{ task.session_idx, task.agent_kind.name() });
             _ = std.c.kill(-pgrp, std.c.SIG.TERM);
-            clock.sleepNanos(quit_term_wait_ms * std.time.ns_per_ms);
+            clock.sleepNanos(io, quit_term_wait_ms * std.time.ns_per_ms);
         } else {
             log.debug("quit teardown: session {d} agent {s} exited gracefully", .{ task.session_idx, task.agent_kind.name() });
         }
@@ -1276,7 +1284,7 @@ const QuitTeardownState = struct {
     worker: QuitTeardownWorker = undefined,
     thread: ?std.Thread = null,
 
-    fn start(self: *QuitTeardownState, sessions: []*SessionState) !bool {
+    fn start(self: *QuitTeardownState, io: std.Io, sessions: []*SessionState) !bool {
         if (self.active) return true;
 
         self.task_count = 0;
@@ -1303,6 +1311,7 @@ const QuitTeardownState = struct {
 
         self.done.store(false, .seq_cst);
         self.worker = .{
+            .io = io,
             .tasks = self.tasks[0..self.task_count],
             .done = &self.done,
         };
@@ -1327,7 +1336,7 @@ const QuitTeardownState = struct {
     }
 };
 
-fn sendExitSequence(master_fd: posix.fd_t, agent_kind: session_state.AgentKind) void {
+fn sendExitSequence(io: std.Io, master_fd: posix.fd_t, agent_kind: session_state.AgentKind) void {
     const sequence = agent_kind.exitControlSequence();
     for (sequence, 0..) |byte, idx| {
         const buf = [1]u8{byte};
@@ -1336,7 +1345,7 @@ fn sendExitSequence(master_fd: posix.fd_t, agent_kind: session_state.AgentKind) 
             return;
         };
         if (idx + 1 < sequence.len) {
-            clock.sleepNanos(220 * std.time.ns_per_ms);
+            clock.sleepNanos(io, 220 * std.time.ns_per_ms);
         }
     }
     log.debug("quit teardown: wrote exit command for agent {s}", .{agent_kind.name()});
@@ -1352,7 +1361,7 @@ fn foregroundPgrp(slave_path_z: [:0]const u8, shell_pid: posix.pid_t) ?posix.pid
     return fg_pgrp;
 }
 
-fn drainQuitCaptureOutput(tasks: []const QuitTeardownTask, sessions: []const *SessionState) void {
+fn drainQuitCaptureOutput(io: std.Io, tasks: []const QuitTeardownTask, sessions: []const *SessionState) void {
     if (tasks.len == 0) return;
 
     var last_capture_lengths: [grid_layout.max_terminals]usize = [_]usize{0} ** grid_layout.max_terminals;
@@ -1360,7 +1369,7 @@ fn drainQuitCaptureOutput(tasks: []const QuitTeardownTask, sessions: []const *Se
         last_capture_lengths[idx] = sessions[task.session_idx].quitCaptureBytes().len;
     }
 
-    const start_ns = clock.nowNanos();
+    const start_ns = clock.nowNanos(io);
     var last_growth_ns = start_ns;
 
     while (true) {
@@ -1377,13 +1386,13 @@ fn drainQuitCaptureOutput(tasks: []const QuitTeardownTask, sessions: []const *Se
             last_capture_lengths[idx] = new_len;
         }
 
-        const now_ns = clock.nowNanos();
+        const now_ns = clock.nowNanos(io);
         if (saw_growth) {
             last_growth_ns = now_ns;
         }
 
         if (!shouldContinueQuitCaptureDrain(start_ns, last_growth_ns, now_ns)) break;
-        clock.sleepNanos(quit_capture_drain_poll_ns);
+        clock.sleepNanos(io, quit_capture_drain_poll_ns);
     }
 }
 
@@ -1394,13 +1403,14 @@ fn shouldContinueQuitCaptureDrain(start_ns: i128, last_growth_ns: i128, now_ns: 
 }
 
 fn startQuitFlow(
+    io: std.Io,
     quit_state: *QuitTeardownState,
     sessions: []*SessionState,
     overlay: *ui_mod.quit_blocking_overlay.QuitBlockingOverlayComponent,
 ) bool {
     if (builtin.os.tag != .macos) return true;
     if (quit_state.active) return false;
-    const started = quit_state.start(sessions) catch |err| {
+    const started = quit_state.start(io, sessions) catch |err| {
         log.warn("quit teardown: failed to start worker thread: {}", .{err});
         return true;
     };
@@ -1409,7 +1419,7 @@ fn startQuitFlow(
     return false;
 }
 
-pub fn run(log_dir_override: ?[]const u8) !void {
+pub fn run(io: std.Io, log_dir_override: ?[]const u8) !void {
     var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
@@ -1425,10 +1435,10 @@ pub fn run(log_dir_override: ?[]const u8) !void {
     const notify_sock = try notify.getNotifySocketPath(allocator);
     defer allocator.free(notify_sock);
 
-    const control_sock = try control.getControlSocketPath(allocator);
+    const control_sock = try control.getControlSocketPath(allocator, io);
     defer allocator.free(control_sock);
 
-    const control_discovery_path = try control.getControlDiscoveryPath(allocator);
+    const control_discovery_path = try control.getControlDiscoveryPath(allocator, io);
     defer allocator.free(control_discovery_path);
 
     var notify_stop = std.atomic.Value(bool).init(false);
@@ -1437,10 +1447,10 @@ pub fn run(log_dir_override: ?[]const u8) !void {
     var pty_wake_pending = std.atomic.Value(bool).init(false);
     var pty_reader_state = pty_reader.PtyReader{};
 
-    var config = config_mod.Config.load(allocator) catch |err| blk: {
+    var config = config_mod.Config.load(allocator, io) catch |err| blk: {
         if (err == error.ConfigNotFound) {
             std.debug.print("Config not found, creating default config file\n", .{});
-            config_mod.Config.createDefaultConfigFile(allocator) catch |create_err| {
+            config_mod.Config.createDefaultConfigFile(allocator, io) catch |create_err| {
                 std.debug.print("Failed to create default config: {}\n", .{create_err});
             };
         } else {
@@ -1457,7 +1467,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
     defer config.deinit(allocator);
 
     var file_logging_enabled = false;
-    logging_mod.init(allocator, .{
+    logging_mod.init(allocator, io, .{
         .min_level = config.logging.getMinLevel(),
         .directory_override = log_dir_override,
     }) catch |err| {
@@ -1478,9 +1488,9 @@ pub fn run(log_dir_override: ?[]const u8) !void {
         logging_mod.deinit();
     }
 
-    var persistence = config_mod.Persistence.load(allocator) catch |err| blk: {
+    var persistence = config_mod.Persistence.load(allocator, io) catch |err| blk: {
         std.debug.print("Failed to load persistence: {}, using defaults\n", .{err});
-        var fallback = config_mod.Persistence.init(allocator);
+        var fallback = config_mod.Persistence.init(allocator, io);
         fallback.font_size = config.font.size;
         fallback.window = config.window;
         break :blk fallback;
@@ -1534,6 +1544,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
     defer platform.stopTextInput(sdl.window);
     const notify_thread = try notify.startNotifyThread(
         allocator,
+        io,
         notify_sock,
         &notify_queue,
         &notify_stop,
@@ -1548,6 +1559,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
     }
     const control_thread = try control.startControlThread(
         allocator,
+        io,
         control_sock,
         control_discovery_path,
         &control_queue,
@@ -1561,9 +1573,10 @@ pub fn run(log_dir_override: ?[]const u8) !void {
         control_stop.store(true, .seq_cst);
         control.failPending(&control_queue, allocator, .app_not_running, "Architect is shutting down");
         control_thread.join();
-        control.cleanupControlFiles(control_sock, control_discovery_path);
+        control.cleanupControlFiles(io, control_sock, control_discovery_path);
     }
     const pty_reader_thread = try pty_reader.start(
+        io,
         &pty_reader_state,
         &pty_reader_stop,
         &pty_wake_pending,
@@ -1596,7 +1609,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
     var scale_y = sdl.scale_y;
     var ui_scale: f32 = @max(scale_x, scale_y);
 
-    var font_paths = try font_paths_mod.FontPaths.init(allocator, config.font.family);
+    var font_paths = try font_paths_mod.FontPaths.init(allocator, io, config.font.family);
     defer font_paths.deinit();
 
     var shared_font_cache = font_cache_mod.FontCache.initWithFallbacks(allocator, false);
@@ -1692,7 +1705,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
 
     // Initialize all session slots
     for (0..grid_layout.max_terminals) |i| {
-        sessions_storage[i] = try SessionState.init(allocator, i, shell_path, size, notify_sock, theme, &pty_reader_state);
+        sessions_storage[i] = try SessionState.init(allocator, io, i, shell_path, size, notify_sock, theme, &pty_reader_state);
         sessions[i] = &sessions_storage[i];
         init_count += 1;
     }
@@ -1854,8 +1867,8 @@ pub fn run(log_dir_override: ?[]const u8) !void {
     var next_frame_wait: FrameWaitDecision = .none;
     while (running) {
         var next_event = waitForNextFrame(next_frame_wait);
-        const frame_start_ns: i128 = clock.nowNanos();
-        const now = clock.nowMillis();
+        const frame_start_ns: i128 = clock.nowNanos(io);
+        const now = clock.nowMillis(io);
         if (relaunch_trace_frames > 0) {
             log.info("frame trace start mode={s} grid_resizing={} grid={d}x{d}", .{
                 @tagName(anim_state.mode),
@@ -1925,7 +1938,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
                 c.SDL_EVENT_QUIT => {
                     if (quit_teardown.active) continue;
                     if (handleQuitRequest(sessions[0..], quit_confirm_component)) {
-                        if (startQuitFlow(&quit_teardown, sessions[0..], quit_blocking_overlay_component)) {
+                        if (startQuitFlow(io, &quit_teardown, sessions[0..], quit_blocking_overlay_component)) {
                             running = false;
                         }
                     }
@@ -1938,7 +1951,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
                         continue;
                     }
                     if (handleQuitRequest(sessions[0..], quit_confirm_component)) {
-                        if (startQuitFlow(&quit_teardown, sessions[0..], quit_blocking_overlay_component)) {
+                        if (startQuitFlow(io, &quit_teardown, sessions[0..], quit_blocking_overlay_component)) {
                             running = false;
                         }
                     }
@@ -1960,6 +1973,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
                     ui_scale = @max(scale_x, scale_y);
                     var scale_change_ctx = RuntimeScaleChangeContext{
                         .allocator = allocator,
+                        .io = io,
                         .renderer = renderer,
                         .shared_font_cache = &shared_font_cache,
                         .ui_font_cache = &ui_font_cache,
@@ -2061,6 +2075,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
                     const mouse_y: c_int = @intFromFloat(scaled_event.drop.y);
 
                     const hovered_session = layout.calculateHoveredSession(
+                        io,
                         mouse_x,
                         mouse_y,
                         &anim_state,
@@ -2103,7 +2118,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
                         if (quit_teardown.active) continue;
                         if (config.ui.show_hotkey_feedback) ui.showHotkey("⌘Q", now);
                         if (handleQuitRequest(sessions[0..], quit_confirm_component)) {
-                            if (startQuitFlow(&quit_teardown, sessions[0..], quit_blocking_overlay_component)) {
+                            if (startQuitFlow(io, &quit_teardown, sessions[0..], quit_blocking_overlay_component)) {
                                 running = false;
                             }
                         }
@@ -2644,7 +2659,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
         if (terminal_entries_changed) {
             markPersistenceDirty(&persistence_dirty, &persistence_dirty_since_ms, now);
         }
-        savePersistenceIfDirty(&persistence, allocator, &persistence_dirty, &persistence_dirty_since_ms, now);
+        savePersistenceIfDirty(&persistence, allocator, io, &persistence_dirty, &persistence_dirty_since_ms, now);
 
         if (quit_teardown.isFinished()) {
             running = false;
@@ -2658,6 +2673,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
 
         const spawn_context = SpawnSessionContext{
             .allocator = allocator,
+            .io = io,
             .sessions = sessions,
             .grid = &grid,
             .anim_state = &anim_state,
@@ -2946,7 +2962,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
             },
             .ConfirmQuit => {
                 if (!quit_teardown.active) {
-                    if (startQuitFlow(&quit_teardown, sessions[0..], quit_blocking_overlay_component)) {
+                    if (startQuitFlow(io, &quit_teardown, sessions[0..], quit_blocking_overlay_component)) {
                         running = false;
                     }
                 }
@@ -2957,7 +2973,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
                     if (config.ui.show_hotkey_feedback) ui.showHotkey("⌘,", now);
 
                     if (builtin.os.tag == .macos) {
-                        _ = proc.spawnDetached(allocator, &.{ "open", "-t", config_path }) catch |err| {
+                        _ = proc.spawnDetached(allocator, io, &.{ "open", "-t", config_path }) catch |err| {
                             std.debug.print("Failed to open config file: {}\n", .{err});
                         };
                     } else {
@@ -3413,7 +3429,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
                 log.info("frame trace after render", .{});
             }
             metrics_mod.increment(.frame_count);
-            last_render_ns = clock.nowNanos();
+            last_render_ns = clock.nowNanos(io);
         }
 
         if (relaunch_trace_frames > 0) {
@@ -3426,13 +3442,13 @@ pub fn run(log_dir_override: ?[]const u8) !void {
             window_close_suppress_countdown -= 1;
         }
 
-        const frame_end_ns: i128 = clock.nowNanos();
+        const frame_end_ns: i128 = clock.nowNanos(io);
         const frame_ns = frame_end_ns - frame_start_ns;
         next_frame_wait = computeFrameWaitDecision(is_idle, sdl.vsync_enabled, frame_ns);
     }
 
     if (builtin.os.tag == .macos) {
-        const now = clock.nowMillis();
+        const now = clock.nowMillis(io);
         for (sessions) |session| {
             session.updateCwd(now);
         }
@@ -3440,7 +3456,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
         if (quit_teardown.active) {
             quit_blocking_overlay_component.setActive(false);
             quit_teardown.join();
-            drainQuitCaptureOutput(quit_teardown.tasks[0..quit_teardown.task_count], sessions[0..]);
+            drainQuitCaptureOutput(io, quit_teardown.tasks[0..quit_teardown.task_count], sessions[0..]);
             for (quit_teardown.tasks[0..quit_teardown.task_count]) |task| {
                 const session = sessions[task.session_idx];
                 session.stopQuitCapture();
@@ -3473,7 +3489,7 @@ pub fn run(log_dir_override: ?[]const u8) !void {
         };
     }
 
-    persistence.save(allocator) catch |err| {
+    persistence.save(allocator, io) catch |err| {
         std.debug.print("Failed to save persistence: {}\n", .{err});
     };
     persistence.deinit(allocator);
@@ -3616,11 +3632,13 @@ test "drainPendingSessionSends waits for the deadline, then writes the pending t
     session.spawned = true;
     session.dead = false;
     session.shell = shell_mod.Shell{
+        .io = std.testing.io,
         .pty = .{ .master = pipe_fds[1], .slave = pipe_fds[0] },
         .child_pid = -1,
     };
     session.pending_write = .empty;
     session.allocator = allocator;
+    session.io = std.testing.io;
     var sessions = [_]*SessionState{&session};
 
     var pending_sends = std.ArrayList(PendingSessionSend).empty;
@@ -4001,7 +4019,7 @@ test "seedSessionAgentMetadataFromEntry seeds known restored metadata" {
 test "syncPersistenceTerminalEntriesFromSessions ignores restored agent metadata until quit capture" {
     const allocator = std.testing.allocator;
 
-    var persistence = config_mod.Persistence.init(allocator);
+    var persistence = config_mod.Persistence.init(allocator, std.testing.io);
     defer persistence.deinit(allocator);
 
     try persistence.appendTerminalEntry(allocator, "/one", "codex", "stale-seed");
@@ -4029,7 +4047,7 @@ test "syncPersistenceTerminalEntriesFromSessions ignores restored agent metadata
 test "syncPersistenceTerminalEntriesFromSessions reacts to cd, spawn, and despawn" {
     const allocator = std.testing.allocator;
 
-    var persistence = config_mod.Persistence.init(allocator);
+    var persistence = config_mod.Persistence.init(allocator, std.testing.io);
     defer persistence.deinit(allocator);
 
     var sessions_storage: [2]SessionState = undefined;

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -1791,7 +1791,7 @@ pub fn run(io: std.Io, log_dir_override: ?[]const u8) !void {
     try ui.register(session_interaction_component.asComponent());
 
     const worktree_comp_ptr = try allocator.create(ui_mod.worktree_overlay.WorktreeOverlayComponent);
-    worktree_comp_ptr.* = .{ .allocator = allocator };
+    worktree_comp_ptr.* = .{ .allocator = allocator, .io = io };
     const worktree_component = ui_mod.UiComponent{
         .ptr = worktree_comp_ptr,
         .vtable = &ui_mod.worktree_overlay.WorktreeOverlayComponent.vtable,
@@ -1819,7 +1819,7 @@ pub fn run(io: std.Io, log_dir_override: ?[]const u8) !void {
     try ui.register(help_component);
 
     const pr_dropdown_comp_ptr = try allocator.create(ui_mod.pr_dropdown.PRDropdownComponent);
-    pr_dropdown_comp_ptr.* = .{ .allocator = allocator };
+    pr_dropdown_comp_ptr.* = .{ .allocator = allocator, .io = io };
     const pr_dropdown_component = ui_mod.UiComponent{
         .ptr = pr_dropdown_comp_ptr,
         .vtable = &ui_mod.pr_dropdown.PRDropdownComponent.vtable,
@@ -1851,11 +1851,11 @@ pub fn run(io: std.Io, log_dir_override: ?[]const u8) !void {
     try ui.register(cwd_bar_component.asComponent());
     const metrics_overlay_component = try ui_mod.metrics_overlay.MetricsOverlayComponent.init(allocator);
     try ui.register(metrics_overlay_component.asComponent());
-    const diff_overlay_component = try ui_mod.diff_overlay.DiffOverlayComponent.init(allocator);
+    const diff_overlay_component = try ui_mod.diff_overlay.DiffOverlayComponent.init(allocator, io);
     try ui.register(diff_overlay_component.asComponent());
     const reader_overlay_component = try ui_mod.reader_overlay.ReaderOverlayComponent.init(allocator, sessions);
     try ui.register(reader_overlay_component.asComponent());
-    const story_overlay_component = try ui_mod.story_overlay.StoryOverlayComponent.init(allocator);
+    const story_overlay_component = try ui_mod.story_overlay.StoryOverlayComponent.init(allocator, io);
     try ui.register(story_overlay_component.asComponent());
     const selection_agent_overlay_component = try ui_mod.selection_agent_overlay.SelectionAgentOverlayComponent.init(allocator);
     try ui.register(selection_agent_overlay_component.asComponent());

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -17,6 +17,7 @@ const terminal_actions = @import("terminal_actions.zig");
 const ui_host = @import("ui_host.zig");
 const worktree = @import("worktree.zig");
 const control = @import("control.zig");
+const posix_util = @import("../posix_util.zig");
 const notify = @import("../session/notify.zig");
 const pty_reader = @import("../session/pty_reader.zig");
 const session_state = @import("../session/state.zig");
@@ -3624,9 +3625,10 @@ test "drainPendingSessionSends waits for the deadline, then writes the pending t
     // A pipe stands in for the PTY: `Shell.write` writes to `pty.master`, so the
     // test can read the other end to observe exactly what was sent, instead of
     // trusting a fabricated session whose `sendInput` would silently no-op.
-    const pipe_fds = try posix.pipe();
-    defer posix.close(pipe_fds[0]);
-    defer posix.close(pipe_fds[1]);
+    var pipe_fds: [2]std.posix.fd_t = undefined;
+    try posix_util.pipe(&pipe_fds);
+    defer _ = std.c.close(pipe_fds[0]);
+    defer _ = std.c.close(pipe_fds[1]);
 
     var session: SessionState = undefined;
     session.id = 1;

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -794,11 +794,12 @@ fn buildQueuedCommand(allocator: std.mem.Allocator, command: []const u8) ![]u8 {
 }
 
 fn completeExternalSpawnFailure(
+    io: std.Io,
     pending: *control.PendingSpawn,
     code: control.SpawnErrorCode,
     message: []const u8,
 ) void {
-    pending.completion.complete(.{ .failure = .{
+    pending.completion.complete(io, .{ .failure = .{
         .code = code,
         .message = message,
     } });
@@ -893,14 +894,14 @@ fn handleExternalSpawnRequest(
 ) void {
     const allocator = context.allocator;
     if (validateExternalSpawnCwd(context.io, pending.request.cwd)) |failure| {
-        pending.completion.complete(.{ .failure = failure });
+        pending.completion.complete(context.io, .{ .failure = failure });
         return;
     }
 
     const command_input = if (pending.request.command) |command| blk: {
         break :blk buildQueuedCommand(allocator, command) catch |err| {
             log.warn("failed to prepare external spawn command: {}", .{err});
-            completeExternalSpawnFailure(pending, .spawn_failed, "failed to prepare command for the new session");
+            completeExternalSpawnFailure(context.io, pending, .spawn_failed, "failed to prepare command for the new session");
             return;
         };
     } else null;
@@ -908,7 +909,7 @@ fn handleExternalSpawnRequest(
 
     const cwd_buf = allocZ(allocator, pending.request.cwd) catch |err| {
         log.warn("failed to allocate external spawn cwd: {}", .{err});
-        completeExternalSpawnFailure(pending, .spawn_failed, "failed to prepare working directory");
+        completeExternalSpawnFailure(context.io, pending, .spawn_failed, "failed to prepare working directory");
         return;
     };
     defer allocator.free(cwd_buf);
@@ -921,11 +922,11 @@ fn handleExternalSpawnRequest(
         else
             "failed to spawn terminal session";
         const code: control.SpawnErrorCode = if (err == error.NoFreeSession) .full_grid else .spawn_failed;
-        completeExternalSpawnFailure(pending, code, message);
+        completeExternalSpawnFailure(context.io, pending, code, message);
         return;
     };
 
-    pending.completion.complete(.{ .success = .{
+    pending.completion.complete(context.io, .{ .success = .{
         .session_id = session.id,
         .slot_index = session.slot_index,
     } });
@@ -1445,7 +1446,7 @@ pub fn run(io: std.Io, log_dir_override: ?[]const u8) !void {
     var control_stop = std.atomic.Value(bool).init(false);
     var pty_reader_stop = std.atomic.Value(bool).init(false);
     var pty_wake_pending = std.atomic.Value(bool).init(false);
-    var pty_reader_state = pty_reader.PtyReader{};
+    var pty_reader_state = pty_reader.PtyReader.init(io);
 
     var config = config_mod.Config.load(allocator, io) catch |err| blk: {
         if (err == error.ConfigNotFound) {
@@ -1571,7 +1572,7 @@ pub fn run(io: std.Io, log_dir_override: ?[]const u8) !void {
     );
     defer {
         control_stop.store(true, .seq_cst);
-        control.failPending(&control_queue, allocator, .app_not_running, "Architect is shutting down");
+        control.failPending(&control_queue, allocator, io, .app_not_running, "Architect is shutting down");
         control_thread.join();
         control.cleanupControlFiles(io, control_sock, control_discovery_path);
     }
@@ -2692,7 +2693,7 @@ pub fn run(io: std.Io, log_dir_override: ?[]const u8) !void {
             .cell_height_pixels = &cell_height_pixels,
         };
 
-        var control_requests = control_queue.drainAll();
+        var control_requests = control_queue.drainAll(io);
         defer control_requests.deinit(allocator);
         const had_control_requests = control_requests.items.len > 0;
         for (control_requests.items) |*request| {
@@ -2700,7 +2701,7 @@ pub fn run(io: std.Io, log_dir_override: ?[]const u8) !void {
             request.request.deinit(allocator);
         }
 
-        var notifications = notify_queue.drainAll();
+        var notifications = notify_queue.drainAll(io);
         defer notifications.deinit(allocator);
         const had_notifications = notifications.items.len > 0;
         for (notifications.items) |note| {

--- a/src/app/runtime.zig
+++ b/src/app/runtime.zig
@@ -1342,7 +1342,7 @@ fn sendExitSequence(io: std.Io, master_fd: posix.fd_t, agent_kind: session_state
     const sequence = agent_kind.exitControlSequence();
     for (sequence, 0..) |byte, idx| {
         const buf = [1]u8{byte};
-        _ = posix.write(master_fd, &buf) catch |err| {
+        _ = posix_util.write(master_fd, &buf) catch |err| {
             log.warn("quit teardown: failed to send exit key sequence (step {d}) for {s}: {}", .{ idx + 1, agent_kind.name(), err });
             return;
         };
@@ -1354,8 +1354,15 @@ fn sendExitSequence(io: std.Io, master_fd: posix.fd_t, agent_kind: session_state
 }
 
 fn foregroundPgrp(slave_path_z: [:0]const u8, shell_pid: posix.pid_t) ?posix.pid_t {
-    const fd = posix.openZ(slave_path_z, .{ .ACCMODE = .RDONLY, .NOCTTY = true }, 0) catch return null;
-    defer posix.close(fd);
+    const fd = while (true) {
+        const open_fd = std.c.open(slave_path_z, .{ .ACCMODE = .RDONLY, .NOCTTY = true }, @as(std.c.mode_t, 0));
+        switch (std.c.errno(open_fd)) {
+            .SUCCESS => break open_fd,
+            .INTR => continue,
+            else => return null,
+        }
+    };
+    defer _ = std.c.close(fd);
     const fg = tcgetpgrp(fd);
     if (fg <= 0) return null;
     const fg_pgrp: posix.pid_t = @intCast(fg);

--- a/src/app/terminal_actions.zig
+++ b/src/app/terminal_actions.zig
@@ -79,7 +79,6 @@ pub fn pasteText(
             defer allocator.free(buf);
             break :blk ghostty_vt.input.encodePaste(buf, opts);
         },
-        else => return err,
     };
 
     for (slices) |part| {

--- a/src/app/terminal_history.zig
+++ b/src/app/terminal_history.zig
@@ -182,10 +182,10 @@ test "stripAnsiAlloc converts OSC 133 prompt markers to marker line" {
 test "extractTerminalText roundtrip includes scrollback and viewport text" {
     const allocator = std.testing.allocator;
 
-    var terminal = try ghostty_vt.Terminal.init(allocator, .{
+    var terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{
         .cols = 8,
         .rows = 3,
-        .max_scrollback = 8 * 32,
+        .max_scrollback_bytes = 8 * 32,
     });
     defer terminal.deinit(allocator);
 

--- a/src/clock.zig
+++ b/src/clock.zig
@@ -11,26 +11,32 @@ const std = @import("std");
 /// functions did. `nowNanos` is used for frame pacing, which would be better
 /// served by a monotonic clock, but switching it is a behavior change and is
 /// deliberately out of scope for the toolchain migration.
-pub fn nowSeconds() i64 {
-    return std.time.timestamp();
+pub fn nowSeconds(io: std.Io) i64 {
+    return std.Io.Timestamp.now(io, .real).toSeconds();
 }
 
-pub fn nowMillis() i64 {
-    return std.time.milliTimestamp();
+pub fn nowMillis(io: std.Io) i64 {
+    return std.Io.Timestamp.now(io, .real).toMilliseconds();
 }
 
-pub fn nowNanos() i128 {
-    return std.time.nanoTimestamp();
+pub fn nowNanos(io: std.Io) i128 {
+    return std.Io.Timestamp.now(io, .real).toNanoseconds();
 }
 
-pub fn sleepNanos(nanoseconds: u64) void {
-    std.Thread.sleep(nanoseconds);
+pub fn sleepNanos(io: std.Io, nanoseconds: u64) void {
+    std.Io.sleep(io, .fromNanoseconds(@intCast(nanoseconds)), .awake) catch |err| {
+        std.log.scoped(.clock).warn("sleep interrupted: {}", .{err});
+    };
 }
 
 test "the three clock reads agree on the same instant" {
-    const secs = nowSeconds();
-    const millis = nowMillis();
-    const nanos = nowNanos();
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const secs = nowSeconds(io);
+    const millis = nowMillis(io);
+    const nanos = nowNanos(io);
 
     // All three read the same wall clock, so they must agree once scaled
     // down to seconds. A one-second tolerance absorbs a tick landing
@@ -48,15 +54,20 @@ test "the three clock reads agree on the same instant" {
 }
 
 test "nowSeconds returns a plausible wall-clock time" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
     // 2026-01-01T00:00:00Z. Guards against a clock source that returns
     // uptime or zero instead of Unix time.
-    try std.testing.expect(nowSeconds() > 1_767_225_600);
+    try std.testing.expect(nowSeconds(threaded.io()) > 1_767_225_600);
 }
 
-test "sleepNanos advances the monotonic reading by at least the requested span" {
+test "sleepNanos advances the clock by at least the requested span" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
     const requested_ns: u64 = 5 * std.time.ns_per_ms;
-    const before = nowNanos();
-    sleepNanos(requested_ns);
-    const elapsed = nowNanos() - before;
-    try std.testing.expect(elapsed >= requested_ns);
+    const before = nowNanos(io);
+    sleepNanos(io, requested_ns);
+    try std.testing.expect(nowNanos(io) - before >= requested_ns);
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -326,8 +326,8 @@ pub const Persistence = struct {
 
     window: WindowConfig = .{},
     font_size: c_int = 14,
-    terminal_entries: std.ArrayListUnmanaged(TerminalEntry) = .{},
-    recent_folders: std.ArrayListUnmanaged(RecentFolder) = .{},
+    terminal_entries: std.ArrayList(TerminalEntry) = .empty,
+    recent_folders: std.ArrayList(RecentFolder) = .empty,
     visit_counter: u32 = 0,
     onboarding_shown: bool = false,
 
@@ -770,7 +770,7 @@ fn parseTerminalKey(key: []const u8) ?struct { row: usize, col: usize } {
     return .{ .row = row - 1, .col = col - 1 };
 }
 
-fn writeFileAtomicallyAbsolute(io: std.Io, path: []const u8, contents: []const u8) !void {
+fn writeFileAtomicallyAbsolute(io: std.Io, path: []const u8, contents: []const u8) SaveError!void {
     const dir_path = fs.path.dirname(path) orelse return error.InvalidPath;
     var dir = try Dir.openDirAbsolute(io, dir_path, .{});
     defer dir.close(io);
@@ -942,9 +942,14 @@ pub const LoadError = error{
 } || Dir.ReadFileAllocError;
 
 pub const SaveError = error{
+    BrokenPipe,
+    DeviceBusy,
+    FileTooBig,
     HomeNotFound,
     InvalidPath,
     InvalidConfig,
+    LockViolation,
+    NotOpenForWriting,
     OutOfMemory,
     WriteFailed,
 } || Dir.CreateDirError || Dir.OpenError || Dir.CreateFileAtomicError || std.Io.Writer.Error || File.SyncError || Dir.RenameError;

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 const fs = std.fs;
+const Dir = std.Io.Dir;
+const File = std.Io.File;
 const env = @import("env.zig");
 const toml = @import("toml");
 
@@ -371,15 +373,12 @@ pub const Persistence = struct {
         const persistence_path = try getPersistencePath(allocator);
         defer allocator.free(persistence_path);
 
-        const file = fs.openFileAbsolute(persistence_path, .{}) catch |err| {
+        const contents = Dir.cwd().readFileAlloc(io, persistence_path, allocator, .limited(1024 * 1024)) catch |err| {
             return switch (err) {
                 error.FileNotFound => Persistence.init(allocator, io),
                 else => err,
             };
         };
-        defer file.close();
-
-        const contents = try file.readToEndAlloc(allocator, 1024 * 1024);
         defer allocator.free(contents);
 
         var persistence = Persistence.init(allocator, io);
@@ -468,7 +467,7 @@ pub const Persistence = struct {
         defer allocator.free(persistence_path);
 
         const persistence_dir = fs.path.dirname(persistence_path) orelse return error.InvalidPath;
-        fs.makeDirAbsolute(persistence_dir) catch |err| switch (err) {
+        Dir.createDirAbsolute(io, persistence_dir, .default_dir) catch |err| switch (err) {
             error.PathAlreadyExists => {},
             else => return err,
         };
@@ -772,20 +771,18 @@ fn parseTerminalKey(key: []const u8) ?struct { row: usize, col: usize } {
 }
 
 fn writeFileAtomicallyAbsolute(io: std.Io, path: []const u8, contents: []const u8) !void {
-    _ = io;
     const dir_path = fs.path.dirname(path) orelse return error.InvalidPath;
-    var dir = try fs.openDirAbsolute(dir_path, .{});
-    defer dir.close();
+    var dir = try Dir.openDirAbsolute(io, dir_path, .{});
+    defer dir.close(io);
 
-    var write_buffer: [4096]u8 = undefined;
-    var atomic_file = try dir.atomicFile(fs.path.basename(path), .{
-        .write_buffer = &write_buffer,
+    var atomic_file = try dir.createFileAtomic(io, fs.path.basename(path), .{
+        .replace = true,
     });
-    defer atomic_file.deinit();
+    defer atomic_file.deinit(io);
 
-    try atomic_file.file_writer.file.writeAll(contents);
-    try atomic_file.file_writer.file.sync();
-    try atomic_file.renameIntoPlace();
+    try atomic_file.file.writeStreamingAll(io, contents);
+    try atomic_file.file.sync(io);
+    try atomic_file.replace(io);
 }
 
 pub const Config = struct {
@@ -816,7 +813,7 @@ pub const Config = struct {
         defer allocator.free(config_path);
 
         const config_dir = fs.path.dirname(config_path) orelse return error.InvalidPath;
-        fs.makeDirAbsolute(config_dir) catch |err| switch (err) {
+        Dir.createDirAbsolute(io, config_dir, .default_dir) catch |err| switch (err) {
             error.PathAlreadyExists => {},
             else => return err,
         };
@@ -891,14 +888,10 @@ pub const Config = struct {
     }
 
     fn loadTomlConfig(allocator: std.mem.Allocator, io: std.Io, config_path: []const u8) LoadError!Config {
-        _ = io;
-        const file = fs.openFileAbsolute(config_path, .{}) catch |err| switch (err) {
+        const content = Dir.cwd().readFileAlloc(io, config_path, allocator, .limited(1024 * 1024)) catch |err| switch (err) {
             error.FileNotFound => return error.ConfigNotFound,
             else => return err,
         };
-        defer file.close();
-
-        const content = try file.readToEndAlloc(allocator, 1024 * 1024);
         defer allocator.free(content);
 
         var parser = toml.Parser(Config).init(allocator);
@@ -946,7 +939,7 @@ pub const LoadError = error{
     HomeNotFound,
     InvalidPath,
     OutOfMemory,
-} || fs.File.OpenError || fs.File.ReadError;
+} || Dir.ReadFileAllocError;
 
 pub const SaveError = error{
     HomeNotFound,
@@ -954,7 +947,7 @@ pub const SaveError = error{
     InvalidConfig,
     OutOfMemory,
     WriteFailed,
-} || fs.File.OpenError || fs.File.WriteError || fs.File.SyncError || fs.Dir.MakeError || fs.Dir.OpenError || std.posix.RenameError;
+} || Dir.CreateDirError || Dir.OpenError || Dir.CreateFileAtomicError || std.Io.Writer.Error || File.SyncError || Dir.RenameError;
 
 test "Color.fromHex - valid hex colors" {
     const white = Color.fromHex("#FFFFFF") orelse return error.TestUnexpectedResult;
@@ -1178,17 +1171,20 @@ test "Persistence.appendLegacyTerminalEntries migrates row-major order" {
 
 test "Persistence save/load round-trip preserves all fields" {
     const allocator = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
 
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    const tmp_path = try tmp_dir.dir.realpathAlloc(allocator, ".");
+    const tmp_path = try tmp_dir.dir.realPathFileAlloc(io, ".", allocator);
     defer allocator.free(tmp_path);
 
     const test_file = try fs.path.join(allocator, &[_][]const u8{ tmp_path, "test_persistence.toml" });
     defer allocator.free(test_file);
 
-    var original = Persistence.init(allocator, std.testing.io);
+    var original = Persistence.init(allocator, io);
     defer original.deinit(allocator);
 
     original.window.width = 1920;
@@ -1201,14 +1197,12 @@ test "Persistence save/load round-trip preserves all fields" {
     try original.appendTerminalEntry(allocator, "/home/user/project2", "claude", "abc-123-def");
     try original.appendTerminalEntry(allocator, "/tmp/test", null, null);
 
-    try original.saveToPath(allocator, std.testing.io, test_file);
+    try original.saveToPath(allocator, io, test_file);
 
-    var loaded = Persistence.init(allocator, std.testing.io);
+    var loaded = Persistence.init(allocator, io);
     defer loaded.deinit(allocator);
 
-    const file = try fs.openFileAbsolute(test_file, .{});
-    defer file.close();
-    const contents = try file.readToEndAlloc(allocator, 1024 * 1024);
+    const contents = try Dir.cwd().readFileAlloc(io, test_file, allocator, .limited(1024 * 1024));
     defer allocator.free(contents);
 
     var parser = toml.Parser(Persistence.TomlPersistenceV3).init(allocator);
@@ -1270,11 +1264,14 @@ test "Persistence treats missing onboarding state as already shown" {
 
 test "writeFileAtomicallyAbsolute replaces file with valid TOML" {
     const allocator = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
 
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    const tmp_path = try tmp_dir.dir.realpathAlloc(allocator, ".");
+    const tmp_path = try tmp_dir.dir.realPathFileAlloc(io, ".", allocator);
     defer allocator.free(tmp_path);
 
     const test_file = try fs.path.join(allocator, &[_][]const u8{ tmp_path, "atomic_persistence.toml" });
@@ -1289,7 +1286,7 @@ test "writeFileAtomicallyAbsolute replaces file with valid TOML" {
         \\y = 20
         \\
     ;
-    try writeFileAtomicallyAbsolute(std.testing.io, test_file, initial);
+    try writeFileAtomicallyAbsolute(io, test_file, initial);
 
     const replaced =
         \\font_size = 16
@@ -1300,11 +1297,9 @@ test "writeFileAtomicallyAbsolute replaces file with valid TOML" {
         \\y = 200
         \\
     ;
-    try writeFileAtomicallyAbsolute(std.testing.io, test_file, replaced);
+    try writeFileAtomicallyAbsolute(io, test_file, replaced);
 
-    const file = try fs.openFileAbsolute(test_file, .{});
-    defer file.close();
-    const contents = try file.readToEndAlloc(allocator, 1024 * 1024);
+    const contents = try Dir.cwd().readFileAlloc(io, test_file, allocator, .limited(1024 * 1024));
     defer allocator.free(contents);
 
     var parser = toml.Parser(Persistence.TomlPersistenceV3).init(allocator);

--- a/src/config.zig
+++ b/src/config.zig
@@ -354,8 +354,9 @@ pub const Persistence = struct {
         onboarding_shown: ?bool = null,
     };
 
-    pub fn init(allocator: std.mem.Allocator) Persistence {
+    pub fn init(allocator: std.mem.Allocator, io: std.Io) Persistence {
         _ = allocator;
+        _ = io;
         return .{};
     }
 
@@ -366,13 +367,13 @@ pub const Persistence = struct {
         self.recent_folders.deinit(allocator);
     }
 
-    pub fn load(allocator: std.mem.Allocator) !Persistence {
+    pub fn load(allocator: std.mem.Allocator, io: std.Io) !Persistence {
         const persistence_path = try getPersistencePath(allocator);
         defer allocator.free(persistence_path);
 
         const file = fs.openFileAbsolute(persistence_path, .{}) catch |err| {
             return switch (err) {
-                error.FileNotFound => Persistence.init(allocator),
+                error.FileNotFound => Persistence.init(allocator, io),
                 else => err,
             };
         };
@@ -381,7 +382,7 @@ pub const Persistence = struct {
         const contents = try file.readToEndAlloc(allocator, 1024 * 1024);
         defer allocator.free(contents);
 
-        var persistence = Persistence.init(allocator);
+        var persistence = Persistence.init(allocator, io);
 
         // Try V3 format first (recent_folders as table with counts)
         var parser_v3 = toml.Parser(TomlPersistenceV3).init(allocator);
@@ -447,7 +448,7 @@ pub const Persistence = struct {
 
         var result_v1 = parser_v1.parseString(contents) catch |err| {
             std.log.err("Failed to parse persistence TOML: {any}", .{err});
-            return Persistence.init(allocator);
+            return Persistence.init(allocator, io);
         };
         defer result_v1.deinit();
 
@@ -462,7 +463,7 @@ pub const Persistence = struct {
         return persistence;
     }
 
-    pub fn save(self: Persistence, allocator: std.mem.Allocator) !void {
+    pub fn save(self: Persistence, allocator: std.mem.Allocator, io: std.Io) !void {
         const persistence_path = try getPersistencePath(allocator);
         defer allocator.free(persistence_path);
 
@@ -472,16 +473,16 @@ pub const Persistence = struct {
             else => return err,
         };
 
-        try self.saveToPath(allocator, persistence_path);
+        try self.saveToPath(allocator, io, persistence_path);
     }
 
-    pub fn saveToPath(self: Persistence, allocator: std.mem.Allocator, path: []const u8) !void {
+    pub fn saveToPath(self: Persistence, allocator: std.mem.Allocator, io: std.Io, path: []const u8) !void {
         var writer = std.Io.Writer.Allocating.init(allocator);
         defer writer.deinit();
         try self.serializeToWriter(&writer.writer);
         const serialized = writer.written();
 
-        try writeFileAtomicallyAbsolute(path, serialized);
+        try writeFileAtomicallyAbsolute(io, path, serialized);
     }
 
     pub fn serializeToWriter(self: Persistence, writer: anytype) !void {
@@ -770,7 +771,8 @@ fn parseTerminalKey(key: []const u8) ?struct { row: usize, col: usize } {
     return .{ .row = row - 1, .col = col - 1 };
 }
 
-fn writeFileAtomicallyAbsolute(path: []const u8, contents: []const u8) !void {
+fn writeFileAtomicallyAbsolute(io: std.Io, path: []const u8, contents: []const u8) !void {
+    _ = io;
     const dir_path = fs.path.dirname(path) orelse return error.InvalidPath;
     var dir = try fs.openDirAbsolute(dir_path, .{});
     defer dir.close();
@@ -797,11 +799,11 @@ pub const Config = struct {
     logging: LoggingConfig = .{},
     worktree: WorktreeConfig = .{},
 
-    pub fn load(allocator: std.mem.Allocator) LoadError!Config {
+    pub fn load(allocator: std.mem.Allocator, io: std.Io) LoadError!Config {
         const config_path = try getConfigPath(allocator);
         defer allocator.free(config_path);
 
-        return loadTomlConfig(allocator, config_path);
+        return loadTomlConfig(allocator, io, config_path);
     }
 
     pub fn getConfigPath(allocator: std.mem.Allocator) ![]u8 {
@@ -809,7 +811,7 @@ pub const Config = struct {
         return try fs.path.join(allocator, &[_][]const u8{ home, ".config", "architect", "config.toml" });
     }
 
-    pub fn createDefaultConfigFile(allocator: std.mem.Allocator) SaveError!void {
+    pub fn createDefaultConfigFile(allocator: std.mem.Allocator, io: std.Io) SaveError!void {
         const config_path = try getConfigPath(allocator);
         defer allocator.free(config_path);
 
@@ -885,10 +887,11 @@ pub const Config = struct {
             \\
         ;
 
-        try writeFileAtomicallyAbsolute(config_path, template);
+        try writeFileAtomicallyAbsolute(io, config_path, template);
     }
 
-    fn loadTomlConfig(allocator: std.mem.Allocator, config_path: []const u8) LoadError!Config {
+    fn loadTomlConfig(allocator: std.mem.Allocator, io: std.Io, config_path: []const u8) LoadError!Config {
+        _ = io;
         const file = fs.openFileAbsolute(config_path, .{}) catch |err| switch (err) {
             error.FileNotFound => return error.ConfigNotFound,
             else => return err,
@@ -1125,7 +1128,7 @@ test "parseTerminalKey decodes 1-based coordinates" {
 
 test "Persistence.appendTerminalEntry preserves order and fields" {
     const allocator = std.testing.allocator;
-    var persistence = Persistence.init(allocator);
+    var persistence = Persistence.init(allocator, std.testing.io);
     defer persistence.deinit(allocator);
 
     try persistence.appendTerminalEntry(allocator, "/one", null, null);
@@ -1141,7 +1144,7 @@ test "Persistence.appendTerminalEntry preserves order and fields" {
 
 test "Persistence.appendLegacyTerminalEntries migrates row-major order" {
     const allocator = std.testing.allocator;
-    var persistence = Persistence.init(allocator);
+    var persistence = Persistence.init(allocator, std.testing.io);
     defer persistence.deinit(allocator);
 
     var legacy = toml.HashMap([]const u8){ .map = std.StringHashMap([]const u8).init(allocator) };
@@ -1185,7 +1188,7 @@ test "Persistence save/load round-trip preserves all fields" {
     const test_file = try fs.path.join(allocator, &[_][]const u8{ tmp_path, "test_persistence.toml" });
     defer allocator.free(test_file);
 
-    var original = Persistence.init(allocator);
+    var original = Persistence.init(allocator, std.testing.io);
     defer original.deinit(allocator);
 
     original.window.width = 1920;
@@ -1198,9 +1201,9 @@ test "Persistence save/load round-trip preserves all fields" {
     try original.appendTerminalEntry(allocator, "/home/user/project2", "claude", "abc-123-def");
     try original.appendTerminalEntry(allocator, "/tmp/test", null, null);
 
-    try original.saveToPath(allocator, test_file);
+    try original.saveToPath(allocator, std.testing.io, test_file);
 
-    var loaded = Persistence.init(allocator);
+    var loaded = Persistence.init(allocator, std.testing.io);
     defer loaded.deinit(allocator);
 
     const file = try fs.openFileAbsolute(test_file, .{});
@@ -1256,7 +1259,7 @@ test "Persistence save/load round-trip preserves all fields" {
 }
 
 test "Persistence treats missing onboarding state as already shown" {
-    var persistence = Persistence.init(std.testing.allocator);
+    var persistence = Persistence.init(std.testing.allocator, std.testing.io);
     defer persistence.deinit(std.testing.allocator);
 
     try std.testing.expect(!persistence.onboarding_shown);
@@ -1286,7 +1289,7 @@ test "writeFileAtomicallyAbsolute replaces file with valid TOML" {
         \\y = 20
         \\
     ;
-    try writeFileAtomicallyAbsolute(test_file, initial);
+    try writeFileAtomicallyAbsolute(std.testing.io, test_file, initial);
 
     const replaced =
         \\font_size = 16
@@ -1297,7 +1300,7 @@ test "writeFileAtomicallyAbsolute replaces file with valid TOML" {
         \\y = 200
         \\
     ;
-    try writeFileAtomicallyAbsolute(test_file, replaced);
+    try writeFileAtomicallyAbsolute(std.testing.io, test_file, replaced);
 
     const file = try fs.openFileAbsolute(test_file, .{});
     defer file.close();
@@ -1320,7 +1323,7 @@ test "writeFileAtomicallyAbsolute replaces file with valid TOML" {
 test "Persistence.removeRecentFolder removes the named entry" {
     const allocator = std.testing.allocator;
 
-    var persistence = Persistence.init(allocator);
+    var persistence = Persistence.init(allocator, std.testing.io);
     defer persistence.deinit(allocator);
 
     try persistence.appendRecentFolder(allocator, "/");
@@ -1336,7 +1339,7 @@ test "Persistence.removeRecentFolder removes the named entry" {
 test "Persistence.appendRecentFolder stores more than 10 directories" {
     const allocator = std.testing.allocator;
 
-    var persistence = Persistence.init(allocator);
+    var persistence = Persistence.init(allocator, std.testing.io);
     defer persistence.deinit(allocator);
 
     // Add 10 directories with count > 1 to fill the old cap
@@ -1369,7 +1372,7 @@ test "Persistence.appendRecentFolder stores more than 10 directories" {
 test "Persistence.appendRecentFolder evicts oldest entry when cap is reached" {
     const allocator = std.testing.allocator;
 
-    var persistence = Persistence.init(allocator);
+    var persistence = Persistence.init(allocator, std.testing.io);
     defer persistence.deinit(allocator);
 
     // Fill to max capacity with single-visit directories
@@ -1399,7 +1402,7 @@ test "Persistence.appendRecentFolder evicts oldest entry when cap is reached" {
 test "Persistence.appendRecentFolder skipping logic: removeRecentFolder leaves other entries intact" {
     const allocator = std.testing.allocator;
 
-    var persistence = Persistence.init(allocator);
+    var persistence = Persistence.init(allocator, std.testing.io);
     defer persistence.deinit(allocator);
 
     try persistence.appendRecentFolder(allocator, "/");

--- a/src/env.zig
+++ b/src/env.zig
@@ -18,11 +18,28 @@ comptime {
 ///
 /// This is the only sanctioned module-level accessor in the codebase. The
 /// `io` context is never stored this way.
+var process_environ: ?std.process.Environ = null;
+
+/// Must be called exactly once, from `main`, before any thread is spawned.
+pub fn init(environ: std.process.Environ) void {
+    std.debug.assert(process_environ == null);
+    process_environ = environ;
+}
+
 pub fn get(key: []const u8) ?[:0]const u8 {
-    return std.posix.getenv(key);
+    const environ = process_environ orelse
+        @panic("env.get called before env.init; main must call env.init first");
+    return environ.getPosix(key);
+}
+
+fn initForTest() void {
+    if (process_environ == null) {
+        process_environ = std.testing.environ;
+    }
 }
 
 test "get returns a value for a variable the process always has" {
+    initForTest();
     // PATH is guaranteed present in every shell Architect is launched from,
     // including the CI runners and the Nix dev shell.
     const path = get("PATH");
@@ -31,5 +48,6 @@ test "get returns a value for a variable the process always has" {
 }
 
 test "get returns null for a variable that is not set" {
+    initForTest();
     try std.testing.expectEqual(@as(?[:0]const u8, null), get("ARCHITECT_DEFINITELY_NOT_SET_9f3a1c"));
 }

--- a/src/font_paths.zig
+++ b/src/font_paths.zig
@@ -79,7 +79,7 @@ pub const FontPaths = struct {
 
         paths.symbol_fallback = try allocator.dupeZ(u8, "/System/Library/Fonts/Supplemental/Arial Unicode.ttf");
         const stix_path = "/System/Library/Fonts/Supplemental/STIXTwoMath.otf";
-        paths.symbol_fallback_secondary = if (std.fs.accessAbsolute(stix_path, .{})) |_|
+        paths.symbol_fallback_secondary = if (std.Io.Dir.accessAbsolute(io, stix_path, .{})) |_|
             try allocator.dupeZ(u8, stix_path)
         else |_|
             null;
@@ -136,14 +136,13 @@ fn findSystemFont(allocator: std.mem.Allocator, io: std.Io, font_family: []const
 }
 
 fn searchFontInDirectory(allocator: std.mem.Allocator, io: std.Io, dir_path: []const u8, font_family: []const u8, style_suffix: []const u8) ![:0]const u8 {
-    _ = io;
     const extensions = [_][]const u8{ "otf", "ttf", "ttc" };
 
     for (extensions) |ext| {
         const font_path = try std.fmt.allocPrint(allocator, "{s}/{s}-{s}.{s}", .{ dir_path, font_family, style_suffix, ext });
         defer allocator.free(font_path);
 
-        std.fs.accessAbsolute(font_path, .{}) catch |err| {
+        std.Io.Dir.accessAbsolute(io, font_path, .{}) catch |err| {
             log.debug("font not found at {s}: {}", .{ font_path, err });
             continue;
         };
@@ -155,7 +154,7 @@ fn searchFontInDirectory(allocator: std.mem.Allocator, io: std.Io, dir_path: []c
         const font_path = try std.fmt.allocPrint(allocator, "{s}/{s}{s}.{s}", .{ dir_path, font_family, style_suffix, ext });
         defer allocator.free(font_path);
 
-        std.fs.accessAbsolute(font_path, .{}) catch |err| {
+        std.Io.Dir.accessAbsolute(io, font_path, .{}) catch |err| {
             log.debug("font not found at {s}: {}", .{ font_path, err });
             continue;
         };
@@ -168,7 +167,7 @@ fn searchFontInDirectory(allocator: std.mem.Allocator, io: std.Io, dir_path: []c
             const font_path = try std.fmt.allocPrint(allocator, "{s}/{s}.{s}", .{ dir_path, font_family, ext });
             defer allocator.free(font_path);
 
-            std.fs.accessAbsolute(font_path, .{}) catch |err| {
+            std.Io.Dir.accessAbsolute(io, font_path, .{}) catch |err| {
                 log.debug("font not found at {s}: {}", .{ font_path, err });
                 continue;
             };
@@ -179,18 +178,18 @@ fn searchFontInDirectory(allocator: std.mem.Allocator, io: std.Io, dir_path: []c
 
     const ttc_path = try std.fmt.allocPrint(allocator, "{s}/{s}.ttc", .{ dir_path, font_family });
     defer allocator.free(ttc_path);
-    if (std.fs.accessAbsolute(ttc_path, .{})) {
+    if (std.Io.Dir.accessAbsolute(io, ttc_path, .{})) {
         log.info("Found TTC file containing {s} variant: {s}", .{ style_suffix, ttc_path });
         return allocator.dupeZ(u8, ttc_path);
     } else |_| {}
 
     log.info("Recursively searching {s} for {s} {s}", .{ dir_path, font_family, style_suffix });
 
-    var dir = std.fs.openDirAbsolute(dir_path, .{ .iterate = true }) catch |err| {
+    var dir = std.Io.Dir.openDirAbsolute(io, dir_path, .{ .iterate = true }) catch |err| {
         log.warn("Could not open directory {s}: {}", .{ dir_path, err });
         return error.FontNotFound;
     };
-    defer dir.close();
+    defer dir.close(io);
 
     var walker = dir.walk(allocator) catch |err| {
         log.warn("Could not walk directory {s}: {}", .{ dir_path, err });
@@ -198,7 +197,7 @@ fn searchFontInDirectory(allocator: std.mem.Allocator, io: std.Io, dir_path: []c
     };
     defer walker.deinit();
 
-    while (walker.next()) |maybe_entry| {
+    while (walker.next(io)) |maybe_entry| {
         const entry = maybe_entry orelse break;
         if (entry.kind != .file) continue;
 

--- a/src/font_paths.zig
+++ b/src/font_paths.zig
@@ -13,8 +13,9 @@ pub const FontPaths = struct {
     symbol_fallback_secondary: ?[:0]const u8,
     emoji_fallback: ?[:0]const u8,
     allocator: std.mem.Allocator,
+    io: std.Io,
 
-    pub fn init(allocator: std.mem.Allocator, font_family: ?[]const u8) !FontPaths {
+    pub fn init(allocator: std.mem.Allocator, io: std.Io, font_family: ?[]const u8) !FontPaths {
         if (builtin.os.tag != .macos) {
             log.err("Only macOS is supported", .{});
             return error.UnsupportedPlatform;
@@ -22,54 +23,55 @@ pub const FontPaths = struct {
 
         var paths: FontPaths = undefined;
         paths.allocator = allocator;
+        paths.io = io;
 
         const selected_family = if (font_family) |ff| if (ff.len > 0) ff else default_font_family else default_font_family;
 
-        if (findSystemFont(allocator, selected_family, "Regular")) |regular_path| {
+        if (findSystemFont(allocator, io, selected_family, "Regular")) |regular_path| {
             paths.regular = regular_path;
         } else |_| {
             if (font_family) |requested| {
                 log.warn("Font family '{s}' not found, falling back to {s}", .{ requested, default_font_family });
             }
-            paths.regular = try findSystemFont(allocator, default_font_family, "Regular");
+            paths.regular = try findSystemFont(allocator, io, default_font_family, "Regular");
         }
 
         const regular_is_ttc = std.mem.endsWith(u8, paths.regular, ".ttc");
 
-        if (findSystemFont(allocator, selected_family, "Bold")) |bold_path| {
+        if (findSystemFont(allocator, io, selected_family, "Bold")) |bold_path| {
             paths.bold = bold_path;
         } else |_| {
             if (regular_is_ttc) {
                 log.info("Using TTC file for Bold variant: {s}", .{paths.regular});
                 paths.bold = try allocator.dupeZ(u8, paths.regular);
             } else if (font_family != null and !std.mem.eql(u8, selected_family, default_font_family)) {
-                paths.bold = findSystemFont(allocator, default_font_family, "Bold") catch try allocator.dupeZ(u8, paths.regular);
+                paths.bold = findSystemFont(allocator, io, default_font_family, "Bold") catch try allocator.dupeZ(u8, paths.regular);
             } else {
                 paths.bold = try allocator.dupeZ(u8, paths.regular);
             }
         }
 
-        if (findSystemFont(allocator, selected_family, "Italic")) |italic_path| {
+        if (findSystemFont(allocator, io, selected_family, "Italic")) |italic_path| {
             paths.italic = italic_path;
         } else |_| {
             if (regular_is_ttc) {
                 log.info("Using TTC file for Italic variant: {s}", .{paths.regular});
                 paths.italic = try allocator.dupeZ(u8, paths.regular);
             } else if (font_family != null and !std.mem.eql(u8, selected_family, default_font_family)) {
-                paths.italic = findSystemFont(allocator, default_font_family, "Italic") catch try allocator.dupeZ(u8, paths.regular);
+                paths.italic = findSystemFont(allocator, io, default_font_family, "Italic") catch try allocator.dupeZ(u8, paths.regular);
             } else {
                 paths.italic = try allocator.dupeZ(u8, paths.regular);
             }
         }
 
-        if (findSystemFont(allocator, selected_family, "BoldItalic")) |bold_italic_path| {
+        if (findSystemFont(allocator, io, selected_family, "BoldItalic")) |bold_italic_path| {
             paths.bold_italic = bold_italic_path;
         } else |_| {
             if (regular_is_ttc) {
                 log.info("Using TTC file for BoldItalic variant: {s}", .{paths.regular});
                 paths.bold_italic = try allocator.dupeZ(u8, paths.regular);
             } else if (font_family != null and !std.mem.eql(u8, selected_family, default_font_family)) {
-                paths.bold_italic = findSystemFont(allocator, default_font_family, "BoldItalic") catch try allocator.dupeZ(u8, paths.regular);
+                paths.bold_italic = findSystemFont(allocator, io, default_font_family, "BoldItalic") catch try allocator.dupeZ(u8, paths.regular);
             } else {
                 paths.bold_italic = try allocator.dupeZ(u8, paths.regular);
             }
@@ -105,7 +107,7 @@ pub const FontPaths = struct {
 
 const default_font_family = "SFNSMono";
 
-fn findSystemFont(allocator: std.mem.Allocator, font_family: []const u8, style: []const u8) ![:0]const u8 {
+fn findSystemFont(allocator: std.mem.Allocator, io: std.Io, font_family: []const u8, style: []const u8) ![:0]const u8 {
     const search_dirs = [_][]const u8{
         "/System/Library/Fonts",
         "/Library/Fonts",
@@ -115,7 +117,7 @@ fn findSystemFont(allocator: std.mem.Allocator, font_family: []const u8, style: 
     const style_suffix = style;
 
     for (search_dirs) |dir| {
-        if (searchFontInDirectory(allocator, dir, font_family, style_suffix)) |path| {
+        if (searchFontInDirectory(allocator, io, dir, font_family, style_suffix)) |path| {
             return path;
         } else |_| {}
     }
@@ -124,7 +126,7 @@ fn findSystemFont(allocator: std.mem.Allocator, font_family: []const u8, style: 
         const user_fonts_dir = try std.fmt.allocPrint(allocator, "{s}/Library/Fonts", .{h});
         defer allocator.free(user_fonts_dir);
 
-        if (searchFontInDirectory(allocator, user_fonts_dir, font_family, style_suffix)) |path| {
+        if (searchFontInDirectory(allocator, io, user_fonts_dir, font_family, style_suffix)) |path| {
             return path;
         } else |_| {}
     }
@@ -133,7 +135,8 @@ fn findSystemFont(allocator: std.mem.Allocator, font_family: []const u8, style: 
     return error.FontNotFound;
 }
 
-fn searchFontInDirectory(allocator: std.mem.Allocator, dir_path: []const u8, font_family: []const u8, style_suffix: []const u8) ![:0]const u8 {
+fn searchFontInDirectory(allocator: std.mem.Allocator, io: std.Io, dir_path: []const u8, font_family: []const u8, style_suffix: []const u8) ![:0]const u8 {
+    _ = io;
     const extensions = [_][]const u8{ "otf", "ttf", "ttc" };
 
     for (extensions) |ext| {

--- a/src/logging.zig
+++ b/src/logging.zig
@@ -19,7 +19,7 @@ pub const InitOptions = struct {
 };
 
 const LoggerState = struct {
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = .init,
     initialized: bool = false,
     allocator: ?std.mem.Allocator = null,
     io: ?std.Io = null,
@@ -263,8 +263,8 @@ fn emitLoggingInternalError(err: anyerror) void {
 }
 
 pub fn init(allocator: std.mem.Allocator, io: std.Io, options: InitOptions) !void {
-    state.mutex.lock();
-    defer state.mutex.unlock();
+    state.mutex.lockUncancelable(io);
+    defer state.mutex.unlock(io);
 
     if (state.initialized) return;
 
@@ -295,18 +295,17 @@ pub fn init(allocator: std.mem.Allocator, io: std.Io, options: InitOptions) !voi
 }
 
 pub fn deinit() void {
-    state.mutex.lock();
-    defer state.mutex.unlock();
+    const io = state.io orelse return;
+    state.mutex.lockUncancelable(io);
+    defer state.mutex.unlock(io);
 
     if (!state.initialized) return;
 
     if (state.file) |file| {
-        if (state.io) |io| {
-            file.sync(io) catch |err| {
-                emitLoggingInternalError(err);
-            };
-            file.close(io);
-        }
+        file.sync(io) catch |err| {
+            emitLoggingInternalError(err);
+        };
+        file.close(io);
     }
 
     if (state.directory_path) |path| {
@@ -326,20 +325,23 @@ pub fn deinit() void {
 }
 
 pub fn isInitialized() bool {
-    state.mutex.lock();
-    defer state.mutex.unlock();
+    const io = state.io orelse return false;
+    state.mutex.lockUncancelable(io);
+    defer state.mutex.unlock(io);
     return state.initialized;
 }
 
 pub fn writeStartupMarker() !void {
-    state.mutex.lock();
-    defer state.mutex.unlock();
+    const io = state.io orelse return error.LoggerNotInitialized;
+    state.mutex.lockUncancelable(io);
+    defer state.mutex.unlock(io);
     try writeEventLocked(&state, "runtime", "architect startup", "startup", null);
 }
 
 pub fn writeShutdownMarker() !void {
-    state.mutex.lock();
-    defer state.mutex.unlock();
+    const io = state.io orelse return error.LoggerNotInitialized;
+    state.mutex.lockUncancelable(io);
+    defer state.mutex.unlock(io);
     try writeEventLocked(&state, "runtime", "architect shutdown", "shutdown", null);
 }
 
@@ -349,8 +351,9 @@ pub fn writeEvent(
     event_name: []const u8,
     extra_data: ?[]const u8,
 ) !void {
-    state.mutex.lock();
-    defer state.mutex.unlock();
+    const io = state.io orelse return error.LoggerNotInitialized;
+    state.mutex.lockUncancelable(io);
+    defer state.mutex.unlock(io);
     try writeEventLocked(&state, scope_name, message, event_name, extra_data);
 }
 
@@ -361,9 +364,9 @@ pub fn logFn(
     args: anytype,
 ) void {
     var should_fallback_to_stderr = false;
-    {
-        state.mutex.lock();
-        defer state.mutex.unlock();
+    if (state.io) |io| {
+        state.mutex.lockUncancelable(io);
+        defer state.mutex.unlock(io);
 
         if (!state.initialized) {
             should_fallback_to_stderr = true;
@@ -380,6 +383,8 @@ pub fn logFn(
                 should_fallback_to_stderr = true;
             };
         }
+    } else {
+        should_fallback_to_stderr = true;
     }
 
     if (should_fallback_to_stderr) {

--- a/src/logging.zig
+++ b/src/logging.zig
@@ -20,6 +20,7 @@ const LoggerState = struct {
     mutex: std.Thread.Mutex = .{},
     initialized: bool = false,
     allocator: ?std.mem.Allocator = null,
+    io: ?std.Io = null,
     directory_path: ?[]u8 = null,
     file: ?fs.File = null,
     current_size: u64 = 0,
@@ -151,7 +152,7 @@ fn rotateLocked(s: *LoggerState) !void {
 
     var active_path_buf: [fs.max_path_bytes]u8 = undefined;
     const active_path = try buildPath(&active_path_buf, directory_path, active_log_filename);
-    const now_secs = clock.nowSeconds();
+    const now_secs = clock.nowSeconds(s.io orelse return error.LoggerNotInitialized);
     var suffix_buf: [32]u8 = undefined;
     const suffix = try rotationSuffix(now_secs, &suffix_buf);
 
@@ -195,7 +196,7 @@ fn writeRecordLocked(
     if (!force_write and !isEnabled(s.min_level, level)) return;
 
     var timestamp_buf: [32]u8 = undefined;
-    const timestamp = try timestampToLocalIso8601(clock.nowSeconds(), &timestamp_buf);
+    const timestamp = try timestampToLocalIso8601(clock.nowSeconds(s.io orelse return error.LoggerNotInitialized), &timestamp_buf);
 
     var line_buf: [8192]u8 = undefined;
     const line = blk: {
@@ -257,7 +258,7 @@ fn emitLoggingInternalError(err: anyerror) void {
     nosuspend stderr_writer.print("file logging failed: {}\n", .{err}) catch return;
 }
 
-pub fn init(allocator: std.mem.Allocator, options: InitOptions) !void {
+pub fn init(allocator: std.mem.Allocator, io: std.Io, options: InitOptions) !void {
     state.mutex.lock();
     defer state.mutex.unlock();
 
@@ -280,6 +281,7 @@ pub fn init(allocator: std.mem.Allocator, options: InitOptions) !void {
     const active = try openActiveLogFile(directory_path);
 
     state.allocator = allocator;
+    state.io = io;
     state.directory_path = directory_path;
     state.file = active.file;
     state.current_size = active.size;
@@ -309,6 +311,7 @@ pub fn deinit() void {
 
     state.initialized = false;
     state.allocator = null;
+    state.io = null;
     state.directory_path = null;
     state.file = null;
     state.current_size = 0;
@@ -411,7 +414,7 @@ test "logFn respects minimum level filtering" {
     const tmp_path = try tmp_dir.dir.realpathAlloc(allocator, ".");
     defer allocator.free(tmp_path);
 
-    try init(allocator, .{
+    try init(allocator, std.testing.io, .{
         .directory_override = tmp_path,
         .min_level = .warn,
         .max_file_size_bytes = 1024 * 1024,
@@ -436,7 +439,7 @@ test "log line includes timestamp, level, scope, and message fields" {
     const tmp_path = try tmp_dir.dir.realpathAlloc(allocator, ".");
     defer allocator.free(tmp_path);
 
-    try init(allocator, .{
+    try init(allocator, std.testing.io, .{
         .directory_override = tmp_path,
         .min_level = .debug,
     });
@@ -469,7 +472,7 @@ test "rotation archives old file once size limit is exceeded" {
     const tmp_path = try tmp_dir.dir.realpathAlloc(allocator, ".");
     defer allocator.free(tmp_path);
 
-    try init(allocator, .{
+    try init(allocator, std.testing.io, .{
         .directory_override = tmp_path,
         .min_level = .debug,
         .max_file_size_bytes = 256,
@@ -512,7 +515,7 @@ test "init resolves a relative directory_override to an absolute log directory" 
         std.debug.print("failed to clean up test log directory: {}\n", .{err});
     };
 
-    try init(allocator, .{
+    try init(allocator, std.testing.io, .{
         .directory_override = relative_dir,
         .min_level = .info,
     });
@@ -540,7 +543,7 @@ test "startup, shutdown, and explicit events are emitted with info level" {
     const tmp_path = try tmp_dir.dir.realpathAlloc(allocator, ".");
     defer allocator.free(tmp_path);
 
-    try init(allocator, .{
+    try init(allocator, std.testing.io, .{
         .directory_override = tmp_path,
         .min_level = .err,
     });

--- a/src/logging.zig
+++ b/src/logging.zig
@@ -23,7 +23,7 @@ const LoggerState = struct {
     initialized: bool = false,
     allocator: ?std.mem.Allocator = null,
     io: ?std.Io = null,
-    directory_path: ?[]u8 = null,
+    directory_path: ?[:0]u8 = null,
     file: ?File = null,
     current_size: u64 = 0,
     min_level: std.log.Level = .info,
@@ -154,22 +154,21 @@ fn rotateLocked(s: *LoggerState) !void {
     existing_file.close(io);
     s.file = null;
 
-    var active_path_buf: [fs.max_path_bytes]u8 = undefined;
-    const active_path = try buildPath(&active_path_buf, directory_path, active_log_filename);
+    var directory = try Dir.openDirAbsolute(io, directory_path, .{});
+    defer directory.close(io);
+
     const now_secs = clock.nowSeconds(io);
     var suffix_buf: [32]u8 = undefined;
     const suffix = try rotationSuffix(now_secs, &suffix_buf);
 
     var archive_name_buf: [128]u8 = undefined;
-    var archive_path_buf: [fs.max_path_bytes]u8 = undefined;
     var attempt: usize = 0;
     while (true) : (attempt += 1) {
         const archive_name = if (attempt == 0)
             try std.fmt.bufPrint(&archive_name_buf, "architect-{s}.log", .{suffix})
         else
             try std.fmt.bufPrint(&archive_name_buf, "architect-{s}-{d}.log", .{ suffix, attempt });
-        const archive_path = try buildPath(&archive_path_buf, directory_path, archive_name);
-        Dir.renameAbsolute(active_path, archive_path, io) catch |err| switch (err) {
+        directory.renamePreserve(active_log_filename, directory, archive_name, io) catch |err| switch (err) {
             error.PathAlreadyExists => continue,
             error.FileNotFound => break,
             else => return err,
@@ -207,29 +206,23 @@ fn writeRecordLocked(
         var writer = std.Io.Writer.fixed(&line_buf);
         writer.print("{s} level={s} scope={s} msg=\"", .{ timestamp, logLevelLabel(level), scope_name }) catch |err| switch (err) {
             error.WriteFailed => break :blk "1970-01-01T00:00:00Z level=ERROR scope=logging msg=\"failed to format log line\"\n",
-            else => return err,
         };
         writeEscapedMessage(&writer, message) catch |err| switch (err) {
             error.WriteFailed => {},
-            else => return err,
         };
         writer.writeByte('"') catch |err| switch (err) {
             error.WriteFailed => {},
-            else => return err,
         };
         if (extra_data) |extra| {
             writer.writeByte(' ') catch |err| switch (err) {
                 error.WriteFailed => {},
-                else => return err,
             };
             writer.writeAll(extra) catch |err| switch (err) {
                 error.WriteFailed => {},
-                else => return err,
             };
         }
         writer.writeByte('\n') catch |err| switch (err) {
             error.WriteFailed => {},
-            else => return err,
         };
         break :blk writer.buffered();
     };
@@ -257,9 +250,9 @@ fn writeEventLocked(
 
 fn emitLoggingInternalError(err: anyerror) void {
     var stderr_buf: [128]u8 = undefined;
-    var stderr_writer = std.debug.lockStderrWriter(&stderr_buf);
-    defer std.debug.unlockStderrWriter();
-    nosuspend stderr_writer.print("file logging failed: {}\n", .{err}) catch return;
+    const stderr = std.debug.lockStderr(&stderr_buf);
+    defer std.debug.unlockStderr();
+    nosuspend stderr.file_writer.interface.print("file logging failed: {}\n", .{err}) catch return;
 }
 
 pub fn init(allocator: std.mem.Allocator, io: std.Io, options: InitOptions) !void {

--- a/src/logging.zig
+++ b/src/logging.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const fs = std.fs;
+const Dir = std.Io.Dir;
+const File = std.Io.File;
 const clock = @import("clock.zig");
 const env = @import("env.zig");
 const time_c = @cImport({
@@ -22,7 +24,7 @@ const LoggerState = struct {
     allocator: ?std.mem.Allocator = null,
     io: ?std.Io = null,
     directory_path: ?[]u8 = null,
-    file: ?fs.File = null,
+    file: ?File = null,
     current_size: u64 = 0,
     min_level: std.log.Level = .info,
     max_file_size_bytes: u64 = default_max_file_size_bytes,
@@ -129,15 +131,16 @@ fn writeEscapedMessage(writer: *std.Io.Writer, message: []const u8) !void {
     }
 }
 
-fn openActiveLogFile(directory_path: []const u8) !struct { file: fs.File, size: u64 } {
+fn openActiveLogFile(io: std.Io, directory_path: []const u8) !struct { file: File, size: u64 } {
     var active_path_buf: [fs.max_path_bytes]u8 = undefined;
     const active_path = try buildPath(&active_path_buf, directory_path, active_log_filename);
-    const file = try fs.createFileAbsolute(active_path, .{
+    const file = try Dir.createFileAbsolute(io, active_path, .{
         .truncate = false,
         .read = true,
     });
-    const size = try file.getEndPos();
-    try file.seekTo(size);
+    const size = (try file.stat(io)).size;
+    var writer = file.writerStreaming(io, &.{});
+    try writer.seekTo(size);
     return .{
         .file = file,
         .size = size,
@@ -147,12 +150,13 @@ fn openActiveLogFile(directory_path: []const u8) !struct { file: fs.File, size: 
 fn rotateLocked(s: *LoggerState) !void {
     const directory_path = s.directory_path orelse return error.LoggerNotInitialized;
     const existing_file = s.file orelse return error.LoggerNotInitialized;
-    existing_file.close();
+    const io = s.io orelse return error.LoggerNotInitialized;
+    existing_file.close(io);
     s.file = null;
 
     var active_path_buf: [fs.max_path_bytes]u8 = undefined;
     const active_path = try buildPath(&active_path_buf, directory_path, active_log_filename);
-    const now_secs = clock.nowSeconds(s.io orelse return error.LoggerNotInitialized);
+    const now_secs = clock.nowSeconds(io);
     var suffix_buf: [32]u8 = undefined;
     const suffix = try rotationSuffix(now_secs, &suffix_buf);
 
@@ -165,7 +169,7 @@ fn rotateLocked(s: *LoggerState) !void {
         else
             try std.fmt.bufPrint(&archive_name_buf, "architect-{s}-{d}.log", .{ suffix, attempt });
         const archive_path = try buildPath(&archive_path_buf, directory_path, archive_name);
-        fs.renameAbsolute(active_path, archive_path) catch |err| switch (err) {
+        Dir.renameAbsolute(active_path, archive_path, io) catch |err| switch (err) {
             error.PathAlreadyExists => continue,
             error.FileNotFound => break,
             else => return err,
@@ -173,7 +177,7 @@ fn rotateLocked(s: *LoggerState) !void {
         break;
     }
 
-    const active = try openActiveLogFile(directory_path);
+    const active = try openActiveLogFile(io, directory_path);
     s.file = active.file;
     s.current_size = active.size;
 }
@@ -232,7 +236,7 @@ fn writeRecordLocked(
 
     try ensureCapacityLocked(s, line.len);
     const log_file = s.file orelse return error.LoggerNotInitialized;
-    try log_file.writeAll(line);
+    try log_file.writeStreamingAll(s.io orelse return error.LoggerNotInitialized, line);
     s.current_size += line.len;
 }
 
@@ -273,12 +277,12 @@ pub fn init(allocator: std.mem.Allocator, io: std.Io, options: InitOptions) !voi
             try defaultLogDirectoryPath(allocator);
         defer allocator.free(raw_directory_path);
 
-        try fs.cwd().makePath(raw_directory_path);
-        break :blk try fs.cwd().realpathAlloc(allocator, raw_directory_path);
+        try Dir.cwd().createDirPath(io, raw_directory_path);
+        break :blk try Dir.cwd().realPathFileAlloc(io, raw_directory_path, allocator);
     };
     errdefer allocator.free(directory_path);
 
-    const active = try openActiveLogFile(directory_path);
+    const active = try openActiveLogFile(io, directory_path);
 
     state.allocator = allocator;
     state.io = io;
@@ -297,10 +301,12 @@ pub fn deinit() void {
     if (!state.initialized) return;
 
     if (state.file) |file| {
-        file.sync() catch |err| {
-            emitLoggingInternalError(err);
-        };
-        file.close();
+        if (state.io) |io| {
+            file.sync(io) catch |err| {
+                emitLoggingInternalError(err);
+            };
+            file.close(io);
+        }
     }
 
     if (state.directory_path) |path| {
@@ -350,7 +356,7 @@ pub fn writeEvent(
 
 pub fn logFn(
     comptime level: std.log.Level,
-    comptime scope: @Type(.enum_literal),
+    comptime scope: @EnumLiteral(),
     comptime format: []const u8,
     args: anytype,
 ) void {
@@ -385,12 +391,10 @@ fn activeLogPathAlloc(allocator: std.mem.Allocator, directory_path: []const u8) 
     return fs.path.join(allocator, &[_][]const u8{ directory_path, active_log_filename });
 }
 
-fn readActiveLogAlloc(allocator: std.mem.Allocator, directory_path: []const u8) ![]u8 {
+fn readActiveLogAlloc(allocator: std.mem.Allocator, io: std.Io, directory_path: []const u8) ![]u8 {
     const active_path = try activeLogPathAlloc(allocator, directory_path);
     defer allocator.free(active_path);
-    const file = try fs.openFileAbsolute(active_path, .{});
-    defer file.close();
-    return file.readToEndAlloc(allocator, 4 * 1024 * 1024);
+    return try Dir.cwd().readFileAlloc(io, active_path, allocator, .limited(4 * 1024 * 1024));
 }
 
 test "timestampToLocalIso8601 includes local timezone offset" {
@@ -411,7 +415,7 @@ test "logFn respects minimum level filtering" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    const tmp_path = try tmp_dir.dir.realpathAlloc(allocator, ".");
+    const tmp_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, ".", allocator);
     defer allocator.free(tmp_path);
 
     try init(allocator, std.testing.io, .{
@@ -424,7 +428,7 @@ test "logFn respects minimum level filtering" {
     logFn(.info, .logging_test, "info message should be filtered", .{});
     logFn(.warn, .logging_test, "warn message should be written", .{});
 
-    const contents = try readActiveLogAlloc(allocator, tmp_path);
+    const contents = try readActiveLogAlloc(allocator, std.testing.io, tmp_path);
     defer allocator.free(contents);
 
     try std.testing.expect(!std.mem.containsAtLeast(u8, contents, 1, "info message should be filtered"));
@@ -436,7 +440,7 @@ test "log line includes timestamp, level, scope, and message fields" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    const tmp_path = try tmp_dir.dir.realpathAlloc(allocator, ".");
+    const tmp_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, ".", allocator);
     defer allocator.free(tmp_path);
 
     try init(allocator, std.testing.io, .{
@@ -447,7 +451,7 @@ test "log line includes timestamp, level, scope, and message fields" {
 
     logFn(.info, .runtime, "hello structured log", .{});
 
-    const contents = try readActiveLogAlloc(allocator, tmp_path);
+    const contents = try readActiveLogAlloc(allocator, std.testing.io, tmp_path);
     defer allocator.free(contents);
 
     const line = std.mem.trim(u8, contents, "\n");
@@ -469,7 +473,7 @@ test "rotation archives old file once size limit is exceeded" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    const tmp_path = try tmp_dir.dir.realpathAlloc(allocator, ".");
+    const tmp_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, ".", allocator);
     defer allocator.free(tmp_path);
 
     try init(allocator, std.testing.io, .{
@@ -484,13 +488,13 @@ test "rotation archives old file once size limit is exceeded" {
         logFn(.info, .rotation_test, "rotation line {d} abcdefghijklmnopqrstuvwxyz", .{idx});
     }
 
-    var dir = try fs.openDirAbsolute(tmp_path, .{ .iterate = true });
-    defer dir.close();
+    var dir = try Dir.openDirAbsolute(std.testing.io, tmp_path, .{ .iterate = true });
+    defer dir.close(std.testing.io);
     var iterator = dir.iterate();
 
     var active_found = false;
     var archive_count: usize = 0;
-    while (try iterator.next()) |entry| {
+    while (try iterator.next(std.testing.io)) |entry| {
         if (entry.kind != .file) continue;
         if (std.mem.eql(u8, entry.name, active_log_filename)) {
             active_found = true;
@@ -508,10 +512,10 @@ test "rotation archives old file once size limit is exceeded" {
 test "init resolves a relative directory_override to an absolute log directory" {
     const allocator = std.testing.allocator;
     const relative_dir = ".tmp/logging_relative_override_test";
-    fs.cwd().deleteTree(relative_dir) catch |err| {
+    Dir.cwd().deleteTree(std.testing.io, relative_dir) catch |err| {
         std.debug.print("failed to pre-clean test log directory: {}\n", .{err});
     };
-    defer fs.cwd().deleteTree(relative_dir) catch |err| {
+    defer Dir.cwd().deleteTree(std.testing.io, relative_dir) catch |err| {
         std.debug.print("failed to clean up test log directory: {}\n", .{err});
     };
 
@@ -525,11 +529,11 @@ test "init resolves a relative directory_override to an absolute log directory" 
     try std.testing.expect(fs.path.isAbsolute(resolved));
     try std.testing.expect(std.mem.endsWith(u8, resolved, "logging_relative_override_test"));
 
-    var dir = try fs.openDirAbsolute(resolved, .{ .iterate = true });
-    defer dir.close();
+    var dir = try Dir.openDirAbsolute(std.testing.io, resolved, .{ .iterate = true });
+    defer dir.close(std.testing.io);
     var found_active = false;
     var iterator = dir.iterate();
-    while (try iterator.next()) |entry| {
+    while (try iterator.next(std.testing.io)) |entry| {
         if (entry.kind == .file and std.mem.eql(u8, entry.name, active_log_filename)) found_active = true;
     }
     try std.testing.expect(found_active);
@@ -540,7 +544,7 @@ test "startup, shutdown, and explicit events are emitted with info level" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    const tmp_path = try tmp_dir.dir.realpathAlloc(allocator, ".");
+    const tmp_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, ".", allocator);
     defer allocator.free(tmp_path);
 
     try init(allocator, std.testing.io, .{
@@ -553,7 +557,7 @@ test "startup, shutdown, and explicit events are emitted with info level" {
     try writeEvent("runtime", "entered full view", "view_enter_full", "from=Grid to=Full");
     try writeShutdownMarker();
 
-    const contents = try readActiveLogAlloc(allocator, tmp_path);
+    const contents = try readActiveLogAlloc(allocator, std.testing.io, tmp_path);
     defer allocator.free(contents);
 
     var event_lines: usize = 0;

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const runtime = @import("app/runtime.zig");
 const logging = @import("logging.zig");
 const cli_args = @import("cli_args.zig");
+const env = @import("env.zig");
 
 pub const std_options: std.Options = .{
     // Keep compile-time logging permissive; runtime filtering is handled by
@@ -11,17 +12,22 @@ pub const std_options: std.Options = .{
     .logFn = logging.logFn,
 };
 
-pub fn main() !void {
-    const allocator = std.heap.page_allocator;
-    const argv = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, argv);
+pub fn main(init: std.process.Init) !void {
+    env.init(init.minimal.environ);
 
-    const parsed = cli_args.parse(argv[1..]) catch |err| {
+    var args = init.minimal.args;
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(init.gpa);
+    while (args.next()) |arg| {
+        try argv.append(init.gpa, arg);
+    }
+
+    const parsed = cli_args.parse(argv.items[1..]) catch |err| {
         std.debug.print("architect: {s}\n{s}", .{ @errorName(err), cli_args.usage_text });
         std.process.exit(1);
     };
 
-    try runtime.run(parsed.log_dir_override);
+    try runtime.run(init.io, parsed.log_dir_override);
 }
 
 // Zig only collects tests from files reachable through this block, so every

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,7 +15,8 @@ pub const std_options: std.Options = .{
 pub fn main(init: std.process.Init) !void {
     env.init(init.minimal.environ);
 
-    var args = init.minimal.args;
+    var args = std.process.Args.Iterator.init(init.minimal.args);
+    defer args.deinit();
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(init.gpa);
     while (args.next()) |arg| {

--- a/src/mcp/main.zig
+++ b/src/mcp/main.zig
@@ -26,7 +26,7 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, stdin_file: std.Io.File, st
     var discarding_oversized_line = false;
     var chunk: [4096]u8 = undefined;
     while (true) {
-        const n = try stdin_file.read(&chunk);
+        const n = try stdin_file.readStreaming(io, &.{&chunk});
         if (n == 0) break;
 
         for (chunk[0..n]) |byte| {
@@ -46,7 +46,7 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, stdin_file: std.Io.File, st
             }
             if (byte == '\r') continue;
             if (buffer.items.len >= control.max_message_bytes) {
-                try writeJsonRpcError(allocator, stdout_file, null, .invalid_request, "message is too large");
+                try writeJsonRpcError(allocator, io, stdout_file, null, .invalid_request, "message is too large");
                 buffer.clearRetainingCapacity();
                 discarding_oversized_line = true;
                 continue;
@@ -63,27 +63,27 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, stdin_file: std.Io.File, st
 fn handleMessage(
     allocator: std.mem.Allocator,
     io: std.Io,
-    stdout_file: std.fs.File,
+    stdout_file: std.Io.File,
     bytes: []const u8,
 ) !void {
     var parsed = std.json.parseFromSlice(std.json.Value, allocator, bytes, .{}) catch {
-        try writeJsonRpcError(allocator, stdout_file, null, .parse_error, "parse error");
+        try writeJsonRpcError(allocator, io, stdout_file, null, .parse_error, "parse error");
         return;
     };
     defer parsed.deinit();
 
     if (parsed.value != .object) {
-        try writeJsonRpcError(allocator, stdout_file, null, .invalid_request, "request must be an object");
+        try writeJsonRpcError(allocator, io, stdout_file, null, .invalid_request, "request must be an object");
         return;
     }
 
     const object = parsed.value.object;
     const method_value = object.get("method") orelse {
-        try writeJsonRpcError(allocator, stdout_file, object.get("id"), .invalid_request, "method is required");
+        try writeJsonRpcError(allocator, io, stdout_file, object.get("id"), .invalid_request, "method is required");
         return;
     };
     if (method_value != .string) {
-        try writeJsonRpcError(allocator, stdout_file, object.get("id"), .invalid_request, "method must be a string");
+        try writeJsonRpcError(allocator, io, stdout_file, object.get("id"), .invalid_request, "method must be a string");
         return;
     }
 
@@ -96,50 +96,51 @@ fn handleMessage(
     }
 
     if (std.mem.eql(u8, method_value.string, "initialize")) {
-        try writeInitializeResult(allocator, stdout_file, id_value);
+        try writeInitializeResult(allocator, io, stdout_file, id_value);
     } else if (std.mem.eql(u8, method_value.string, "ping")) {
-        try writeEmptyResult(allocator, stdout_file, id_value);
+        try writeEmptyResult(allocator, io, stdout_file, id_value);
     } else if (std.mem.eql(u8, method_value.string, "tools/list")) {
-        try writeToolsListResult(allocator, stdout_file, id_value);
+        try writeToolsListResult(allocator, io, stdout_file, id_value);
     } else if (std.mem.eql(u8, method_value.string, "tools/call")) {
         try handleToolsCall(allocator, io, stdout_file, id_value, object.get("params"));
     } else {
-        try writeJsonRpcError(allocator, stdout_file, id_value, .method_not_found, "method not found");
+        try writeJsonRpcError(allocator, io, stdout_file, id_value, .method_not_found, "method not found");
     }
 }
 
 fn handleToolsCall(
     allocator: std.mem.Allocator,
     io: std.Io,
-    stdout_file: std.fs.File,
+    stdout_file: std.Io.File,
     id_value: ?std.json.Value,
     params_value: ?std.json.Value,
 ) !void {
     const params = params_value orelse {
-        try writeJsonRpcError(allocator, stdout_file, id_value, .invalid_params, "params are required");
+        try writeJsonRpcError(allocator, io, stdout_file, id_value, .invalid_params, "params are required");
         return;
     };
     if (params != .object) {
-        try writeJsonRpcError(allocator, stdout_file, id_value, .invalid_params, "params must be an object");
+        try writeJsonRpcError(allocator, io, stdout_file, id_value, .invalid_params, "params must be an object");
         return;
     }
 
     const name_value = params.object.get("name") orelse {
-        try writeJsonRpcError(allocator, stdout_file, id_value, .invalid_params, "tool name is required");
+        try writeJsonRpcError(allocator, io, stdout_file, id_value, .invalid_params, "tool name is required");
         return;
     };
     if (name_value != .string or !std.mem.eql(u8, name_value.string, tool_name)) {
-        try writeJsonRpcError(allocator, stdout_file, id_value, .invalid_params, "unknown tool");
+        try writeJsonRpcError(allocator, io, stdout_file, id_value, .invalid_params, "unknown tool");
         return;
     }
 
     const arguments = params.object.get("arguments") orelse {
-        try writeToolFailure(allocator, stdout_file, id_value, .invalid_request, "cwd is required");
+        try writeToolFailure(allocator, io, stdout_file, id_value, .invalid_request, "cwd is required");
         return;
     };
     var request = control.parseSpawnRequestFromValue(allocator, arguments) catch |err| {
         try writeToolFailure(
             allocator,
+            io,
             stdout_file,
             id_value,
             .invalid_request,
@@ -155,20 +156,21 @@ fn handleToolsCall(
             log.debug("failed to format Architect contact error: {}", .{fmt_err});
             break :blk "failed to contact Architect";
         };
-        try writeToolFailure(allocator, stdout_file, id_value, .app_not_running, message);
+        try writeToolFailure(allocator, io, stdout_file, id_value, .app_not_running, message);
         return;
     };
     defer response.deinit(allocator);
 
     switch (response.response) {
-        .success => |success| try writeToolSuccess(allocator, stdout_file, id_value, success),
-        .failure => |failure| try writeToolFailure(allocator, stdout_file, id_value, failure.code, failure.message),
+        .success => |success| try writeToolSuccess(allocator, io, stdout_file, id_value, success),
+        .failure => |failure| try writeToolFailure(allocator, io, stdout_file, id_value, failure.code, failure.message),
     }
 }
 
 fn writeInitializeResult(
     allocator: std.mem.Allocator,
-    stdout_file: std.fs.File,
+    io: std.Io,
+    stdout_file: std.Io.File,
     id_value: ?std.json.Value,
 ) !void {
     var out: std.Io.Writer.Allocating = .init(allocator);
@@ -193,12 +195,13 @@ fn writeInitializeResult(
     try json.endObject();
     try endRpcResult(&json);
 
-    try writeJsonLine(stdout_file, out.written());
+    try writeJsonLine(io, stdout_file, out.written());
 }
 
 fn writeEmptyResult(
     allocator: std.mem.Allocator,
-    stdout_file: std.fs.File,
+    io: std.Io,
+    stdout_file: std.Io.File,
     id_value: ?std.json.Value,
 ) !void {
     var out: std.Io.Writer.Allocating = .init(allocator);
@@ -208,12 +211,13 @@ fn writeEmptyResult(
     try beginRpcResult(&json, id_value);
     try endRpcResult(&json);
 
-    try writeJsonLine(stdout_file, out.written());
+    try writeJsonLine(io, stdout_file, out.written());
 }
 
 fn writeToolsListResult(
     allocator: std.mem.Allocator,
-    stdout_file: std.fs.File,
+    io: std.Io,
+    stdout_file: std.Io.File,
     id_value: ?std.json.Value,
 ) !void {
     var out: std.Io.Writer.Allocating = .init(allocator);
@@ -227,7 +231,7 @@ fn writeToolsListResult(
     try json.endArray();
     try endRpcResult(&json);
 
-    try writeJsonLine(stdout_file, out.written());
+    try writeJsonLine(io, stdout_file, out.written());
 }
 
 fn writeSpawnSessionTool(json: *std.json.Stringify) !void {
@@ -331,7 +335,8 @@ fn writeSpawnOutputSchema(json: *std.json.Stringify) !void {
 
 fn writeToolSuccess(
     allocator: std.mem.Allocator,
-    stdout_file: std.fs.File,
+    io: std.Io,
+    stdout_file: std.Io.File,
     id_value: ?std.json.Value,
     success: control.SpawnSuccess,
 ) !void {
@@ -362,12 +367,13 @@ fn writeToolSuccess(
     try json.write(false);
     try endRpcResult(&json);
 
-    try writeJsonLine(stdout_file, out.written());
+    try writeJsonLine(io, stdout_file, out.written());
 }
 
 fn writeToolFailure(
     allocator: std.mem.Allocator,
-    stdout_file: std.fs.File,
+    io: std.Io,
+    stdout_file: std.Io.File,
     id_value: ?std.json.Value,
     code: control.SpawnErrorCode,
     message: []const u8,
@@ -399,12 +405,13 @@ fn writeToolFailure(
     try json.write(true);
     try endRpcResult(&json);
 
-    try writeJsonLine(stdout_file, out.written());
+    try writeJsonLine(io, stdout_file, out.written());
 }
 
 fn writeJsonRpcError(
     allocator: std.mem.Allocator,
-    stdout_file: std.fs.File,
+    io: std.Io,
+    stdout_file: std.Io.File,
     id_value: ?std.json.Value,
     code: JsonRpcErrorCode,
     message: []const u8,
@@ -431,7 +438,7 @@ fn writeJsonRpcError(
     try json.endObject();
     try json.endObject();
 
-    try writeJsonLine(stdout_file, out.written());
+    try writeJsonLine(io, stdout_file, out.written());
 }
 
 fn beginRpcResult(json: *std.json.Stringify, id_value: ?std.json.Value) !void {
@@ -453,24 +460,25 @@ fn endRpcResult(json: *std.json.Stringify) !void {
     try json.endObject();
 }
 
-fn writeJsonLine(stdout_file: std.fs.File, bytes: []const u8) !void {
-    try stdout_file.writeAll(bytes);
-    try stdout_file.writeAll("\n");
+fn writeJsonLine(io: std.Io, stdout_file: std.Io.File, bytes: []const u8) !void {
+    try stdout_file.writeStreamingAll(io, bytes);
+    try stdout_file.writeStreamingAll(io, "\n");
 }
 
 test "tools/list exposes exactly spawn_session" {
     const allocator = std.testing.allocator;
+    const io = std.testing.io;
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var out = try tmp.dir.createFile("tools-list.jsonl", .{ .truncate = true });
+    const out = try tmp.dir.createFile(io, "tools-list.jsonl", .{ .truncate = true });
 
     const id = std.json.Value{ .integer = 1 };
-    try writeToolsListResult(allocator, out, id);
-    out.close();
+    try writeToolsListResult(allocator, io, out, id);
+    out.close(io);
 
-    const input = try tmp.dir.readFileAlloc(allocator, "tools-list.jsonl", 16 * 1024);
+    const input = try tmp.dir.readFileAlloc(io, "tools-list.jsonl", allocator, .limited(16 * 1024));
     defer allocator.free(input);
     var parsed = try std.json.parseFromSlice(std.json.Value, allocator, std.mem.trim(u8, input, "\n"), .{});
     defer parsed.deinit();
@@ -485,17 +493,18 @@ test "tools/list exposes exactly spawn_session" {
 
 test "tool failure response is an MCP tool error result" {
     const allocator = std.testing.allocator;
+    const io = std.testing.io;
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var out = try tmp.dir.createFile("failure.jsonl", .{ .truncate = true });
+    const out = try tmp.dir.createFile(io, "failure.jsonl", .{ .truncate = true });
 
     const id = std.json.Value{ .integer = 9 };
-    try writeToolFailure(allocator, out, id, .invalid_cwd, "cwd does not exist");
-    out.close();
+    try writeToolFailure(allocator, io, out, id, .invalid_cwd, "cwd does not exist");
+    out.close(io);
 
-    const input = try tmp.dir.readFileAlloc(allocator, "failure.jsonl", 16 * 1024);
+    const input = try tmp.dir.readFileAlloc(io, "failure.jsonl", allocator, .limited(16 * 1024));
     defer allocator.free(input);
     var parsed = try std.json.parseFromSlice(std.json.Value, allocator, std.mem.trim(u8, input, "\n"), .{});
     defer parsed.deinit();
@@ -513,29 +522,32 @@ test "tool failure response is an MCP tool error result" {
 
 test "run discards the rest of an oversized line" {
     const allocator = std.testing.allocator;
+    const io = std.testing.io;
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-
-    var input = try tmp.dir.createFile("input.jsonl", .{ .read = true });
-    defer input.close();
 
     const oversized = try allocator.alloc(u8, control.max_message_bytes + 10);
     defer allocator.free(oversized);
     @memset(oversized, 'x');
 
-    try input.writeAll(oversized);
-    try input.writeAll("\n");
-    try input.writeAll("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}\n");
-    try input.seekTo(0);
+    {
+        const input_writer = try tmp.dir.createFile(io, "input.jsonl", .{});
+        defer input_writer.close(io);
+        try input_writer.writeStreamingAll(io, oversized);
+        try input_writer.writeStreamingAll(io, "\n");
+        try input_writer.writeStreamingAll(io, "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}\n");
+    }
+    const input = try tmp.dir.openFile(io, "input.jsonl", .{});
+    defer input.close(io);
 
-    var out = try tmp.dir.createFile("output.jsonl", .{ .read = true });
-    defer out.close();
+    {
+        const out = try tmp.dir.createFile(io, "output.jsonl", .{});
+        defer out.close(io);
+        try run(allocator, io, input, out);
+    }
 
-    try run(allocator, input, out);
-    try out.seekTo(0);
-
-    const output = try out.readToEndAlloc(allocator, 64 * 1024);
+    const output = try tmp.dir.readFileAlloc(io, "output.jsonl", allocator, .limited(64 * 1024));
     defer allocator.free(output);
 
     var line_count: usize = 0;

--- a/src/mcp/main.zig
+++ b/src/mcp/main.zig
@@ -26,7 +26,10 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, stdin_file: std.Io.File, st
     var discarding_oversized_line = false;
     var chunk: [4096]u8 = undefined;
     while (true) {
-        const n = try stdin_file.readStreaming(io, &.{&chunk});
+        const n = stdin_file.readStreaming(io, &.{&chunk}) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => return err,
+        };
         if (n == 0) break;
 
         for (chunk[0..n]) |byte| {

--- a/src/mcp/main.zig
+++ b/src/mcp/main.zig
@@ -20,7 +20,6 @@ pub fn main(init: std.process.Init) !void {
 }
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io, stdin_file: std.Io.File, stdout_file: std.Io.File) !void {
-    _ = io;
     var buffer: std.ArrayList(u8) = .empty;
     defer buffer.deinit(allocator);
 
@@ -40,7 +39,7 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, stdin_file: std.Io.File, st
 
             if (byte == '\n') {
                 if (buffer.items.len > 0) {
-                    try handleMessage(allocator, stdout_file, buffer.items);
+                    try handleMessage(allocator, io, stdout_file, buffer.items);
                     buffer.clearRetainingCapacity();
                 }
                 continue;
@@ -57,12 +56,13 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, stdin_file: std.Io.File, st
     }
 
     if (!discarding_oversized_line and buffer.items.len > 0) {
-        try handleMessage(allocator, stdout_file, buffer.items);
+        try handleMessage(allocator, io, stdout_file, buffer.items);
     }
 }
 
 fn handleMessage(
     allocator: std.mem.Allocator,
+    io: std.Io,
     stdout_file: std.fs.File,
     bytes: []const u8,
 ) !void {
@@ -102,7 +102,7 @@ fn handleMessage(
     } else if (std.mem.eql(u8, method_value.string, "tools/list")) {
         try writeToolsListResult(allocator, stdout_file, id_value);
     } else if (std.mem.eql(u8, method_value.string, "tools/call")) {
-        try handleToolsCall(allocator, stdout_file, id_value, object.get("params"));
+        try handleToolsCall(allocator, io, stdout_file, id_value, object.get("params"));
     } else {
         try writeJsonRpcError(allocator, stdout_file, id_value, .method_not_found, "method not found");
     }
@@ -110,6 +110,7 @@ fn handleMessage(
 
 fn handleToolsCall(
     allocator: std.mem.Allocator,
+    io: std.Io,
     stdout_file: std.fs.File,
     id_value: ?std.json.Value,
     params_value: ?std.json.Value,
@@ -148,7 +149,7 @@ fn handleToolsCall(
     };
     defer request.deinit(allocator);
 
-    var response = control.connectAndSendSpawnRequest(allocator, request) catch |err| {
+    var response = control.connectAndSendSpawnRequest(allocator, io, request) catch |err| {
         var message_buf: [160]u8 = undefined;
         const message = std.fmt.bufPrint(&message_buf, "failed to contact Architect: {}", .{err}) catch |fmt_err| blk: {
             log.debug("failed to format Architect contact error: {}", .{fmt_err});

--- a/src/mcp/main.zig
+++ b/src/mcp/main.zig
@@ -15,13 +15,12 @@ const JsonRpcErrorCode = enum(i32) {
     internal_error = -32603,
 };
 
-pub fn main() !void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
-    try run(gpa.allocator(), std.fs.File.stdin(), std.fs.File.stdout());
+pub fn main(init: std.process.Init) !void {
+    try run(init.gpa, init.io, std.Io.File.stdin(), std.Io.File.stdout());
 }
 
-pub fn run(allocator: std.mem.Allocator, stdin_file: std.fs.File, stdout_file: std.fs.File) !void {
+pub fn run(allocator: std.mem.Allocator, io: std.Io, stdin_file: std.Io.File, stdout_file: std.Io.File) !void {
+    _ = io;
     var buffer: std.ArrayList(u8) = .empty;
     defer buffer.deinit(allocator);
 

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -57,7 +57,9 @@ pub fn openUrl(_: std.mem.Allocator, url: []const u8) OpenError!void {
 fn openUrlThread(ctx: *ThreadContext) void {
     defer ctx.deinit();
 
-    _ = proc.spawnDetached(ctx.allocator, &ctx.argv) catch |err| {
+    var threaded: std.Io.Threaded = .init(ctx.allocator, .{});
+    defer threaded.deinit();
+    _ = proc.spawnDetached(ctx.allocator, threaded.io(), &ctx.argv) catch |err| {
         log.warn("failed to open URL '{s}': {}", .{ ctx.url, err });
         return;
     };

--- a/src/platform/macos_input_source.zig
+++ b/src/platform/macos_input_source.zig
@@ -1,13 +1,81 @@
+// zwanzig-disable: identifier-style
 const builtin = @import("builtin");
 
 const is_macos = builtin.os.tag == .macos;
 
-const c = if (is_macos) @cImport({
-    @cInclude("Carbon/Carbon.h");
-    @cInclude("CoreFoundation/CoreFoundation.h");
-    @cInclude("objc/runtime.h");
-    @cInclude("objc/message.h");
-}) else struct {};
+/// Hand-written bindings for the handful of Carbon/CoreFoundation/Objective-C
+/// runtime symbols this file needs, verified against the real macOS SDK
+/// headers (HIToolbox/TextInputSources.h, CoreFoundation's CFBase/CFString/
+/// CFDictionary/CFNumber/CFPreferences.h, objc/objc.h, objc/message.h).
+///
+/// `@cImport`-ing Carbon/CoreFoundation.h pulls in ApplicationServices and
+/// CoreServices, which under Zig 0.16's Aro-based translate-c fail to parse:
+/// nested/umbrella framework headers aren't found (matches a reported
+/// Accelerate/vImage regression), and ImageIO's use of Apple's Blocks syntax
+/// (`(^Foo)(...)`) isn't understood by Aro's C parser at all. Hand-declaring
+/// only the symbols actually used here avoids both problems; the symbols
+/// themselves are decades-old, ABI-frozen APIs.
+const c = if (is_macos) struct {
+    pub const CFTypeID = c_ulong;
+    pub const CFIndex = c_long;
+    pub const Boolean = u8;
+    pub const OSStatus = i32;
+
+    // `const void*`: genuinely generic, so this stays optional-by-default;
+    // any concrete opaque pointer below coerces into it implicitly.
+    pub const CFTypeRef = ?*anyopaque;
+    pub const CFPropertyListRef = CFTypeRef;
+
+    const CFAllocator = opaque {};
+    pub const CFAllocatorRef = *CFAllocator;
+    pub extern const kCFAllocatorDefault: CFAllocatorRef;
+
+    const CFString = opaque {};
+    pub const CFStringRef = *CFString;
+    pub const CFStringEncoding = u32;
+    pub const kCFStringEncodingUTF8: CFStringEncoding = 0x0800_0100;
+    pub extern fn CFStringCreateWithCString(alloc: CFAllocatorRef, c_str: [*:0]const u8, encoding: CFStringEncoding) callconv(.c) ?CFStringRef;
+
+    const CFDictionary = opaque {};
+    pub const CFDictionaryRef = *CFDictionary;
+    pub extern fn CFDictionaryGetTypeID() callconv(.c) CFTypeID;
+    pub extern fn CFDictionaryGetValue(the_dict: CFDictionaryRef, key: CFTypeRef) callconv(.c) CFTypeRef;
+
+    pub const CFNumberType = CFIndex;
+    pub const kCFNumberSInt64Type: CFNumberType = 4;
+    pub extern fn CFNumberGetTypeID() callconv(.c) CFTypeID;
+    pub extern fn CFNumberGetValue(number: CFTypeRef, the_type: CFNumberType, value_ptr: ?*anyopaque) callconv(.c) Boolean;
+
+    pub extern fn CFBooleanGetTypeID() callconv(.c) CFTypeID;
+    pub extern fn CFBooleanGetValue(boolean: CFTypeRef) callconv(.c) Boolean;
+
+    pub extern fn CFGetTypeID(cf: CFTypeRef) callconv(.c) CFTypeID;
+    pub extern fn CFRetain(cf: CFTypeRef) callconv(.c) CFTypeRef;
+    pub extern fn CFRelease(cf: CFTypeRef) callconv(.c) void;
+
+    pub extern fn CFPreferencesCopyAppValue(key: CFStringRef, application_id: CFStringRef) callconv(.c) CFPropertyListRef;
+
+    // Carbon / HIToolbox text input source services (TextInputSources.h).
+    const TISInputSource = opaque {};
+    pub const TISInputSourceRef = *TISInputSource;
+    pub extern const kTISPropertyInputSourceID: CFStringRef;
+    pub extern fn TISCopyCurrentKeyboardInputSource() callconv(.c) ?TISInputSourceRef;
+    pub extern fn TISGetInputSourceProperty(input_source: TISInputSourceRef, property_key: CFStringRef) callconv(.c) ?*anyopaque;
+    pub extern fn TISSelectInputSource(input_source: TISInputSourceRef) callconv(.c) OSStatus;
+
+    // Objective-C runtime (objc/objc.h, objc/message.h). `objc_msgSend`'s
+    // declared signature is never called directly: existing call sites below
+    // take its address and reinterpret it as the specific non-variadic
+    // signature each call actually needs, the standard pattern for calling
+    // objc_msgSend from non-Objective-C code.
+    const objc_class = opaque {};
+    pub const Class = *objc_class;
+    const objc_selector = opaque {};
+    pub const SEL = *objc_selector;
+    pub extern fn objc_getClass(name: [*:0]const u8) callconv(.c) ?Class;
+    pub extern fn sel_registerName(name: [*:0]const u8) callconv(.c) ?SEL;
+    pub extern fn objc_msgSend() callconv(.c) void;
+} else struct {};
 
 pub const InputSourceTracker = if (is_macos) struct {
     source: ?c.TISInputSourceRef = null,

--- a/src/posix_util.zig
+++ b/src/posix_util.zig
@@ -1,0 +1,124 @@
+const std = @import("std");
+
+pub const FcntlError = error{
+    PermissionDenied,
+    FileBusy,
+    ProcessFdQuotaExceeded,
+    Locked,
+    DeadLock,
+    LockedRegionLimitExceeded,
+} || std.posix.UnexpectedError;
+
+pub fn fcntl(fd: std.posix.fd_t, cmd: i32, arg: usize) FcntlError!usize {
+    while (true) {
+        const rc = std.posix.system.fcntl(fd, cmd, arg);
+        switch (std.posix.errno(rc)) {
+            .SUCCESS => return @intCast(rc),
+            .INTR => continue,
+            .AGAIN, .ACCES => return error.Locked,
+            .BADF => unreachable,
+            .BUSY => return error.FileBusy,
+            .INVAL => unreachable,
+            .PERM => return error.PermissionDenied,
+            .MFILE => return error.ProcessFdQuotaExceeded,
+            .NOTDIR => unreachable,
+            .DEADLK => return error.DeadLock,
+            .NOLCK => return error.LockedRegionLimitExceeded,
+            else => |err| return std.posix.unexpectedErrno(err),
+        }
+    }
+}
+
+pub fn dup2(old_fd: std.posix.fd_t, new_fd: std.posix.fd_t) !void {
+    while (true) {
+        switch (std.posix.errno(std.posix.system.dup2(old_fd, new_fd))) {
+            .SUCCESS => return,
+            .BUSY, .INTR => continue,
+            .MFILE => return error.ProcessFdQuotaExceeded,
+            .INVAL, .BADF => unreachable,
+            else => |err| return std.posix.unexpectedErrno(err),
+        }
+    }
+}
+
+pub const ForkError = error{SystemResources} || std.posix.UnexpectedError;
+
+pub fn fork() ForkError!std.posix.pid_t {
+    const rc = std.posix.system.fork();
+    switch (std.posix.errno(rc)) {
+        .SUCCESS => return @intCast(rc),
+        .AGAIN, .NOMEM => return error.SystemResources,
+        else => |err| return std.posix.unexpectedErrno(err),
+    }
+}
+
+pub const PipeError = error{
+    SystemFdQuotaExceeded,
+    ProcessFdQuotaExceeded,
+} || std.posix.UnexpectedError;
+
+pub fn pipe(fds: *[2]std.posix.fd_t) PipeError!void {
+    switch (std.posix.errno(std.posix.system.pipe(fds))) {
+        .SUCCESS => return,
+        .INVAL, .FAULT => unreachable,
+        .NFILE => return error.SystemFdQuotaExceeded,
+        .MFILE => return error.ProcessFdQuotaExceeded,
+        else => |err| return std.posix.unexpectedErrno(err),
+    }
+}
+
+pub const WriteError = error{
+    DiskQuota,
+    FileTooBig,
+    InputOutput,
+    NoSpaceLeft,
+    DeviceBusy,
+    InvalidArgument,
+    AccessDenied,
+    PermissionDenied,
+    BrokenPipe,
+    SystemResources,
+    OperationAborted,
+    NotOpenForWriting,
+    LockViolation,
+    WouldBlock,
+    ConnectionResetByPeer,
+    ProcessNotFound,
+    NoDevice,
+    MessageTooBig,
+} || std.posix.UnexpectedError;
+
+pub fn write(fd: std.posix.fd_t, bytes: []const u8) WriteError!usize {
+    if (bytes.len == 0) return 0;
+
+    const max_count = switch (@import("builtin").os.tag) {
+        .linux => 0x7ffff000,
+        .macos, .ios, .watchos, .tvos, .visionos => std.math.maxInt(i32),
+        else => std.math.maxInt(isize),
+    };
+    while (true) {
+        const rc = std.posix.system.write(fd, bytes.ptr, @min(bytes.len, max_count));
+        switch (std.posix.errno(rc)) {
+            .SUCCESS => return @intCast(rc),
+            .INTR => continue,
+            .INVAL => return error.InvalidArgument,
+            .FAULT => unreachable,
+            .SRCH => return error.ProcessNotFound,
+            .AGAIN => return error.WouldBlock,
+            .BADF => return error.NotOpenForWriting,
+            .DESTADDRREQ => unreachable,
+            .DQUOT => return error.DiskQuota,
+            .FBIG => return error.FileTooBig,
+            .IO => return error.InputOutput,
+            .NOSPC => return error.NoSpaceLeft,
+            .ACCES => return error.AccessDenied,
+            .PERM => return error.PermissionDenied,
+            .PIPE => return error.BrokenPipe,
+            .CONNRESET => return error.ConnectionResetByPeer,
+            .BUSY => return error.DeviceBusy,
+            .NXIO => return error.NoDevice,
+            .MSGSIZE => return error.MessageTooBig,
+            else => |err| return std.posix.unexpectedErrno(err),
+        }
+    }
+}

--- a/src/posix_util.zig
+++ b/src/posix_util.zig
@@ -88,6 +88,46 @@ pub const WriteError = error{
     MessageTooBig,
 } || std.posix.UnexpectedError;
 
+pub const AcceptError = error{
+    WouldBlock,
+    ConnectionAborted,
+    SocketNotListening,
+    ProcessFdQuotaExceeded,
+    SystemFdQuotaExceeded,
+    SystemResources,
+    ProtocolFailure,
+    BlockedByFirewall,
+} || std.posix.UnexpectedError;
+
+/// Accepts a connection on `sock` without capturing the peer address, mirroring
+/// Zig 0.15.2's `std.posix.accept(sock, null, null, 0)`. `std.Io.net.Server.accept`
+/// cannot be used here: it treats `EAGAIN` on a non-blocking listening socket as a
+/// programmer bug and panics, but the call sites need non-blocking accept to poll
+/// a stop flag alongside listening for connections.
+pub fn accept(sock: std.posix.fd_t) AcceptError!std.posix.fd_t {
+    while (true) {
+        const rc = std.posix.system.accept(sock, null, null);
+        switch (std.posix.errno(rc)) {
+            .SUCCESS => return @intCast(rc),
+            .INTR => continue,
+            .AGAIN => return error.WouldBlock,
+            .BADF => unreachable,
+            .CONNABORTED => return error.ConnectionAborted,
+            .FAULT => unreachable,
+            .INVAL => return error.SocketNotListening,
+            .NOTSOCK => unreachable,
+            .MFILE => return error.ProcessFdQuotaExceeded,
+            .NFILE => return error.SystemFdQuotaExceeded,
+            .NOBUFS => return error.SystemResources,
+            .NOMEM => return error.SystemResources,
+            .OPNOTSUPP => unreachable,
+            .PROTO => return error.ProtocolFailure,
+            .PERM => return error.BlockedByFirewall,
+            else => |err| return std.posix.unexpectedErrno(err),
+        }
+    }
+}
+
 pub fn write(fd: std.posix.fd_t, bytes: []const u8) WriteError!usize {
     if (bytes.len == 0) return 0;
 

--- a/src/proc.zig
+++ b/src/proc.zig
@@ -34,63 +34,41 @@ pub const RunOptions = struct {
 
 fn fromStdTerm(term: std.process.Child.Term) Term {
     return switch (term) {
-        .Exited => |code| .{ .exited = code },
-        .Signal => |sig| .{ .signal = sig },
-        .Stopped => |sig| .{ .stopped = sig },
-        .Unknown => |code| .{ .unknown = code },
+        .exited => |code| .{ .exited = code },
+        .signal => |sig| .{ .signal = @intFromEnum(sig) },
+        .stopped => |sig| .{ .stopped = @intFromEnum(sig) },
+        .unknown => |code| .{ .unknown = code },
     };
 }
 
 /// Runs `argv` to completion, collecting stdout and stderr.
-pub fn run(allocator: std.mem.Allocator, options: RunOptions) !RunResult {
-    var child = std.process.Child.init(options.argv, allocator);
-    child.cwd = options.cwd;
-    child.stdin_behavior = .Ignore;
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
-
-    try child.spawn();
-
-    var stdout_buf: std.ArrayList(u8) = .empty;
-    errdefer stdout_buf.deinit(allocator);
-    var stderr_buf: std.ArrayList(u8) = .empty;
-    errdefer stderr_buf.deinit(allocator);
-
-    errdefer {
-        _ = child.kill() catch |kill_err| switch (kill_err) {
-            error.AlreadyTerminated => _ = child.wait() catch |wait_err| {
-                std.log.scoped(.proc).warn("failed to reap child after output failure: {}", .{wait_err});
-            },
-            else => std.log.scoped(.proc).warn("failed to stop child after output failure: {}", .{kill_err}),
-        };
-    }
-
-    try child.collectOutput(allocator, &stdout_buf, &stderr_buf, options.max_output_bytes);
-    const term = try child.wait();
-
-    const stdout_slice = try stdout_buf.toOwnedSlice(allocator);
-    errdefer allocator.free(stdout_slice);
-    const stderr_slice = try stderr_buf.toOwnedSlice(allocator);
-
+pub fn run(allocator: std.mem.Allocator, io: std.Io, options: RunOptions) !RunResult {
+    const result = try std.process.run(allocator, io, .{
+        .argv = options.argv,
+        .cwd = if (options.cwd) |c| .{ .path = c } else .inherit,
+        .stdout_limit = .limited(options.max_output_bytes),
+        .stderr_limit = .limited(options.max_output_bytes),
+    });
     return .{
-        .term = fromStdTerm(term),
-        .stdout = stdout_slice,
-        .stderr = stderr_slice,
+        .term = fromStdTerm(result.term),
+        .stdout = result.stdout,
+        .stderr = result.stderr,
     };
 }
 
 /// Spawns `argv`, waits for it, and discards its output.
-pub fn spawnDetached(allocator: std.mem.Allocator, argv: []const []const u8) !Term {
-    var child = std.process.Child.init(argv, allocator);
-    child.stdin_behavior = .Ignore;
-    child.stdout_behavior = .Ignore;
-    child.stderr_behavior = .Ignore;
-    return fromStdTerm(try child.spawnAndWait());
+pub fn spawnDetached(allocator: std.mem.Allocator, io: std.Io, argv: []const []const u8) !Term {
+    _ = allocator;
+    var child = try std.process.spawn(io, .{ .argv = argv });
+    return fromStdTerm(try child.wait(io));
 }
 
 test "run collects stdout and reports a zero exit" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+
     const allocator = std.testing.allocator;
-    const result = try run(allocator, .{
+    const result = try run(allocator, threaded.io(), .{
         .argv = &.{ "/bin/sh", "-c", "printf hello" },
     });
     defer allocator.free(result.stdout);
@@ -101,8 +79,11 @@ test "run collects stdout and reports a zero exit" {
 }
 
 test "run separates stderr from stdout and reports a nonzero exit" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+
     const allocator = std.testing.allocator;
-    const result = try run(allocator, .{
+    const result = try run(allocator, threaded.io(), .{
         .argv = &.{ "/bin/sh", "-c", "printf out; printf err 1>&2; exit 3" },
     });
     defer allocator.free(result.stdout);
@@ -114,8 +95,11 @@ test "run separates stderr from stdout and reports a nonzero exit" {
 }
 
 test "run honors cwd" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+
     const allocator = std.testing.allocator;
-    const result = try run(allocator, .{
+    const result = try run(allocator, threaded.io(), .{
         .argv = &.{ "/bin/sh", "-c", "pwd" },
         .cwd = "/",
     });
@@ -126,14 +110,20 @@ test "run honors cwd" {
 }
 
 test "run surfaces a missing executable as an error rather than a term" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+
     const allocator = std.testing.allocator;
-    try std.testing.expectError(error.FileNotFound, run(allocator, .{
+    try std.testing.expectError(error.FileNotFound, run(allocator, threaded.io(), .{
         .argv = &.{"/nonexistent/architect-test-binary"},
     }));
 }
 
 test "spawnDetached waits for the child and returns its term" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+
     const allocator = std.testing.allocator;
-    const term = try spawnDetached(allocator, &.{ "/bin/sh", "-c", "exit 7" });
+    const term = try spawnDetached(allocator, threaded.io(), &.{ "/bin/sh", "-c", "exit 7" });
     try std.testing.expectEqual(Term{ .exited = 7 }, term);
 }

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -3,6 +3,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const posix = std.posix;
+const posix_util = @import("posix_util.zig");
 
 const log = std.log.scoped(.pty);
 
@@ -74,12 +75,12 @@ const PosixPty = struct {
         }
 
         cloexec: {
-            const flags = std.posix.fcntl(master_fd, std.posix.F.GETFD, 0) catch |err| {
+            const flags = posix_util.fcntl(master_fd, std.posix.F.GETFD, 0) catch |err| {
                 log.warn("error getting flags for master fd err={}", .{err});
                 break :cloexec;
             };
 
-            _ = std.posix.fcntl(
+            _ = posix_util.fcntl(
                 master_fd,
                 std.posix.F.SETFD,
                 flags | std.posix.FD_CLOEXEC,
@@ -168,15 +169,15 @@ const PosixPty = struct {
 
         // The pre-dup2 fds are no longer needed; stdin/stdout/stderr already point
         // at the slave. Match ghostty's close pattern.
-        posix.close(self.slave);
-        posix.close(self.master);
+        _ = std.c.close(self.slave);
+        _ = std.c.close(self.master);
     }
 };
 
 test "setSize updates slave winsize via master ioctl" {
     var pty = try Pty.open(.{ .ws_row = 24, .ws_col = 80, .ws_xpixel = 800, .ws_ypixel = 600 });
     defer pty.deinit();
-    defer posix.close(pty.slave);
+    defer _ = std.c.close(pty.slave);
 
     try pty.setSize(.{ .ws_row = 40, .ws_col = 120, .ws_xpixel = 1200, .ws_ypixel = 800 });
 

--- a/src/render/renderer.zig
+++ b/src/render/renderer.zig
@@ -498,7 +498,7 @@ fn renderSessionContent(
 
         const current_row_pin = row_pin orelse continue;
         row_pin = current_row_pin.down(1);
-        const row_cells = current_row_pin.node.data.getCells(current_row_pin.rowAndCell().row);
+        const row_cells = current_row_pin.node.page().getCells(current_row_pin.rowAndCell().row);
 
         var col: usize = 0;
         while (col < visible_cols) : (col += 1) {
@@ -506,7 +506,7 @@ fn renderSessionContent(
             const cell = &row_cells[col];
             var cell_pin = current_row_pin;
             cell_pin.x = @intCast(col);
-            const cp: u21 = if (cell.content_tag == .codepoint or cell.content_tag == .codepoint_grapheme) cell.content.codepoint else 0;
+            const cp: u21 = if (cell.content_tag == .codepoint or cell.content_tag == .codepoint_grapheme) cell.content.codepoint.data else 0;
             const glyph_width_cells: c_int = switch (cell.wide) {
                 .wide => 2,
                 else => 1,
@@ -614,7 +614,7 @@ fn renderSessionContent(
                 cluster_len += 1;
 
                 if (cell.hasGrapheme()) {
-                    if (current_row_pin.node.data.lookupGrapheme(cell)) |extra| {
+                    if (current_row_pin.node.page().lookupGrapheme(cell)) |extra| {
                         for (extra) |gcp| {
                             if (cluster_len >= cluster_buf.len) break;
                             cluster_buf[cluster_len] = gcp;
@@ -1290,10 +1290,10 @@ test "getCellColor uses the live terminal palette for indexed colors" {
 test "row pin stepping matches per-cell getCell for content, wide flag, and style" {
     const allocator = std.testing.allocator;
 
-    var terminal = try ghostty_vt.Terminal.init(allocator, .{
+    var terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{
         .cols = 10,
         .rows = 4,
-        .max_scrollback = 0,
+        .max_scrollback_bytes = 0,
     });
     defer terminal.deinit(allocator);
 
@@ -1306,7 +1306,7 @@ test "row pin stepping matches per-cell getCell for content, wide flag, and styl
     var row: usize = 0;
     while (row < @as(usize, terminal.rows)) : (row += 1) {
         const row_rac = row_pin.rowAndCell();
-        const row_cells = row_pin.node.data.getCells(row_rac.row);
+        const row_cells = row_pin.node.page().getCells(row_rac.row);
 
         var col: usize = 0;
         while (col < @as(usize, terminal.cols)) : (col += 1) {
@@ -1317,7 +1317,7 @@ test "row pin stepping matches per-cell getCell for content, wide flag, and styl
             try std.testing.expectEqual(reference.cell.content_tag, walked_cell.content_tag);
             try std.testing.expectEqual(reference.cell.wide, walked_cell.wide);
             if (reference.cell.content_tag == .codepoint or reference.cell.content_tag == .codepoint_grapheme) {
-                try std.testing.expectEqual(reference.cell.content.codepoint, walked_cell.content.codepoint);
+                try std.testing.expectEqual(reference.cell.content.codepoint.data, walked_cell.content.codepoint.data);
             }
 
             const reference_style = reference.style();

--- a/src/session/notify.zig
+++ b/src/session/notify.zig
@@ -4,6 +4,7 @@ const clock = @import("../clock.zig");
 const env = @import("../env.zig");
 const app_state = @import("../app/app_state.zig");
 const atomic = std.atomic;
+const posix_util = @import("../posix_util.zig");
 
 const log = std.log.scoped(.notify);
 
@@ -25,7 +26,7 @@ pub const StoryNotification = struct {
 
 pub const NotificationQueue = struct {
     mutex: std.Io.Mutex = .init,
-    items: std.ArrayListUnmanaged(Notification) = .{},
+    items: std.ArrayList(Notification) = .empty,
 
     pub fn deinit(self: *NotificationQueue, allocator: std.mem.Allocator) void {
         self.items.deinit(allocator);
@@ -37,11 +38,11 @@ pub const NotificationQueue = struct {
         try self.items.append(allocator, item);
     }
 
-    pub fn drainAll(self: *NotificationQueue, io: std.Io) std.ArrayListUnmanaged(Notification) {
+    pub fn drainAll(self: *NotificationQueue, io: std.Io) std.ArrayList(Notification) {
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
         const items = self.items;
-        self.items = .{};
+        self.items = .empty;
         return items;
     }
 };
@@ -116,7 +117,7 @@ pub fn startNotifyThread(
     stop: *atomic.Value(bool),
     runtime_wake: ?RuntimeWake,
 ) StartNotifyThreadError!std.Thread {
-    _ = std.posix.unlink(socket_path) catch |err| switch (err) {
+    _ = std.Io.Dir.cwd().deleteFile(io, socket_path) catch |err| switch (err) {
         error.FileNotFound => {},
         else => log.warn("failed to unlink notify socket: {}", .{err}),
     };
@@ -177,32 +178,30 @@ pub fn startNotifyThread(
         }
 
         fn run(ctx: NotifyContext) !void {
-            const addr = try std.net.Address.initUnix(ctx.socket_path);
-            const fd = try posix.socket(posix.AF.UNIX, posix.SOCK.STREAM, 0);
-            defer posix.close(fd);
-
-            try posix.bind(fd, &addr.any, addr.getOsSockLen());
-            try posix.listen(fd, 16);
+            const address = try std.Io.net.UnixAddress.init(ctx.socket_path);
+            var server = try address.listen(ctx.io, .{ .kernel_backlog = 16 });
+            defer server.deinit(ctx.io);
+            const fd = server.socket.handle;
             const sock_path = std.mem.sliceTo(ctx.socket_path, 0);
-            std.posix.fchmodat(posix.AT.FDCWD, sock_path, 0o600, 0) catch |err| {
+            std.Io.Dir.cwd().setFilePermissions(ctx.io, sock_path, .fromMode(0o600), .{}) catch |err| {
                 log.warn("failed to chmod notify socket: {}", .{err});
             };
 
             // Make accept non-blocking so the loop can observe stop requests.
-            const flags = posix.fcntl(fd, posix.F.GETFL, 0) catch |err| blk: {
+            const flags = posix_util.fcntl(fd, posix.F.GETFL, 0) catch |err| blk: {
                 log.warn("failed to get socket flags: {}", .{err});
                 break :blk null;
             };
             if (flags) |f| {
                 var o_flags: posix.O = @bitCast(@as(u32, @intCast(f)));
                 o_flags.NONBLOCK = true;
-                if (posix.fcntl(fd, posix.F.SETFL, @as(u32, @bitCast(o_flags)))) |_| {} else |err| {
+                if (posix_util.fcntl(fd, posix.F.SETFL, @as(u32, @bitCast(o_flags)))) |_| {} else |err| {
                     log.warn("failed to set socket non-blocking: {}", .{err});
                 }
             }
 
             while (!ctx.stop.load(.seq_cst)) {
-                const conn_fd = posix.accept(fd, null, null, 0) catch |err| switch (err) {
+                const connection = server.accept(ctx.io) catch |err| switch (err) {
                     error.WouldBlock => {
                         clock.sleepNanos(ctx.io, std.time.ns_per_ms * 10);
                         continue;
@@ -212,21 +211,22 @@ pub fn startNotifyThread(
                         continue;
                     },
                 };
-                defer posix.close(conn_fd);
+                defer connection.close(ctx.io);
+                const conn_fd = connection.socket.handle;
 
-                const conn_flags = posix.fcntl(conn_fd, posix.F.GETFL, 0) catch |err| blk: {
+                const conn_flags = posix_util.fcntl(conn_fd, posix.F.GETFL, 0) catch |err| blk: {
                     log.debug("failed to get connection flags: {}", .{err});
                     break :blk null;
                 };
                 if (conn_flags) |f| {
                     var o_flags: posix.O = @bitCast(@as(u32, @intCast(f)));
                     o_flags.NONBLOCK = true;
-                    if (posix.fcntl(conn_fd, posix.F.SETFL, @as(u32, @bitCast(o_flags)))) |_| {} else |err| {
+                    if (posix_util.fcntl(conn_fd, posix.F.SETFL, @as(u32, @bitCast(o_flags)))) |_| {} else |err| {
                         log.warn("failed to set connection non-blocking: {}", .{err});
                     }
                 }
 
-                var buffer = std.ArrayList(u8){};
+                var buffer: std.ArrayList(u8) = .empty;
                 defer buffer.deinit(ctx.allocator);
 
                 var tmp: [512]u8 = undefined;

--- a/src/session/notify.zig
+++ b/src/session/notify.zig
@@ -24,22 +24,22 @@ pub const StoryNotification = struct {
 };
 
 pub const NotificationQueue = struct {
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = .init,
     items: std.ArrayListUnmanaged(Notification) = .{},
 
     pub fn deinit(self: *NotificationQueue, allocator: std.mem.Allocator) void {
         self.items.deinit(allocator);
     }
 
-    pub fn push(self: *NotificationQueue, allocator: std.mem.Allocator, item: Notification) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+    pub fn push(self: *NotificationQueue, allocator: std.mem.Allocator, io: std.Io, item: Notification) !void {
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
         try self.items.append(allocator, item);
     }
 
-    pub fn drainAll(self: *NotificationQueue) std.ArrayListUnmanaged(Notification) {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+    pub fn drainAll(self: *NotificationQueue, io: std.Io) std.ArrayListUnmanaged(Notification) {
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
         const items = self.items;
         self.items = .{};
         return items;
@@ -90,11 +90,12 @@ fn releaseNotification(allocator: std.mem.Allocator, note: Notification) void {
 
 fn enqueueNotification(
     allocator: std.mem.Allocator,
+    io: std.Io,
     queue: *NotificationQueue,
     runtime_wake: ?RuntimeWake,
     note: Notification,
 ) void {
-    queue.push(allocator, note) catch |err| {
+    queue.push(allocator, io, note) catch |err| {
         log.warn("failed to queue notification for session {d}: {}", .{ notificationSessionId(note), err });
         releaseNotification(allocator, note);
         return;
@@ -248,7 +249,7 @@ pub fn startNotifyThread(
                 if (buffer.items.len == 0) continue;
 
                 if (parseNotification(buffer.items, ctx.allocator)) |note| {
-                    enqueueNotification(ctx.allocator, ctx.queue, ctx.runtime_wake, note);
+                    enqueueNotification(ctx.allocator, ctx.io, ctx.queue, ctx.runtime_wake, note);
                 }
             }
         }
@@ -270,11 +271,11 @@ test "NotificationQueue - push and drain" {
     var queue = NotificationQueue{};
     defer queue.deinit(allocator);
 
-    try queue.push(allocator, .{ .status = .{ .session = 0, .state = .running } });
-    try queue.push(allocator, .{ .status = .{ .session = 1, .state = .awaiting_approval } });
-    try queue.push(allocator, .{ .status = .{ .session = 2, .state = .done } });
+    try queue.push(allocator, std.testing.io, .{ .status = .{ .session = 0, .state = .running } });
+    try queue.push(allocator, std.testing.io, .{ .status = .{ .session = 1, .state = .awaiting_approval } });
+    try queue.push(allocator, std.testing.io, .{ .status = .{ .session = 2, .state = .done } });
 
-    var items = queue.drainAll();
+    var items = queue.drainAll(std.testing.io);
     defer items.deinit(allocator);
 
     try std.testing.expectEqual(@as(usize, 3), items.items.len);
@@ -304,12 +305,13 @@ test "enqueueNotification wakes after queueing" {
 
     enqueueNotification(
         allocator,
+        std.testing.io,
         &queue,
         wake,
         .{ .status = .{ .session = 7, .state = .done } },
     );
 
-    var items = queue.drainAll();
+    var items = queue.drainAll(std.testing.io);
     defer items.deinit(allocator);
 
     try std.testing.expectEqual(@as(usize, 1), wake_count);
@@ -339,17 +341,18 @@ test "enqueueNotification skips wake when queueing fails" {
     };
 
     while (true) {
-        queue.push(allocator, .{ .status = .{ .session = 1, .state = .running } }) catch break;
+        queue.push(allocator, std.testing.io, .{ .status = .{ .session = 1, .state = .running } }) catch break;
     }
 
     enqueueNotification(
         allocator,
+        std.testing.io,
         &queue,
         wake,
         .{ .status = .{ .session = 7, .state = .done } },
     );
 
-    var items = queue.drainAll();
+    var items = queue.drainAll(std.testing.io);
     defer items.deinit(allocator);
 
     try std.testing.expectEqual(@as(usize, 0), wake_count);

--- a/src/session/notify.zig
+++ b/src/session/notify.zig
@@ -58,6 +58,7 @@ pub fn getNotifySocketPath(allocator: std.mem.Allocator) GetNotifySocketPathErro
 
 const NotifyContext = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
     socket_path: [:0]const u8,
     queue: *NotificationQueue,
     stop: *atomic.Value(bool),
@@ -108,6 +109,7 @@ pub const StartNotifyThreadError = std.Thread.SpawnError;
 
 pub fn startNotifyThread(
     allocator: std.mem.Allocator,
+    io: std.Io,
     socket_path: [:0]const u8,
     queue: *NotificationQueue,
     stop: *atomic.Value(bool),
@@ -201,7 +203,7 @@ pub fn startNotifyThread(
             while (!ctx.stop.load(.seq_cst)) {
                 const conn_fd = posix.accept(fd, null, null, 0) catch |err| switch (err) {
                     error.WouldBlock => {
-                        clock.sleepNanos(std.time.ns_per_ms * 10);
+                        clock.sleepNanos(ctx.io, std.time.ns_per_ms * 10);
                         continue;
                     },
                     else => {
@@ -254,6 +256,7 @@ pub fn startNotifyThread(
 
     const ctx = NotifyContext{
         .allocator = allocator,
+        .io = io,
         .socket_path = socket_path,
         .queue = queue,
         .stop = stop,

--- a/src/session/notify.zig
+++ b/src/session/notify.zig
@@ -201,7 +201,7 @@ pub fn startNotifyThread(
             }
 
             while (!ctx.stop.load(.seq_cst)) {
-                const connection = server.accept(ctx.io) catch |err| switch (err) {
+                const conn_fd = posix_util.accept(fd) catch |err| switch (err) {
                     error.WouldBlock => {
                         clock.sleepNanos(ctx.io, std.time.ns_per_ms * 10);
                         continue;
@@ -211,8 +211,7 @@ pub fn startNotifyThread(
                         continue;
                     },
                 };
-                defer connection.close(ctx.io);
-                const conn_fd = connection.socket.handle;
+                defer _ = std.c.close(conn_fd);
 
                 const conn_flags = posix_util.fcntl(conn_fd, posix.F.GETFL, 0) catch |err| blk: {
                     log.debug("failed to get connection flags: {}", .{err});

--- a/src/session/pty_reader.zig
+++ b/src/session/pty_reader.zig
@@ -42,25 +42,27 @@ pub const PtyOutputBuffer = struct {
         closed,
     };
 
-    mutex: std.Thread.Mutex = .{},
+    io: std.Io,
+    mutex: std.Io.Mutex = .init,
     data: []u8,
     head: usize = 0,
     len: usize = 0,
     eof: bool = false,
     read_error: ?posix.ReadError = null,
 
-    pub fn create(allocator: std.mem.Allocator) error{OutOfMemory}!*PtyOutputBuffer {
-        return createWithCapacity(allocator, buffer_capacity);
+    pub fn create(allocator: std.mem.Allocator, io: std.Io) error{OutOfMemory}!*PtyOutputBuffer {
+        return createWithCapacity(allocator, io, buffer_capacity);
     }
 
     pub fn createWithCapacity(
         allocator: std.mem.Allocator,
+        io: std.Io,
         capacity: usize,
     ) error{OutOfMemory}!*PtyOutputBuffer {
         std.debug.assert(capacity > 0);
         const self = try allocator.create(PtyOutputBuffer);
         errdefer allocator.destroy(self);
-        self.* = .{ .data = try allocator.alloc(u8, capacity) };
+        self.* = .{ .io = io, .data = try allocator.alloc(u8, capacity) };
         return self;
     }
 
@@ -72,8 +74,8 @@ pub const PtyOutputBuffer = struct {
     /// Reader-thread side: drain `fd` into free ring space until the fd
     /// would block, the ring fills, or the fd closes/fails.
     pub fn pumpFd(self: *PtyOutputBuffer, fd: posix.fd_t) PumpOutcome {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
 
         if (self.eof or self.read_error != null) return .closed;
 
@@ -104,8 +106,8 @@ pub const PtyOutputBuffer = struct {
 
     /// Main-thread side: copy up to `dest.len` buffered bytes out, in order.
     pub fn consume(self: *PtyOutputBuffer, dest: []u8) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
 
         var copied: usize = 0;
         while (copied < dest.len and self.len > 0) {
@@ -123,8 +125,8 @@ pub const PtyOutputBuffer = struct {
     /// Surface the first unrecoverable read error once all buffered bytes are
     /// drained, so output preceding the failure is not lost.
     pub fn takePendingReadError(self: *PtyOutputBuffer) ?posix.ReadError {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
         if (self.len > 0) return null;
         const err = self.read_error orelse return null;
         self.read_error = null;
@@ -136,8 +138,8 @@ pub const PtyOutputBuffer = struct {
     }
 
     fn pollState(self: *PtyOutputBuffer) PollState {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
         if (self.eof or self.read_error != null) return .closed;
         if (self.len == self.data.len) return .full;
         return .ready;
@@ -171,21 +173,26 @@ fn isWakeWorthy(revents: i16) bool {
 /// read of a registered fd happens while `mutex` is held, so `retire`
 /// returning guarantees the reader can no longer touch the fd or buffer.
 pub const PtyReader = struct {
-    mutex: std.Thread.Mutex = .{},
+    io: std.Io,
+    mutex: std.Io.Mutex = .init,
     entries: [grid_layout.max_terminals]Entry = undefined,
     entry_count: usize = 0,
 
+    pub fn init(io: std.Io) PtyReader {
+        return .{ .io = io };
+    }
+
     pub fn register(self: *PtyReader, fd: posix.fd_t, buffer: *PtyOutputBuffer) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
         std.debug.assert(self.entry_count < self.entries.len);
         self.entries[self.entry_count] = .{ .fd = fd, .buffer = buffer };
         self.entry_count += 1;
     }
 
     pub fn retire(self: *PtyReader, fd: posix.fd_t) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
         for (self.entries[0..self.entry_count], 0..) |entry, i| {
             if (entry.fd == fd) {
                 self.entries[i] = self.entries[self.entry_count - 1];
@@ -201,8 +208,8 @@ pub const PtyReader = struct {
         self: *PtyReader,
         out: *[grid_layout.max_terminals]posix.pollfd,
     ) PollSnapshot {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
         var count: usize = 0;
         var has_full_buffer = false;
         for (self.entries[0..self.entry_count]) |entry| {
@@ -219,8 +226,8 @@ pub const PtyReader = struct {
     }
 
     fn pumpReadyFds(self: *PtyReader, pollfds: []const posix.pollfd) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
         var progressed = false;
         for (pollfds) |pfd| {
             if (!isWakeWorthy(pfd.revents)) continue;
@@ -313,8 +320,8 @@ fn waitForBufferBytes(io: std.Io, buffer: *PtyOutputBuffer, timeout_ms: u64) boo
 }
 
 fn bufferHasBytes(buffer: *PtyOutputBuffer) bool {
-    buffer.mutex.lock();
-    defer buffer.mutex.unlock();
+    buffer.mutex.lockUncancelable(buffer.io);
+    defer buffer.mutex.unlock(buffer.io);
     return buffer.len > 0;
 }
 
@@ -334,7 +341,7 @@ test "isWakeWorthy fires for readable, hangup, error, and invalid fds" {
 
 test "PtyOutputBuffer pumps a pipe and consumes in order" {
     const allocator = std.testing.allocator;
-    const buffer = try PtyOutputBuffer.create(allocator);
+    const buffer = try PtyOutputBuffer.create(allocator, std.testing.io);
     defer buffer.destroy(allocator);
 
     const fds = try makeNonBlockingPipe();
@@ -354,7 +361,7 @@ test "PtyOutputBuffer pumps a pipe and consumes in order" {
 
 test "PtyOutputBuffer returns idle when the fd has no data" {
     const allocator = std.testing.allocator;
-    const buffer = try PtyOutputBuffer.create(allocator);
+    const buffer = try PtyOutputBuffer.create(allocator, std.testing.io);
     defer buffer.destroy(allocator);
 
     const fds = try makeNonBlockingPipe();
@@ -366,7 +373,7 @@ test "PtyOutputBuffer returns idle when the fd has no data" {
 
 test "PtyOutputBuffer wraps around a small ring without corrupting bytes" {
     const allocator = std.testing.allocator;
-    const buffer = try PtyOutputBuffer.createWithCapacity(allocator, 8);
+    const buffer = try PtyOutputBuffer.createWithCapacity(allocator, std.testing.io, 8);
     defer buffer.destroy(allocator);
 
     const fds = try makeNonBlockingPipe();
@@ -388,7 +395,7 @@ test "PtyOutputBuffer wraps around a small ring without corrupting bytes" {
 
 test "PtyOutputBuffer reports full and resumes after the consumer drains" {
     const allocator = std.testing.allocator;
-    const buffer = try PtyOutputBuffer.createWithCapacity(allocator, 4);
+    const buffer = try PtyOutputBuffer.createWithCapacity(allocator, std.testing.io, 4);
     defer buffer.destroy(allocator);
 
     const fds = try makeNonBlockingPipe();
@@ -412,7 +419,7 @@ test "PtyOutputBuffer reports full and resumes after the consumer drains" {
 
 test "PtyOutputBuffer records EOF when the write end closes" {
     const allocator = std.testing.allocator;
-    const buffer = try PtyOutputBuffer.create(allocator);
+    const buffer = try PtyOutputBuffer.create(allocator, std.testing.io);
     defer buffer.destroy(allocator);
 
     const fds = try makeNonBlockingPipe();
@@ -433,7 +440,7 @@ test "PtyOutputBuffer records EOF when the write end closes" {
 
 test "PtyOutputBuffer surfaces a read error only after the ring is drained" {
     const allocator = std.testing.allocator;
-    const buffer = try PtyOutputBuffer.create(allocator);
+    const buffer = try PtyOutputBuffer.create(allocator, std.testing.io);
     defer buffer.destroy(allocator);
 
     const fds = try makeNonBlockingPipe();
@@ -444,8 +451,8 @@ test "PtyOutputBuffer surfaces a read error only after the ring is drained" {
     try std.testing.expectEqual(PumpOutcome.progressed, buffer.pumpFd(fds[0]));
 
     {
-        buffer.mutex.lock();
-        defer buffer.mutex.unlock();
+        buffer.mutex.lockUncancelable(buffer.io);
+        defer buffer.mutex.unlock(buffer.io);
         buffer.read_error = error.NotOpenForReading;
     }
 
@@ -458,10 +465,10 @@ test "PtyOutputBuffer surfaces a read error only after the ring is drained" {
 
 test "PtyReader register/retire updates the poll snapshot" {
     const allocator = std.testing.allocator;
-    const buffer = try PtyOutputBuffer.createWithCapacity(allocator, 16);
+    const buffer = try PtyOutputBuffer.createWithCapacity(allocator, std.testing.io, 16);
     defer buffer.destroy(allocator);
 
-    var reader = PtyReader{};
+    var reader = PtyReader.init(std.testing.io);
     reader.register(7, buffer);
     var pollfds: [grid_layout.max_terminals]posix.pollfd = undefined;
     try std.testing.expectEqual(@as(usize, 1), reader.snapshotPollfds(&pollfds).count);
@@ -473,19 +480,19 @@ test "PtyReader register/retire updates the poll snapshot" {
 
 test "PtyReader snapshot distinguishes full and closed buffers" {
     const allocator = std.testing.allocator;
-    const full_buffer = try PtyOutputBuffer.createWithCapacity(allocator, 4);
+    const full_buffer = try PtyOutputBuffer.createWithCapacity(allocator, std.testing.io, 4);
     defer full_buffer.destroy(allocator);
-    const closed_buffer = try PtyOutputBuffer.createWithCapacity(allocator, 4);
+    const closed_buffer = try PtyOutputBuffer.createWithCapacity(allocator, std.testing.io, 4);
     defer closed_buffer.destroy(allocator);
 
-    full_buffer.mutex.lock();
+    full_buffer.mutex.lockUncancelable(full_buffer.io);
     full_buffer.len = full_buffer.data.len;
-    full_buffer.mutex.unlock();
-    closed_buffer.mutex.lock();
+    full_buffer.mutex.unlock(full_buffer.io);
+    closed_buffer.mutex.lockUncancelable(closed_buffer.io);
     closed_buffer.eof = true;
-    closed_buffer.mutex.unlock();
+    closed_buffer.mutex.unlock(closed_buffer.io);
 
-    var reader = PtyReader{};
+    var reader = PtyReader.init(std.testing.io);
     reader.register(7, full_buffer);
     reader.register(8, closed_buffer);
     var pollfds: [grid_layout.max_terminals]posix.pollfd = undefined;
@@ -506,14 +513,14 @@ test "PtyReader thread drains a pipe into the buffer and posts one wake" {
     const allocator = std.testing.allocator;
     var threaded: std.Io.Threaded = .init(allocator, .{});
     defer threaded.deinit();
-    const buffer = try PtyOutputBuffer.create(allocator);
+    const buffer = try PtyOutputBuffer.create(allocator, threaded.io());
     defer buffer.destroy(allocator);
 
     const fds = try makeNonBlockingPipe();
     defer posix.close(fds[0]);
     defer posix.close(fds[1]);
 
-    var reader = PtyReader{};
+    var reader = PtyReader.init(threaded.io());
     var stop = atomic.Value(bool).init(false);
     var wake_pending = atomic.Value(bool).init(false);
     var wake_count = atomic.Value(usize).init(0);
@@ -550,14 +557,14 @@ test "PtyReader.retire prevents any further reads of the fd" {
     const allocator = std.testing.allocator;
     var threaded: std.Io.Threaded = .init(allocator, .{});
     defer threaded.deinit();
-    const buffer = try PtyOutputBuffer.create(allocator);
+    const buffer = try PtyOutputBuffer.create(allocator, threaded.io());
     defer buffer.destroy(allocator);
 
     const fds = try makeNonBlockingPipe();
     defer posix.close(fds[0]);
     defer posix.close(fds[1]);
 
-    var reader = PtyReader{};
+    var reader = PtyReader.init(threaded.io());
     var stop = atomic.Value(bool).init(false);
     var wake_pending = atomic.Value(bool).init(false);
 

--- a/src/session/pty_reader.zig
+++ b/src/session/pty_reader.zig
@@ -3,6 +3,7 @@ const posix = std.posix;
 const atomic = std.atomic;
 const clock = @import("../clock.zig");
 const grid_layout = @import("../app/grid_layout.zig");
+const posix_util = @import("../posix_util.zig");
 
 const log = std.log.scoped(.pty_reader);
 
@@ -301,13 +302,12 @@ fn run(ctx: ReaderContext) void {
     }
 }
 
-fn makeNonBlockingPipe() ![2]posix.fd_t {
-    const fds = try posix.pipe();
-    const flags = try posix.fcntl(fds[0], posix.F.GETFL, 0);
+fn makeNonBlockingPipe(fds: *[2]posix.fd_t) !void {
+    try posix_util.pipe(fds);
+    const flags = try posix_util.fcntl(fds[0], posix.F.GETFL, 0);
     var o_flags: posix.O = @bitCast(@as(u32, @intCast(flags)));
     o_flags.NONBLOCK = true;
-    _ = try posix.fcntl(fds[0], posix.F.SETFL, @as(u32, @bitCast(o_flags)));
-    return fds;
+    _ = try posix_util.fcntl(fds[0], posix.F.SETFL, @as(u32, @bitCast(o_flags)));
 }
 
 fn waitForBufferBytes(io: std.Io, buffer: *PtyOutputBuffer, timeout_ms: u64) bool {
@@ -344,12 +344,13 @@ test "PtyOutputBuffer pumps a pipe and consumes in order" {
     const buffer = try PtyOutputBuffer.create(allocator, std.testing.io);
     defer buffer.destroy(allocator);
 
-    const fds = try makeNonBlockingPipe();
-    defer posix.close(fds[0]);
-    defer posix.close(fds[1]);
+    var fds: [2]posix.fd_t = undefined;
+    try makeNonBlockingPipe(&fds);
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
 
-    _ = try posix.write(fds[1], "hello ");
-    _ = try posix.write(fds[1], "world");
+    _ = try posix_util.write(fds[1], "hello ");
+    _ = try posix_util.write(fds[1], "world");
 
     try std.testing.expectEqual(PumpOutcome.progressed, buffer.pumpFd(fds[0]));
 
@@ -364,9 +365,10 @@ test "PtyOutputBuffer returns idle when the fd has no data" {
     const buffer = try PtyOutputBuffer.create(allocator, std.testing.io);
     defer buffer.destroy(allocator);
 
-    const fds = try makeNonBlockingPipe();
-    defer posix.close(fds[0]);
-    defer posix.close(fds[1]);
+    var fds: [2]posix.fd_t = undefined;
+    try makeNonBlockingPipe(&fds);
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
 
     try std.testing.expectEqual(PumpOutcome.idle, buffer.pumpFd(fds[0]));
 }
@@ -376,18 +378,19 @@ test "PtyOutputBuffer wraps around a small ring without corrupting bytes" {
     const buffer = try PtyOutputBuffer.createWithCapacity(allocator, std.testing.io, 8);
     defer buffer.destroy(allocator);
 
-    const fds = try makeNonBlockingPipe();
-    defer posix.close(fds[0]);
-    defer posix.close(fds[1]);
+    var fds: [2]posix.fd_t = undefined;
+    try makeNonBlockingPipe(&fds);
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
 
     var out: [8]u8 = undefined;
 
-    _ = try posix.write(fds[1], "abcdef");
+    _ = try posix_util.write(fds[1], "abcdef");
     try std.testing.expectEqual(PumpOutcome.progressed, buffer.pumpFd(fds[0]));
     try std.testing.expectEqual(@as(usize, 4), buffer.consume(out[0..4]));
     try std.testing.expectEqualSlices(u8, "abcd", out[0..4]);
 
-    _ = try posix.write(fds[1], "ghijk");
+    _ = try posix_util.write(fds[1], "ghijk");
     try std.testing.expectEqual(PumpOutcome.progressed, buffer.pumpFd(fds[0]));
     const n = buffer.consume(&out);
     try std.testing.expectEqualSlices(u8, "efghijk", out[0..n]);
@@ -398,11 +401,12 @@ test "PtyOutputBuffer reports full and resumes after the consumer drains" {
     const buffer = try PtyOutputBuffer.createWithCapacity(allocator, std.testing.io, 4);
     defer buffer.destroy(allocator);
 
-    const fds = try makeNonBlockingPipe();
-    defer posix.close(fds[0]);
-    defer posix.close(fds[1]);
+    var fds: [2]posix.fd_t = undefined;
+    try makeNonBlockingPipe(&fds);
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
 
-    _ = try posix.write(fds[1], "abcdef");
+    _ = try posix_util.write(fds[1], "abcdef");
     try std.testing.expectEqual(PumpOutcome.progressed, buffer.pumpFd(fds[0]));
     try std.testing.expectEqual(PumpOutcome.full, buffer.pumpFd(fds[0]));
     try std.testing.expect(!buffer.canAcceptBytes());
@@ -422,11 +426,12 @@ test "PtyOutputBuffer records EOF when the write end closes" {
     const buffer = try PtyOutputBuffer.create(allocator, std.testing.io);
     defer buffer.destroy(allocator);
 
-    const fds = try makeNonBlockingPipe();
-    defer posix.close(fds[0]);
+    var fds: [2]posix.fd_t = undefined;
+    try makeNonBlockingPipe(&fds);
+    defer _ = std.c.close(fds[0]);
 
-    _ = try posix.write(fds[1], "tail");
-    posix.close(fds[1]);
+    _ = try posix_util.write(fds[1], "tail");
+    _ = std.c.close(fds[1]);
 
     try std.testing.expectEqual(PumpOutcome.progressed, buffer.pumpFd(fds[0]));
     try std.testing.expectEqual(PumpOutcome.closed, buffer.pumpFd(fds[0]));
@@ -443,11 +448,12 @@ test "PtyOutputBuffer surfaces a read error only after the ring is drained" {
     const buffer = try PtyOutputBuffer.create(allocator, std.testing.io);
     defer buffer.destroy(allocator);
 
-    const fds = try makeNonBlockingPipe();
-    defer posix.close(fds[0]);
-    defer posix.close(fds[1]);
+    var fds: [2]posix.fd_t = undefined;
+    try makeNonBlockingPipe(&fds);
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
 
-    _ = try posix.write(fds[1], "data");
+    _ = try posix_util.write(fds[1], "data");
     try std.testing.expectEqual(PumpOutcome.progressed, buffer.pumpFd(fds[0]));
 
     {
@@ -516,9 +522,10 @@ test "PtyReader thread drains a pipe into the buffer and posts one wake" {
     const buffer = try PtyOutputBuffer.create(allocator, threaded.io());
     defer buffer.destroy(allocator);
 
-    const fds = try makeNonBlockingPipe();
-    defer posix.close(fds[0]);
-    defer posix.close(fds[1]);
+    var fds: [2]posix.fd_t = undefined;
+    try makeNonBlockingPipe(&fds);
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
 
     var reader = PtyReader.init(threaded.io());
     var stop = atomic.Value(bool).init(false);
@@ -535,20 +542,20 @@ test "PtyReader thread drains a pipe into the buffer and posts one wake" {
     }
 
     reader.register(fds[0], buffer);
-    _ = try posix.write(fds[1], "ping");
+    _ = try posix_util.write(fds[1], "ping");
 
     try std.testing.expect(waitForBufferBytes(threaded.io(), buffer, 2_000));
     try std.testing.expect(wake_pending.load(.seq_cst));
     try std.testing.expectEqual(@as(usize, 1), wake_count.load(.seq_cst));
 
-    _ = try posix.write(fds[1], "pong");
+    _ = try posix_util.write(fds[1], "pong");
     clock.sleepNanos(threaded.io(), 300 * std.time.ns_per_ms);
     try std.testing.expectEqual(@as(usize, 1), wake_count.load(.seq_cst));
 
     var out: [16]u8 = undefined;
     _ = buffer.consume(&out);
     wake_pending.store(false, .seq_cst);
-    _ = try posix.write(fds[1], "again");
+    _ = try posix_util.write(fds[1], "again");
     try std.testing.expect(waitForBufferBytes(threaded.io(), buffer, 2_000));
     try std.testing.expectEqual(@as(usize, 2), wake_count.load(.seq_cst));
 }
@@ -560,9 +567,10 @@ test "PtyReader.retire prevents any further reads of the fd" {
     const buffer = try PtyOutputBuffer.create(allocator, threaded.io());
     defer buffer.destroy(allocator);
 
-    const fds = try makeNonBlockingPipe();
-    defer posix.close(fds[0]);
-    defer posix.close(fds[1]);
+    var fds: [2]posix.fd_t = undefined;
+    try makeNonBlockingPipe(&fds);
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
 
     var reader = PtyReader.init(threaded.io());
     var stop = atomic.Value(bool).init(false);
@@ -575,13 +583,13 @@ test "PtyReader.retire prevents any further reads of the fd" {
     }
 
     reader.register(fds[0], buffer);
-    _ = try posix.write(fds[1], "before");
+    _ = try posix_util.write(fds[1], "before");
     try std.testing.expect(waitForBufferBytes(threaded.io(), buffer, 2_000));
     var out: [32]u8 = undefined;
     _ = buffer.consume(&out);
 
     reader.retire(fds[0]);
-    _ = try posix.write(fds[1], "after");
+    _ = try posix_util.write(fds[1], "after");
     clock.sleepNanos(threaded.io(), 300 * std.time.ns_per_ms);
     try std.testing.expect(!bufferHasBytes(buffer));
 }

--- a/src/session/pty_reader.zig
+++ b/src/session/pty_reader.zig
@@ -239,6 +239,7 @@ pub const PtyReader = struct {
 };
 
 const ReaderContext = struct {
+    io: std.Io,
     reader: *PtyReader,
     stop: *atomic.Value(bool),
     wake_pending: *atomic.Value(bool),
@@ -248,12 +249,14 @@ const ReaderContext = struct {
 pub const StartError = std.Thread.SpawnError;
 
 pub fn start(
+    io: std.Io,
     reader: *PtyReader,
     stop: *atomic.Value(bool),
     wake_pending: *atomic.Value(bool),
     runtime_wake: ?RuntimeWake,
 ) StartError!std.Thread {
     const ctx = ReaderContext{
+        .io = io,
         .reader = reader,
         .stop = stop,
         .wake_pending = wake_pending,
@@ -272,13 +275,13 @@ fn run(ctx: ReaderContext) void {
                 full_buffer_retry_ns
             else
                 @as(u64, @intCast(poll_timeout_ms)) * std.time.ns_per_ms;
-            clock.sleepNanos(retry_ns);
+            clock.sleepNanos(ctx.io, retry_ns);
             continue;
         }
 
         const ready = posix.poll(pollfds[0..snapshot.count], poll_timeout_ms) catch |err| {
             log.debug("poll failed: {}", .{err});
-            clock.sleepNanos(poll_error_backoff_ns);
+            clock.sleepNanos(ctx.io, poll_error_backoff_ns);
             continue;
         };
         if (ready == 0) continue;
@@ -300,11 +303,11 @@ fn makeNonBlockingPipe() ![2]posix.fd_t {
     return fds;
 }
 
-fn waitForBufferBytes(buffer: *PtyOutputBuffer, timeout_ms: u64) bool {
+fn waitForBufferBytes(io: std.Io, buffer: *PtyOutputBuffer, timeout_ms: u64) bool {
     var waited_ms: u64 = 0;
     while (waited_ms < timeout_ms) : (waited_ms += 5) {
         if (bufferHasBytes(buffer)) return true;
-        clock.sleepNanos(5 * std.time.ns_per_ms);
+        clock.sleepNanos(io, 5 * std.time.ns_per_ms);
     }
     return bufferHasBytes(buffer);
 }
@@ -501,6 +504,8 @@ test "PtyReader snapshot distinguishes full and closed buffers" {
 
 test "PtyReader thread drains a pipe into the buffer and posts one wake" {
     const allocator = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
     const buffer = try PtyOutputBuffer.create(allocator);
     defer buffer.destroy(allocator);
 
@@ -513,7 +518,7 @@ test "PtyReader thread drains a pipe into the buffer and posts one wake" {
     var wake_pending = atomic.Value(bool).init(false);
     var wake_count = atomic.Value(usize).init(0);
 
-    const thread = try start(&reader, &stop, &wake_pending, .{
+    const thread = try start(threaded.io(), &reader, &stop, &wake_pending, .{
         .context = &wake_count,
         .callback = incrementWakeCount,
     });
@@ -525,24 +530,26 @@ test "PtyReader thread drains a pipe into the buffer and posts one wake" {
     reader.register(fds[0], buffer);
     _ = try posix.write(fds[1], "ping");
 
-    try std.testing.expect(waitForBufferBytes(buffer, 2_000));
+    try std.testing.expect(waitForBufferBytes(threaded.io(), buffer, 2_000));
     try std.testing.expect(wake_pending.load(.seq_cst));
     try std.testing.expectEqual(@as(usize, 1), wake_count.load(.seq_cst));
 
     _ = try posix.write(fds[1], "pong");
-    clock.sleepNanos(300 * std.time.ns_per_ms);
+    clock.sleepNanos(threaded.io(), 300 * std.time.ns_per_ms);
     try std.testing.expectEqual(@as(usize, 1), wake_count.load(.seq_cst));
 
     var out: [16]u8 = undefined;
     _ = buffer.consume(&out);
     wake_pending.store(false, .seq_cst);
     _ = try posix.write(fds[1], "again");
-    try std.testing.expect(waitForBufferBytes(buffer, 2_000));
+    try std.testing.expect(waitForBufferBytes(threaded.io(), buffer, 2_000));
     try std.testing.expectEqual(@as(usize, 2), wake_count.load(.seq_cst));
 }
 
 test "PtyReader.retire prevents any further reads of the fd" {
     const allocator = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
     const buffer = try PtyOutputBuffer.create(allocator);
     defer buffer.destroy(allocator);
 
@@ -554,7 +561,7 @@ test "PtyReader.retire prevents any further reads of the fd" {
     var stop = atomic.Value(bool).init(false);
     var wake_pending = atomic.Value(bool).init(false);
 
-    const thread = try start(&reader, &stop, &wake_pending, null);
+    const thread = try start(threaded.io(), &reader, &stop, &wake_pending, null);
     defer {
         stop.store(true, .seq_cst);
         thread.join();
@@ -562,12 +569,12 @@ test "PtyReader.retire prevents any further reads of the fd" {
 
     reader.register(fds[0], buffer);
     _ = try posix.write(fds[1], "before");
-    try std.testing.expect(waitForBufferBytes(buffer, 2_000));
+    try std.testing.expect(waitForBufferBytes(threaded.io(), buffer, 2_000));
     var out: [32]u8 = undefined;
     _ = buffer.consume(&out);
 
     reader.retire(fds[0]);
     _ = try posix.write(fds[1], "after");
-    clock.sleepNanos(300 * std.time.ns_per_ms);
+    clock.sleepNanos(threaded.io(), 300 * std.time.ns_per_ms);
     try std.testing.expect(!bufferHasBytes(buffer));
 }

--- a/src/session/state.zig
+++ b/src/session/state.zig
@@ -12,6 +12,7 @@ const fs = std.fs;
 const cwd_mod = if (builtin.os.tag == .macos) @import("../cwd.zig") else struct {};
 const vt_stream = @import("../vt_stream.zig");
 const pty_reader_mod = @import("pty_reader.zig");
+const posix_util = @import("../posix_util.zig");
 const mac = if (builtin.os.tag == .macos)
     @cImport({
         @cInclude("sys/types.h");
@@ -111,7 +112,7 @@ pub const SessionState = struct {
     /// Set to true once updateCwd observes a non-root directory. Prevents the transient `/`
     /// that the shell briefly reports during startup from polluting recent_folders.
     cwd_settled: bool = false,
-    pending_write: std.ArrayListUnmanaged(u8) = .empty,
+    pending_write: std.ArrayList(u8) = .empty,
     /// Process watcher for event-driven exit detection.
     process_watcher: ?xev.Process = null,
     /// Context for disambiguating process exit callbacks. Includes its own completion struct
@@ -132,7 +133,7 @@ pub const SessionState = struct {
     agent_metadata_captured: bool = false,
     /// Raw PTY output captured after quit teardown starts. Used to avoid extracting
     /// stale UUIDs from earlier scrollback.
-    quit_capture: std.ArrayListUnmanaged(u8) = .empty,
+    quit_capture: std.ArrayList(u8) = .empty,
     quit_capture_active: bool = false,
     synchronized_output_started_ms: i64 = 0,
     synchronized_output_last_output_ms: i64 = 0,
@@ -230,10 +231,10 @@ pub const SessionState = struct {
             }
         }
 
-        var terminal = try ghostty_vt.Terminal.init(self.allocator, .{
+        var terminal = try ghostty_vt.Terminal.init(self.io, self.allocator, .{
             .cols = self.pty_size.ws_col,
             .rows = self.pty_size.ws_row,
-            .max_scrollback = 10_000_000,
+            .max_scrollback_bytes = 10_000_000,
             .default_modes = .{ .grapheme_cluster = true },
             .colors = terminalColorsFromTheme(self.theme),
         });
@@ -397,7 +398,7 @@ pub const SessionState = struct {
         }
     }
 
-    pub const ProcessOutputError = posix.ReadError || posix.WriteError || error{
+    pub const ProcessOutputError = posix.ReadError || std.Io.File.Writer.Error || error{
         DivisionByZero,
         GraphemeAllocOutOfMemory,
         GraphemeMapOutOfMemory,
@@ -646,7 +647,7 @@ pub const SessionState = struct {
                 };
             }
             const was_synchronized_output = self.synchronizedOutputActive();
-            try stream.nextSlice(self.output_buf[0..n]);
+            stream.nextSlice(self.output_buf[0..n]);
             const processed_at_ms = clock.nowMillis(self.io);
             self.updateSynchronizedOutputState(was_synchronized_output, processed_at_ms);
             self.markDirty();
@@ -814,11 +815,9 @@ pub const SessionState = struct {
         if (getForegroundPgrp(shell.child_pid)) |fg| return fg;
 
         const slave_path_z = ptsname(shell.pty.master) orelse return null;
-        const slave_path = std.mem.sliceTo(slave_path_z, 0);
-        const fd = posix.openZ(slave_path, .{ .ACCMODE = .RDONLY, .NOCTTY = true }, 0) catch {
-            return null;
-        };
-        defer posix.close(fd);
+        const fd = std.c.open(slave_path_z, .{ .ACCMODE = .RDONLY, .NOCTTY = true }, @as(std.c.mode_t, 0));
+        if (fd == -1) return null;
+        defer _ = std.c.close(fd);
         const fg_pgrp = tcgetpgrp(fd);
         if (fg_pgrp <= 0) return null;
         return @intCast(fg_pgrp);
@@ -1016,7 +1015,7 @@ fn getForegroundPgrp(child_pid: posix.pid_t) ?posix.pid_t {
     return info.kp_eproc.e_tpgid;
 }
 
-pub const MakeNonBlockingError = posix.FcntlError;
+pub const MakeNonBlockingError = posix_util.FcntlError;
 
 test "synchronized output timeout clears stuck terminal mode" {
     const allocator = std.testing.allocator;
@@ -1026,10 +1025,10 @@ test "synchronized output timeout clears stuck terminal mode" {
     session.dead = false;
     session.render_epoch = 1;
     session.synchronized_output_started_ms = 100;
-    session.terminal = try ghostty_vt.Terminal.init(allocator, .{
+    session.terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{
         .cols = 10,
         .rows = 3,
-        .max_scrollback = 5,
+        .max_scrollback_bytes = 5,
     });
     defer session.terminal.?.deinit(allocator);
 
@@ -1050,10 +1049,10 @@ test "synchronized output timeout resets when mode is already clear" {
     session.dead = false;
     session.render_epoch = 1;
     session.synchronized_output_started_ms = 100;
-    session.terminal = try ghostty_vt.Terminal.init(allocator, .{
+    session.terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{
         .cols = 10,
         .rows = 3,
-        .max_scrollback = 5,
+        .max_scrollback_bytes = 5,
     });
     defer session.terminal.?.deinit(allocator);
 
@@ -1071,10 +1070,10 @@ test "synchronized output timeout waits for output to go quiet" {
     session.render_epoch = 1;
     session.synchronized_output_started_ms = 100;
     session.synchronized_output_last_output_ms = 1050;
-    session.terminal = try ghostty_vt.Terminal.init(allocator, .{
+    session.terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{
         .cols = 10,
         .rows = 3,
-        .max_scrollback = 5,
+        .max_scrollback_bytes = 5,
     });
     defer session.terminal.?.deinit(allocator);
 
@@ -1094,10 +1093,10 @@ test "synchronized output keeps future last-output sample" {
     session.render_epoch = 1;
     session.synchronized_output_started_ms = 100;
     session.synchronized_output_last_output_ms = 1101;
-    session.terminal = try ghostty_vt.Terminal.init(allocator, .{
+    session.terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{
         .cols = 10,
         .rows = 3,
-        .max_scrollback = 5,
+        .max_scrollback_bytes = 5,
     });
     defer session.terminal.?.deinit(allocator);
 
@@ -1116,10 +1115,10 @@ test "synchronized output hard timeout clears chatty sessions" {
     session.render_epoch = 1;
     session.synchronized_output_started_ms = 100;
     session.synchronized_output_last_output_ms = 5099;
-    session.terminal = try ghostty_vt.Terminal.init(allocator, .{
+    session.terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{
         .cols = 10,
         .rows = 3,
-        .max_scrollback = 5,
+        .max_scrollback_bytes = 5,
     });
     defer session.terminal.?.deinit(allocator);
 
@@ -1167,7 +1166,7 @@ test "checkAlive skips waitpid polling when a process watcher owns exit detectio
     };
     const notify_sock: [:0]const u8 = "sock";
 
-    const pid = try posix.fork();
+    const pid = try posix_util.fork();
     if (pid == 0) {
         std.c._exit(0);
     }
@@ -1175,9 +1174,10 @@ test "checkAlive skips waitpid polling when a process watcher owns exit detectio
     // Give the forked child a moment to exit and become reapable.
     clock.sleepNanos(threaded.io(), 50 * std.time.ns_per_ms);
 
-    const pipe_fds = try posix.pipe();
+    var pipe_fds: [2]std.posix.fd_t = undefined;
+    try posix_util.pipe(&pipe_fds);
     // pty.deinit() only closes the master fd; close the slave ourselves.
-    defer posix.close(pipe_fds[0]);
+    defer _ = std.c.close(pipe_fds[0]);
 
     var session = try SessionState.init(allocator, threaded.io(), 0, "/bin/zsh", size, notify_sock, theme, null);
     // Closes pipe_fds[1] (master) via shell.deinit() -> pty.deinit().
@@ -1269,13 +1269,13 @@ test "resetForRespawn clears agent metadata" {
 }
 
 fn makeNonBlocking(fd: posix.fd_t) MakeNonBlockingError!void {
-    const flags = try posix.fcntl(fd, posix.F.GETFL, 0);
+    const flags = try posix_util.fcntl(fd, posix.F.GETFL, 0);
     var o_flags: posix.O = @bitCast(@as(u32, @intCast(flags)));
     o_flags.NONBLOCK = true;
-    _ = try posix.fcntl(fd, posix.F.SETFL, @as(u32, @bitCast(o_flags)));
+    _ = try posix_util.fcntl(fd, posix.F.SETFL, @as(u32, @bitCast(o_flags)));
 }
 
-fn maybeShrinkPendingWrite(buf: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator) void {
+fn maybeShrinkPendingWrite(buf: *std.ArrayList(u8), allocator: std.mem.Allocator) void {
     if (buf.items.len == 0 and buf.capacity > pending_write_shrink_threshold) {
         buf.shrinkAndFree(allocator, 0);
     }
@@ -1283,7 +1283,7 @@ fn maybeShrinkPendingWrite(buf: *std.ArrayListUnmanaged(u8), allocator: std.mem.
 
 test "pending write shrinks when empty and over threshold" {
     const allocator = std.testing.allocator;
-    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(allocator);
 
     try buf.ensureTotalCapacity(allocator, pending_write_shrink_threshold + 10);
@@ -1333,15 +1333,17 @@ test "processOutput consumes a chunked 2026-wrapped frame from the ring buffer i
     var session = try SessionState.init(allocator, std.testing.io, 0, "/bin/zsh", size, notify_sock, colors_mod.Theme.default(), null);
     defer session.deinit(allocator);
 
-    const pipe_fds = try posix.pipe();
-    defer posix.close(pipe_fds[1]);
+    var pipe_fds: [2]std.posix.fd_t = undefined;
+    try posix_util.pipe(&pipe_fds);
+    defer _ = std.c.close(pipe_fds[1]);
     try makeNonBlocking(pipe_fds[0]);
 
     session.shell = .{
+        .io = session.io,
         .pty = .{ .master = pipe_fds[0], .slave = pipe_fds[1] },
         .child_pid = 0,
     };
-    session.terminal = try ghostty_vt.Terminal.init(allocator, .{ .cols = 80, .rows = 24 });
+    session.terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{ .cols = 80, .rows = 24 });
     if (session.terminal) |*terminal| {
         if (session.shell) |*shell| {
             session.stream = vt_stream.initStream(allocator, terminal, shell);
@@ -1352,12 +1354,12 @@ test "processOutput consumes a chunked 2026-wrapped frame from the ring buffer i
     session.dead = true;
     session.quit_capture_active = true;
 
-    _ = try posix.write(pipe_fds[1], "\x1b[?2026h\x1b[H");
+    _ = try posix_util.write(pipe_fds[1], "\x1b[?2026h\x1b[H");
     var i: usize = 0;
     while (i < 40) : (i += 1) {
-        _ = try posix.write(pipe_fds[1], "chunk-of-a-frame ");
+        _ = try posix_util.write(pipe_fds[1], "chunk-of-a-frame ");
     }
-    _ = try posix.write(pipe_fds[1], "\x1b[?2026l");
+    _ = try posix_util.write(pipe_fds[1], "\x1b[?2026l");
 
     try std.testing.expectEqual(
         pty_reader_mod.PumpOutcome.progressed,

--- a/src/session/state.zig
+++ b/src/session/state.zig
@@ -408,6 +408,7 @@ pub const SessionState = struct {
         StringAllocOutOfMemory,
         StyleSetNeedsRehash,
         StyleSetOutOfMemory,
+        VtSemanticFailure,
     };
 
     fn processExitCallback(
@@ -648,6 +649,7 @@ pub const SessionState = struct {
             }
             const was_synchronized_output = self.synchronizedOutputActive();
             stream.nextSlice(self.output_buf[0..n]);
+            if (stream.handler.hasSemanticFailure()) return error.VtSemanticFailure;
             const processed_at_ms = clock.nowMillis(self.io);
             self.updateSynchronizedOutputState(was_synchronized_output, processed_at_ms);
             self.markDirty();
@@ -815,8 +817,14 @@ pub const SessionState = struct {
         if (getForegroundPgrp(shell.child_pid)) |fg| return fg;
 
         const slave_path_z = ptsname(shell.pty.master) orelse return null;
-        const fd = std.c.open(slave_path_z, .{ .ACCMODE = .RDONLY, .NOCTTY = true }, @as(std.c.mode_t, 0));
-        if (fd == -1) return null;
+        const fd = while (true) {
+            const open_fd = std.c.open(slave_path_z, .{ .ACCMODE = .RDONLY, .NOCTTY = true }, @as(std.c.mode_t, 0));
+            switch (std.c.errno(open_fd)) {
+                .SUCCESS => break open_fd,
+                .INTR => continue,
+                else => return null,
+            }
+        };
         defer _ = std.c.close(fd);
         const fg_pgrp = tcgetpgrp(fd);
         if (fg_pgrp <= 0) return null;
@@ -1370,6 +1378,16 @@ test "processOutput consumes a chunked 2026-wrapped frame from the ring buffer i
     if (session.terminal) |*terminal| {
         try std.testing.expect(!terminal.modes.get(.synchronized_output));
     } else return error.TestUnexpectedResult;
+
+    if (session.stream) |*stream| {
+        stream.handler.readonly.semantic_failure = true;
+    } else return error.TestUnexpectedResult;
+    _ = try posix_util.write(pipe_fds[1], "x");
+    try std.testing.expectEqual(
+        pty_reader_mod.PumpOutcome.progressed,
+        session.pty_buffer.?.pumpFd(pipe_fds[0]),
+    );
+    try std.testing.expectError(error.VtSemanticFailure, session.processOutput());
 }
 
 test "failAndTerminate marks dead, bumps render epoch, and drops pending writes" {

--- a/src/session/state.zig
+++ b/src/session/state.zig
@@ -263,7 +263,7 @@ pub const SessionState = struct {
         self.stream = stream;
         self.markDirty();
 
-        const buffer = try pty_reader_mod.PtyOutputBuffer.create(self.allocator);
+        const buffer = try pty_reader_mod.PtyOutputBuffer.create(self.allocator, self.io);
         self.pty_buffer = buffer;
         if (self.pty_reader) |reader| reader.register(shell.pty.master, buffer);
 
@@ -1347,7 +1347,7 @@ test "processOutput consumes a chunked 2026-wrapped frame from the ring buffer i
             session.stream = vt_stream.initStream(allocator, terminal, shell);
         } else return error.TestUnexpectedResult;
     } else return error.TestUnexpectedResult;
-    session.pty_buffer = try pty_reader_mod.PtyOutputBuffer.create(allocator);
+    session.pty_buffer = try pty_reader_mod.PtyOutputBuffer.create(allocator, session.io);
     session.spawned = true;
     session.dead = true;
     session.quit_capture_active = true;

--- a/src/session/state.zig
+++ b/src/session/state.zig
@@ -101,6 +101,7 @@ pub const SessionState = struct {
     session_id_z: [session_id_buf_len:0]u8,
     notify_sock_z: [:0]const u8,
     allocator: std.mem.Allocator,
+    io: std.Io,
     theme: colors_mod.Theme,
     cwd_path: ?[]const u8 = null,
     /// Subslice of cwd_path pointing to the basename. Always points within cwd_path's memory.
@@ -168,6 +169,7 @@ pub const SessionState = struct {
 
     pub fn init(
         allocator: std.mem.Allocator,
+        io: std.Io,
         slot_index: usize,
         shell_path: []const u8,
         size: pty_mod.winsize,
@@ -192,6 +194,7 @@ pub const SessionState = struct {
             .session_id_z = session_id_buf,
             .notify_sock_z = notify_sock,
             .allocator = allocator,
+            .io = io,
             .theme = theme,
         };
     }
@@ -212,6 +215,7 @@ pub const SessionState = struct {
         self.assignNewSessionId();
 
         const shell = try shell_mod.Shell.spawn(
+            self.io,
             self.shell_path,
             self.pty_size,
             &self.session_id_z,
@@ -643,7 +647,7 @@ pub const SessionState = struct {
             }
             const was_synchronized_output = self.synchronizedOutputActive();
             try stream.nextSlice(self.output_buf[0..n]);
-            const processed_at_ms = clock.nowMillis();
+            const processed_at_ms = clock.nowMillis(self.io);
             self.updateSynchronizedOutputState(was_synchronized_output, processed_at_ms);
             self.markDirty();
 
@@ -1137,13 +1141,13 @@ test "SessionState assigns incrementing ids" {
     };
     const notify_sock: [:0]const u8 = "sock";
 
-    var first = try SessionState.init(allocator, 0, "/bin/zsh", size, notify_sock, theme, null);
+    var first = try SessionState.init(allocator, std.testing.io, 0, "/bin/zsh", size, notify_sock, theme, null);
     defer first.deinit(allocator);
     first.assignNewSessionId();
     try std.testing.expectEqual(@as(usize, 0), first.id);
     try std.testing.expectEqualStrings("0", std.mem.sliceTo(first.session_id_z[0..], 0));
 
-    var second = try SessionState.init(allocator, 1, "/bin/zsh", size, notify_sock, theme, null);
+    var second = try SessionState.init(allocator, std.testing.io, 1, "/bin/zsh", size, notify_sock, theme, null);
     defer second.deinit(allocator);
     second.assignNewSessionId();
     try std.testing.expectEqual(@as(usize, 1), second.id);
@@ -1152,6 +1156,8 @@ test "SessionState assigns incrementing ids" {
 
 test "checkAlive skips waitpid polling when a process watcher owns exit detection" {
     const allocator = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
     const theme = colors_mod.Theme.default();
     const size = pty_mod.winsize{
         .ws_row = 24,
@@ -1167,13 +1173,13 @@ test "checkAlive skips waitpid polling when a process watcher owns exit detectio
     }
     defer _ = std.c.waitpid(pid, null, 0);
     // Give the forked child a moment to exit and become reapable.
-    clock.sleepNanos(50 * std.time.ns_per_ms);
+    clock.sleepNanos(threaded.io(), 50 * std.time.ns_per_ms);
 
     const pipe_fds = try posix.pipe();
     // pty.deinit() only closes the master fd; close the slave ourselves.
     defer posix.close(pipe_fds[0]);
 
-    var session = try SessionState.init(allocator, 0, "/bin/zsh", size, notify_sock, theme, null);
+    var session = try SessionState.init(allocator, threaded.io(), 0, "/bin/zsh", size, notify_sock, theme, null);
     // Closes pipe_fds[1] (master) via shell.deinit() -> pty.deinit().
     defer session.deinit(allocator);
 
@@ -1181,6 +1187,7 @@ test "checkAlive skips waitpid polling when a process watcher owns exit detectio
     session.dead = false;
     session.render_epoch = 1;
     session.shell = shell_mod.Shell{
+        .io = threaded.io(),
         .pty = .{ .master = pipe_fds[1], .slave = pipe_fds[0] },
         .child_pid = pid,
     };
@@ -1213,7 +1220,7 @@ test "despawn keeps active wait context alive until callback reclaims it" {
     };
     const notify_sock: [:0]const u8 = "sock";
 
-    var session = try SessionState.init(allocator, 0, "/bin/zsh", size, notify_sock, theme, null);
+    var session = try SessionState.init(allocator, std.testing.io, 0, "/bin/zsh", size, notify_sock, theme, null);
     defer session.deinit(allocator);
 
     const wait_ctx = try allocator.create(SessionState.WaitContext);
@@ -1247,7 +1254,7 @@ test "resetForRespawn clears agent metadata" {
     };
     const notify_sock: [:0]const u8 = "sock";
 
-    var session = try SessionState.init(allocator, 0, "/bin/zsh", size, notify_sock, theme, null);
+    var session = try SessionState.init(allocator, std.testing.io, 0, "/bin/zsh", size, notify_sock, theme, null);
     defer session.deinit(allocator);
 
     session.agent_kind = .codex;
@@ -1323,7 +1330,7 @@ test "processOutput consumes a chunked 2026-wrapped frame from the ring buffer i
     };
     const notify_sock: [:0]const u8 = "sock";
 
-    var session = try SessionState.init(allocator, 0, "/bin/zsh", size, notify_sock, colors_mod.Theme.default(), null);
+    var session = try SessionState.init(allocator, std.testing.io, 0, "/bin/zsh", size, notify_sock, colors_mod.Theme.default(), null);
     defer session.deinit(allocator);
 
     const pipe_fds = try posix.pipe();

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -653,7 +653,7 @@ fn setEnv(name: [:0]const u8, value: [:0]const u8) void {
 
 /// Ensure xterm-ghostty terminfo is compiled and available.
 /// Installs to ~/.cache/architect/terminfo. Must be called from parent process before fork.
-pub fn ensureTerminfoSetup() void {
+pub fn ensureTerminfoSetup(io: std.Io) void {
     if (terminfo_setup_done) return;
     terminfo_setup_done = true;
 
@@ -674,7 +674,7 @@ pub fn ensureTerminfoSetup() void {
 
     // Create ~/.cache first if needed
     const dot_cache = std.fmt.bufPrint(&parent_buf, "{s}/.cache", .{home}) catch return;
-    std.fs.makeDirAbsolute(dot_cache) catch |err| switch (err) {
+    std.Io.Dir.createDirAbsolute(io, dot_cache, .default_dir) catch |err| switch (err) {
         error.PathAlreadyExists => {},
         else => {
             log.warn("Failed to create .cache dir: {}", .{err});
@@ -685,7 +685,7 @@ pub fn ensureTerminfoSetup() void {
     // Create ~/.cache/architect (parent of terminfo dir)
     var architect_buf: [std.fs.max_path_bytes]u8 = undefined;
     const architect_dir = std.fmt.bufPrint(&architect_buf, "{s}/.cache/architect", .{home}) catch return;
-    std.fs.makeDirAbsolute(architect_dir) catch |err| switch (err) {
+    std.Io.Dir.createDirAbsolute(io, architect_dir, .default_dir) catch |err| switch (err) {
         error.PathAlreadyExists => {},
         else => {
             log.warn("Failed to create architect cache dir: {}", .{err});
@@ -694,7 +694,7 @@ pub fn ensureTerminfoSetup() void {
     };
 
     // Create terminfo dir
-    std.fs.makeDirAbsolute(cache_dir) catch |err| switch (err) {
+    std.Io.Dir.createDirAbsolute(io, cache_dir, .default_dir) catch |err| switch (err) {
         error.PathAlreadyExists => {},
         else => {
             log.warn("Failed to create terminfo cache dir: {}", .{err});
@@ -705,7 +705,7 @@ pub fn ensureTerminfoSetup() void {
     // Create x subdir for terminfo entries
     var x_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
     const x_dir = std.fmt.bufPrint(&x_dir_buf, "{s}/x", .{cache_dir}) catch return;
-    std.fs.makeDirAbsolute(x_dir) catch |err| switch (err) {
+    std.Io.Dir.createDirAbsolute(io, x_dir, .default_dir) catch |err| switch (err) {
         error.PathAlreadyExists => {},
         else => {
             log.warn("Failed to create terminfo x dir: {}", .{err});
@@ -717,17 +717,17 @@ pub fn ensureTerminfoSetup() void {
     var src_path_buf: [std.fs.max_path_bytes]u8 = undefined;
     const src_path_z = std.fmt.bufPrintZ(&src_path_buf, "{s}/xterm-ghostty.ti", .{cache_dir}) catch return;
 
-    const src_file = std.fs.createFileAbsolute(src_path_z, .{}) catch |err| {
+    const src_file = std.Io.Dir.createFileAbsolute(io, src_path_z, .{}) catch |err| {
         log.warn("Failed to create terminfo source file: {}", .{err});
         return;
     };
-    defer src_file.close();
-    src_file.writeAll(architect_terminfo_src) catch |err| {
+    defer src_file.close(io);
+    src_file.writeStreamingAll(io, architect_terminfo_src) catch |err| {
         log.warn("Failed to write terminfo source: {}", .{err});
         return;
     };
 
-    const tic_path = findExecutableInPath("tic") orelse {
+    const tic_path = findExecutableInPath(io, "tic") orelse {
         log.warn("tic not found in PATH, falling back to {s}", .{fallback_term});
         return;
     };
@@ -764,7 +764,7 @@ pub fn ensureTerminfoSetup() void {
     }
 }
 
-fn ensureArchitectCommandSetup() void {
+fn ensureArchitectCommandSetup(io: std.Io) void {
     if (architect_command_setup_done) return;
     architect_command_setup_done = true;
 
@@ -786,7 +786,7 @@ fn ensureArchitectCommandSetup() void {
     architect_command_base_z = base_dir_z;
     const base_dir = std.mem.sliceTo(base_dir_z, 0);
 
-    std.fs.makeDirAbsolute(base_dir) catch |err| switch (err) {
+    std.Io.Dir.createDirAbsolute(io, base_dir, .default_dir) catch |err| switch (err) {
         error.PathAlreadyExists => {},
         else => {
             log.warn("failed to create architect command base dir: {}", .{err});
@@ -800,7 +800,7 @@ fn ensureArchitectCommandSetup() void {
     };
     const bin_dir = bin_dir_z[0..bin_dir_z.len];
 
-    std.fs.makeDirAbsolute(bin_dir) catch |err| switch (err) {
+    std.Io.Dir.createDirAbsolute(io, bin_dir, .default_dir) catch |err| switch (err) {
         error.PathAlreadyExists => {},
         else => {
             log.warn("failed to create architect bin dir: {}", .{err});
@@ -813,13 +813,13 @@ fn ensureArchitectCommandSetup() void {
         return;
     };
 
-    const script_file = std.fs.createFileAbsolute(script_path_z, .{ .truncate = true }) catch |err| {
+    const script_file = std.Io.Dir.createFileAbsolute(io, script_path_z, .{ .truncate = true }) catch |err| {
         log.warn("failed to create architect command: {}", .{err});
         return;
     };
-    defer script_file.close();
+    defer script_file.close(io);
 
-    script_file.writeAll(architect_command_script) catch |err| {
+    script_file.writeStreamingAll(io, architect_command_script) catch |err| {
         log.warn("failed to write architect command: {}", .{err});
         return;
     };
@@ -837,7 +837,7 @@ fn isShellNamed(shell_path: []const u8, name: []const u8) bool {
     return std.mem.eql(u8, base, name);
 }
 
-fn ensureArchitectZshProfileSetup() void {
+fn ensureArchitectZshProfileSetup(io: std.Io) void {
     if (architect_zsh_profile_setup_done) return;
     architect_zsh_profile_setup_done = true;
 
@@ -850,7 +850,7 @@ fn ensureArchitectZshProfileSetup() void {
         return;
     };
 
-    std.fs.makeDirAbsolute(zsh_dir_z) catch |err| switch (err) {
+    std.Io.Dir.createDirAbsolute(io, zsh_dir_z, .default_dir) catch |err| switch (err) {
         error.PathAlreadyExists => {},
         else => {
             log.warn("failed to create architect zsh dir: {}", .{err});
@@ -864,13 +864,13 @@ fn ensureArchitectZshProfileSetup() void {
         return;
     };
 
-    const env_file = std.fs.createFileAbsolute(env_path_z, .{ .truncate = true }) catch |err| {
+    const env_file = std.Io.Dir.createFileAbsolute(io, env_path_z, .{ .truncate = true }) catch |err| {
         log.warn("failed to create architect zsh env: {}", .{err});
         return;
     };
-    defer env_file.close();
+    defer env_file.close(io);
 
-    env_file.writeAll(architect_zsh_env_script) catch |err| {
+    env_file.writeStreamingAll(io, architect_zsh_env_script) catch |err| {
         log.warn("failed to write architect zsh env: {}", .{err});
         return;
     };
@@ -881,13 +881,13 @@ fn ensureArchitectZshProfileSetup() void {
         return;
     };
 
-    const profile_file = std.fs.createFileAbsolute(profile_path_z, .{ .truncate = true }) catch |err| {
+    const profile_file = std.Io.Dir.createFileAbsolute(io, profile_path_z, .{ .truncate = true }) catch |err| {
         log.warn("failed to create architect zsh profile: {}", .{err});
         return;
     };
-    defer profile_file.close();
+    defer profile_file.close(io);
 
-    profile_file.writeAll(architect_zsh_profile_script) catch |err| {
+    profile_file.writeStreamingAll(io, architect_zsh_profile_script) catch |err| {
         log.warn("failed to write architect zsh profile: {}", .{err});
         return;
     };
@@ -898,13 +898,13 @@ fn ensureArchitectZshProfileSetup() void {
         return;
     };
 
-    const rc_file = std.fs.createFileAbsolute(rc_path_z, .{ .truncate = true }) catch |err| {
+    const rc_file = std.Io.Dir.createFileAbsolute(io, rc_path_z, .{ .truncate = true }) catch |err| {
         log.warn("failed to create architect zsh rc: {}", .{err});
         return;
     };
-    defer rc_file.close();
+    defer rc_file.close(io);
 
-    rc_file.writeAll(architect_zsh_rc_script) catch |err| {
+    rc_file.writeStreamingAll(io, architect_zsh_rc_script) catch |err| {
         log.warn("failed to write architect zsh rc: {}", .{err});
         return;
     };
@@ -915,13 +915,13 @@ fn ensureArchitectZshProfileSetup() void {
         return;
     };
 
-    const login_file = std.fs.createFileAbsolute(login_path_z, .{ .truncate = true }) catch |err| {
+    const login_file = std.Io.Dir.createFileAbsolute(io, login_path_z, .{ .truncate = true }) catch |err| {
         log.warn("failed to create architect zsh login: {}", .{err});
         return;
     };
-    defer login_file.close();
+    defer login_file.close(io);
 
-    login_file.writeAll(architect_zsh_login_script) catch |err| {
+    login_file.writeStreamingAll(io, architect_zsh_login_script) catch |err| {
         log.warn("failed to write architect zsh login: {}", .{err});
         return;
     };
@@ -995,7 +995,7 @@ fn ensureArchitectCommandPath() void {
     }
 }
 
-fn findExecutableInPath(name: []const u8) ?[:0]const u8 {
+fn findExecutableInPath(io: std.Io, name: []const u8) ?[:0]const u8 {
     const path_env = env.get("PATH") orelse return null;
     const path_env_slice = std.mem.sliceTo(path_env, 0);
     var it = std.mem.splitScalar(u8, path_env_slice, ':');
@@ -1005,7 +1005,7 @@ fn findExecutableInPath(name: []const u8) ?[:0]const u8 {
             log.warn("failed to format candidate path: {}", .{err});
             continue;
         };
-        if (std.fs.cwd().statFile(candidate)) |_| {
+        if (std.Io.Dir.cwd().statFile(io, candidate, .{})) |_| {
             return candidate;
         } else |_| {}
     }
@@ -1027,10 +1027,10 @@ pub const Shell = struct {
 
     pub fn spawn(io: std.Io, shell_path: []const u8, size: pty_mod.winsize, session_id: [:0]const u8, notify_sock: [:0]const u8, working_dir: ?[:0]const u8) SpawnError!Shell {
         // Ensure terminfo is set up (parent process, before fork)
-        ensureTerminfoSetup();
-        ensureArchitectCommandSetup();
+        ensureTerminfoSetup(io);
+        ensureArchitectCommandSetup(io);
         if (isShellNamed(shell_path, "zsh")) {
-            ensureArchitectZshProfileSetup();
+            ensureArchitectZshProfileSetup(io);
         }
 
         const pty_instance = try pty_mod.Pty.open(size);
@@ -1173,21 +1173,22 @@ test "bundled terminfo compiles to legacy short-int format" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    const io = threaded.io();
+    const tmp_path = try tmp.dir.realPathFileAlloc(io, ".", allocator);
     defer allocator.free(tmp_path);
 
     const src_path = try std.fs.path.join(allocator, &.{ tmp_path, "xterm-ghostty.terminfo" });
     defer allocator.free(src_path);
 
     {
-        const src_file = try std.fs.createFileAbsolute(src_path, .{});
-        defer src_file.close();
-        try src_file.writeAll(architect_terminfo_src);
+        const src_file = try std.Io.Dir.createFileAbsolute(io, src_path, .{});
+        defer src_file.close(io);
+        try src_file.writeStreamingAll(io, architect_terminfo_src);
     }
 
-    const tic_path = findExecutableInPath("tic") orelse return error.SkipZigTest;
+    const tic_path = findExecutableInPath(io, "tic") orelse return error.SkipZigTest;
 
-    const term = try proc.spawnDetached(allocator, threaded.io(), &.{ tic_path, "-x", "-o", tmp_path, src_path });
+    const term = try proc.spawnDetached(allocator, io, &.{ tic_path, "-x", "-o", tmp_path, src_path });
     try testing.expectEqual(proc.Term{ .exited = 0 }, term);
 
     // tic stores the compiled entry in either `78/xterm-ghostty` (hashed,
@@ -1199,9 +1200,9 @@ test "bundled terminfo compiles to legacy short-int format" {
     for (candidates) |rel| {
         const full = try std.fs.path.join(allocator, &.{ tmp_path, rel });
         defer allocator.free(full);
-        const file = std.fs.openFileAbsolute(full, .{}) catch continue;
-        defer file.close();
-        const n = try file.readAll(&magic);
+        const file = std.Io.Dir.openFileAbsolute(io, full, .{}) catch continue;
+        defer file.close(io);
+        const n = try file.readStreaming(io, &.{&magic});
         if (n == magic.len) {
             read_ok = true;
             break;

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -1013,6 +1013,7 @@ fn findExecutableInPath(name: []const u8) ?[:0]const u8 {
 }
 
 pub const Shell = struct {
+    io: std.Io,
     pty: pty_mod.Pty,
     child_pid: std.c.pid_t,
 
@@ -1024,7 +1025,7 @@ pub const Shell = struct {
     const name_session: [:0]const u8 = "ARCHITECT_SESSION_ID\x00";
     const name_sock: [:0]const u8 = "ARCHITECT_NOTIFY_SOCK\x00";
 
-    pub fn spawn(shell_path: []const u8, size: pty_mod.winsize, session_id: [:0]const u8, notify_sock: [:0]const u8, working_dir: ?[:0]const u8) SpawnError!Shell {
+    pub fn spawn(io: std.Io, shell_path: []const u8, size: pty_mod.winsize, session_id: [:0]const u8, notify_sock: [:0]const u8, working_dir: ?[:0]const u8) SpawnError!Shell {
         // Ensure terminfo is set up (parent process, before fork)
         ensureTerminfoSetup();
         ensureArchitectCommandSetup();
@@ -1105,6 +1106,7 @@ pub const Shell = struct {
         posix.close(pty_instance.slave);
 
         return .{
+            .io = io,
             .pty = pty_instance,
             .child_pid = pid,
         };
@@ -1129,7 +1131,7 @@ pub const Shell = struct {
                     if (waited_ns >= max_wait_ns) {
                         return if (written > 0) written else err;
                     }
-                    clock.sleepNanos(backoff_ns);
+                    clock.sleepNanos(self.io, backoff_ns);
                     waited_ns += backoff_ns;
                     continue;
                 },
@@ -1165,6 +1167,8 @@ test "pathContainsEntry" {
 test "bundled terminfo compiles to legacy short-int format" {
     const testing = std.testing;
     const allocator = testing.allocator;
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
 
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1183,7 +1187,7 @@ test "bundled terminfo compiles to legacy short-int format" {
 
     const tic_path = findExecutableInPath("tic") orelse return error.SkipZigTest;
 
-    const term = try proc.spawnDetached(allocator, &.{ tic_path, "-x", "-o", tmp_path, src_path });
+    const term = try proc.spawnDetached(allocator, threaded.io(), &.{ tic_path, "-x", "-o", tmp_path, src_path });
     try testing.expectEqual(proc.Term{ .exited = 0 }, term);
 
     // tic stores the compiled entry in either `78/xterm-ghostty` (hashed,

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -7,6 +7,7 @@ const clock = @import("clock.zig");
 const env = @import("env.zig");
 const proc = @import("proc.zig");
 const pty_mod = @import("pty.zig");
+const posix_util = @import("posix_util.zig");
 const libc = @cImport({
     @cInclude("stdlib.h");
 });
@@ -825,7 +826,7 @@ fn ensureArchitectCommandSetup(io: std.Io) void {
     };
 
     const script_path = std.mem.sliceTo(script_path_z, 0);
-    posix.fchmodat(posix.AT.FDCWD, script_path, 0o755, 0) catch |err| {
+    std.Io.Dir.cwd().setFilePermissions(io, script_path, .fromMode(0o755), .{}) catch |err| {
         log.warn("failed to chmod architect command: {}", .{err});
     };
 
@@ -1046,9 +1047,9 @@ pub const Shell = struct {
             // Match ghostty's order: dup2 first so stdin/stdout/stderr point at the
             // slave before childPreExec rebinds the controlling terminal and closes
             // the original master/slave fds.
-            posix.dup2(pty_instance.slave, posix.STDIN_FILENO) catch std.c._exit(1);
-            posix.dup2(pty_instance.slave, posix.STDOUT_FILENO) catch std.c._exit(1);
-            posix.dup2(pty_instance.slave, posix.STDERR_FILENO) catch std.c._exit(1);
+            posix_util.dup2(pty_instance.slave, posix.STDIN_FILENO) catch std.c._exit(1);
+            posix_util.dup2(pty_instance.slave, posix.STDOUT_FILENO) catch std.c._exit(1);
+            posix_util.dup2(pty_instance.slave, posix.STDERR_FILENO) catch std.c._exit(1);
 
             if (libc.setenv(name_session.ptr, session_id, 1) != 0) {
                 std.c._exit(1);
@@ -1083,7 +1084,7 @@ pub const Shell = struct {
                 // Errors are intentionally ignored: we're in a forked child process where
                 // logging is impractical, and chdir failure is non-fatal (shell starts in
                 // the parent's cwd instead).
-                posix.chdir(dir) catch {};
+                _ = std.c.chdir(dir);
             }
 
             pty_instance.childPreExec() catch std.c._exit(1);
@@ -1103,7 +1104,7 @@ pub const Shell = struct {
             }
         }
 
-        posix.close(pty_instance.slave);
+        _ = std.c.close(pty_instance.slave);
 
         return .{
             .io = io,
@@ -1122,9 +1123,10 @@ pub const Shell = struct {
         var waited_ns: u64 = 0;
         const max_wait_ns: u64 = 50 * std.time.ns_per_ms;
         const backoff_ns: u64 = 1 * std.time.ns_per_ms;
+        const pty_file: std.Io.File = .{ .handle = self.pty.master, .flags = .{ .nonblocking = true } };
 
         while (written < data.len) {
-            const n = posix.write(self.pty.master, data[written..]) catch |err| switch (err) {
+            const n = pty_file.writeStreaming(self.io, &.{}, &.{data[written..]}, 1) catch |err| switch (err) {
                 error.WouldBlock => {
                     // PTY is full; retry for a short bounded window so pastes
                     // complete, but avoid indefinitely stalling the UI thread.

--- a/src/ui/components/diff_overlay.zig
+++ b/src/ui/components/diff_overlay.zig
@@ -132,15 +132,15 @@ pub const DiffOverlayComponent = struct {
     overlay: FullscreenOverlay = .{},
     scrollbar_state: scrollbar.State = .{},
 
-    files: std.ArrayList(DiffFile) = .{},
+    files: std.ArrayList(DiffFile) = .empty,
     raw_output: ?[]u8 = null,
-    display_rows: std.ArrayList(DisplayRow) = .{},
+    display_rows: std.ArrayList(DisplayRow) = .empty,
     cache: ?*Cache = null,
     last_repo_root: ?[]u8 = null,
 
     hovered_file: ?usize = null,
 
-    comments: std.ArrayList(DiffComment) = .{},
+    comments: std.ArrayList(DiffComment) = .empty,
     editing: ?EditingComment = null,
     agent_dropdown: dropdown_menu.DropdownMenu,
     send_button_hovered: bool = false,
@@ -556,7 +556,7 @@ pub const DiffOverlayComponent = struct {
         }) catch |err| {
             log.warn("failed to run git command: {}", .{err});
             return switch (err) {
-                error.StdoutStreamTooLong, error.StderrStreamTooLong => error.OutputTooLarge,
+                error.StreamTooLong => error.OutputTooLarge,
                 error.OutOfMemory => error.OutputAllocFailed,
                 else => error.ReadFailed,
             };
@@ -609,12 +609,12 @@ pub const DiffOverlayComponent = struct {
 
             if (std.mem.startsWith(u8, line_text, "diff --git ")) {
                 const path = extractFilePath(line_text);
-                var hunks = std.ArrayList(DiffHunk){};
+                var hunks: std.ArrayList(DiffHunk) = .empty;
                 _ = &hunks;
                 self.files.append(self.allocator, .{
                     .path = path,
                     .collapsed = false,
-                    .hunks = .{},
+                    .hunks = .empty,
                 }) catch |err| {
                     log.warn("failed to append file: {}", .{err});
                     pos = if (line_end < output.len) line_end + 1 else output.len;
@@ -643,7 +643,7 @@ pub const DiffOverlayComponent = struct {
                         .header_text = line_text,
                         .old_start = parsed.old_start,
                         .new_start = parsed.new_start,
-                        .lines = .{},
+                        .lines = .empty,
                     }) catch |err| {
                         log.warn("failed to append hunk: {}", .{err});
                         pos = if (line_end < output.len) line_end + 1 else output.len;
@@ -739,7 +739,7 @@ pub const DiffOverlayComponent = struct {
             file.hunks.deinit(self.allocator);
         }
         self.files.deinit(self.allocator);
-        self.files = .{};
+        self.files = .empty;
         self.hovered_file = null;
         self.freeComments();
         self.cancelEditingImmediate();
@@ -2323,7 +2323,7 @@ pub const DiffOverlayComponent = struct {
             self.allocator.free(comment.text);
         }
         self.comments.deinit(self.allocator);
-        self.comments = .{};
+        self.comments = .empty;
     }
 
     fn cancelEditing(self: *DiffOverlayComponent, now_ms: i64) void {
@@ -2634,7 +2634,7 @@ pub const DiffOverlayComponent = struct {
     }
 
     fn formatCommentsForAgent(self: *DiffOverlayComponent) ?[]const u8 {
-        var buf = std.ArrayList(u8){};
+        var buf: std.ArrayList(u8) = .empty;
         var first = true;
         for (self.comments.items) |comment| {
             if (comment.sent) continue;
@@ -2780,7 +2780,7 @@ pub const DiffOverlayComponent = struct {
         const file_path = std.fs.path.join(self.allocator, &.{ dir_path, "diff_comments.json" }) catch return;
         defer self.allocator.free(file_path);
 
-        var buf = std.ArrayList(u8){};
+        var buf: std.ArrayList(u8) = .empty;
         defer buf.deinit(self.allocator);
         buf.appendSlice(self.allocator, "[\n") catch return;
         var first = true;
@@ -2919,7 +2919,7 @@ pub const DiffOverlayComponent = struct {
     }
 
     fn parseJsonString(self: *DiffOverlayComponent, content: []const u8, pos: *usize) ?[]const u8 {
-        var buf = std.ArrayList(u8){};
+        var buf: std.ArrayList(u8) = .empty;
         while (pos.* < content.len and content[pos.*] != '"') {
             if (content[pos.*] == '\\' and pos.* + 1 < content.len) {
                 pos.* += 1;

--- a/src/ui/components/diff_overlay.zig
+++ b/src/ui/components/diff_overlay.zig
@@ -412,13 +412,13 @@ pub const DiffOverlayComponent = struct {
         };
         defer self.allocator.free(abs_path);
 
-        const file = std.fs.openFileAbsolute(abs_path, .{}) catch |err| {
+        const file = std.Io.Dir.openFileAbsolute(self.io, abs_path, .{}) catch |err| {
             log.warn("failed to open untracked file {s}: {}", .{ rel_path, err });
             return;
         };
-        defer file.close();
+        defer file.close(self.io);
 
-        const stat = file.stat() catch |err| {
+        const stat = file.stat(self.io) catch |err| {
             log.warn("failed to stat untracked file {s}: {}", .{ rel_path, err });
             return;
         };
@@ -433,7 +433,7 @@ pub const DiffOverlayComponent = struct {
             return;
         }
 
-        const content = file.readToEndAlloc(self.allocator, max_file_bytes) catch |err| {
+        const content = std.Io.Dir.cwd().readFileAlloc(self.io, abs_path, self.allocator, .limited(max_file_bytes)) catch |err| {
             log.warn("failed to read untracked file {s}: {}", .{ rel_path, err });
             return;
         };
@@ -2769,7 +2769,7 @@ pub const DiffOverlayComponent = struct {
 
         const dir_path = std.fs.path.join(self.allocator, &.{ repo_root, ".architect" }) catch return;
         defer self.allocator.free(dir_path);
-        std.fs.makeDirAbsolute(dir_path) catch |err| switch (err) {
+        std.Io.Dir.createDirAbsolute(self.io, dir_path, .default_dir) catch |err| switch (err) {
             error.PathAlreadyExists => {},
             else => {
                 log.warn("failed to create .architect dir: {}", .{err});
@@ -2800,12 +2800,12 @@ pub const DiffOverlayComponent = struct {
         }
         buf.appendSlice(self.allocator, "\n]\n") catch return;
 
-        const file = std.fs.createFileAbsolute(file_path, .{ .truncate = true }) catch |err| {
+        const file = std.Io.Dir.createFileAbsolute(self.io, file_path, .{ .truncate = true }) catch |err| {
             log.warn("failed to create comments file: {}", .{err});
             return;
         };
-        defer file.close();
-        file.writeAll(buf.items) catch |err| {
+        defer file.close(self.io);
+        file.writeStreamingAll(self.io, buf.items) catch |err| {
             log.warn("failed to write comments file: {}", .{err});
         };
     }
@@ -2836,9 +2836,7 @@ pub const DiffOverlayComponent = struct {
         const file_path = std.fs.path.join(self.allocator, &.{ repo_root, ".architect", "diff_comments.json" }) catch return;
         defer self.allocator.free(file_path);
 
-        const file = std.fs.openFileAbsolute(file_path, .{}) catch return;
-        defer file.close();
-        const content = file.readToEndAlloc(self.allocator, 1024 * 1024) catch return;
+        const content = std.Io.Dir.cwd().readFileAlloc(self.io, file_path, self.allocator, .limited(1024 * 1024)) catch return;
         defer self.allocator.free(content);
 
         self.parseCommentsJson(content);

--- a/src/ui/components/diff_overlay.zig
+++ b/src/ui/components/diff_overlay.zig
@@ -128,6 +128,7 @@ const GitResult = struct {
 
 pub const DiffOverlayComponent = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
     overlay: FullscreenOverlay = .{},
     scrollbar_state: scrollbar.State = .{},
 
@@ -205,9 +206,9 @@ pub const DiffOverlayComponent = struct {
     // max_chars plus room for tab-to-spaces expansion
     const max_display_buffer: usize = 520;
 
-    pub fn init(allocator: std.mem.Allocator) !*DiffOverlayComponent {
+    pub fn init(allocator: std.mem.Allocator, io: std.Io) !*DiffOverlayComponent {
         const comp = try allocator.create(DiffOverlayComponent);
-        comp.* = .{ .allocator = allocator, .agent_dropdown = dropdown_menu.DropdownMenu.init(allocator) };
+        comp.* = .{ .allocator = allocator, .io = io, .agent_dropdown = dropdown_menu.DropdownMenu.init(allocator) };
         comp.arrow_cursor = c.SDL_CreateSystemCursor(c.SDL_SYSTEM_CURSOR_DEFAULT);
         comp.pointer_cursor = c.SDL_CreateSystemCursor(c.SDL_SYSTEM_CURSOR_POINTER);
         comp.text_cursor = c.SDL_CreateSystemCursor(c.SDL_SYSTEM_CURSOR_TEXT);
@@ -548,7 +549,7 @@ pub const DiffOverlayComponent = struct {
     }
 
     fn runGitCommand(self: *DiffOverlayComponent, cwd: []const u8, argv: []const []const u8) !GitResult {
-        const result = proc.run(self.allocator, .{
+        const result = proc.run(self.allocator, self.io, .{
             .argv = argv,
             .cwd = cwd,
             .max_output_bytes = max_output_bytes,
@@ -3556,6 +3557,7 @@ fn testUiHost() types.UiHost {
 test "diff overlay agent dropdown takes keyboard priority over an open comment editor" {
     var component = DiffOverlayComponent{
         .allocator = std.testing.allocator,
+        .io = std.testing.io,
         .overlay = .{ .visible = true },
         .agent_dropdown = dropdown_menu.DropdownMenu.init(std.testing.allocator),
         .editing = .{
@@ -3605,6 +3607,7 @@ test "diff overlay agent dropdown takes keyboard priority over an open comment e
 test "diff overlay text input while the agent dropdown is open does not leak into the comment editor" {
     var component = DiffOverlayComponent{
         .allocator = std.testing.allocator,
+        .io = std.testing.io,
         .overlay = .{ .visible = true },
         .agent_dropdown = dropdown_menu.DropdownMenu.init(std.testing.allocator),
         .editing = .{

--- a/src/ui/components/markdown_parser.zig
+++ b/src/ui/components/markdown_parser.zig
@@ -241,7 +241,7 @@ pub fn freeBlocks(allocator: std.mem.Allocator, blocks: *std.ArrayList(DisplayBl
         freeStyledSpans(allocator, block.spans);
     }
     blocks.deinit(allocator);
-    blocks.* = .{};
+    blocks.* = .empty;
 }
 
 pub fn freeStyledSpans(allocator: std.mem.Allocator, spans: []StyledSpan) void {
@@ -253,7 +253,7 @@ pub fn freeStyledSpans(allocator: std.mem.Allocator, spans: []StyledSpan) void {
 }
 
 fn trimRightSpaces(line: []const u8) []const u8 {
-    return std.mem.trimRight(u8, line, " \t");
+    return std.mem.trimEnd(u8, line, " \t");
 }
 
 const LineInfo = struct {
@@ -263,7 +263,7 @@ const LineInfo = struct {
 
 fn readLine(input: []const u8, start: usize) LineInfo {
     const line_end = std.mem.indexOfScalarPos(u8, input, start, '\n') orelse input.len;
-    const raw_line = std.mem.trimRight(u8, input[start..line_end], "\r");
+    const raw_line = std.mem.trimEnd(u8, input[start..line_end], "\r");
     const next_start: ?usize = if (line_end < input.len) line_end + 1 else null;
     return .{
         .line = raw_line,
@@ -272,12 +272,12 @@ fn readLine(input: []const u8, start: usize) LineInfo {
 }
 
 fn isFenceLine(line: []const u8) bool {
-    const trimmed = std.mem.trimLeft(u8, line, " \t");
+    const trimmed = std.mem.trimStart(u8, line, " \t");
     return std.mem.startsWith(u8, trimmed, "```");
 }
 
 fn parseFenceLanguage(line: []const u8) []const u8 {
-    const trimmed = std.mem.trimLeft(u8, line, " \t");
+    const trimmed = std.mem.trimStart(u8, line, " \t");
     if (!std.mem.startsWith(u8, trimmed, "```")) return "";
     return std.mem.trim(u8, trimmed[3..], " \t");
 }
@@ -301,7 +301,7 @@ const Heading = struct {
 };
 
 fn parseHeading(line: []const u8) ?Heading {
-    const trimmed = std.mem.trimLeft(u8, line, " \t");
+    const trimmed = std.mem.trimStart(u8, line, " \t");
     if (trimmed.len == 0 or trimmed[0] != '#') return null;
 
     var level: usize = 0;
@@ -325,7 +325,7 @@ const ListItem = struct {
 fn parseListItem(line: []const u8) ?ListItem {
     const leading = countLeadingSpaces(line);
     const indent_level: u8 = @intCast(@min(leading / 2, max_indent_level));
-    const trimmed = std.mem.trimLeft(u8, line, " \t");
+    const trimmed = std.mem.trimStart(u8, line, " \t");
     if (trimmed.len < 2) return null;
 
     if ((trimmed[0] == '-' or trimmed[0] == '*' or trimmed[0] == '+') and trimmed[1] == ' ') {
@@ -377,14 +377,14 @@ const BlockquoteLine = struct {
 };
 
 fn parseBlockquote(line: []const u8) ?BlockquoteLine {
-    var trimmed = std.mem.trimLeft(u8, line, " \t");
+    var trimmed = std.mem.trimStart(u8, line, " \t");
     if (trimmed.len == 0 or trimmed[0] != '>') return null;
 
     var depth: usize = 0;
     while (trimmed.len > 0 and trimmed[0] == '>') {
         depth += 1;
         trimmed = trimmed[1..];
-        trimmed = std.mem.trimLeft(u8, trimmed, " \t");
+        trimmed = std.mem.trimStart(u8, trimmed, " \t");
     }
 
     return .{
@@ -952,7 +952,7 @@ const CodeRefResult = struct {
 };
 
 fn stripCodeRef(line: []const u8) CodeRefResult {
-    const trimmed = std.mem.trimRight(u8, line, " \t\r");
+    const trimmed = std.mem.trimEnd(u8, line, " \t\r");
 
     if (trimmed.len >= 13) { // minimum: <!--ref:N-->
         if (std.mem.endsWith(u8, trimmed, "-->")) {
@@ -966,7 +966,7 @@ fn stripCodeRef(line: []const u8) CodeRefResult {
                     const num = std.fmt.parseInt(u8, trimmed[num_start..num_end], 10) catch {
                         return .{ .text = line, .ref_number = null };
                     };
-                    const stripped = std.mem.trimRight(u8, trimmed[0..abs_pos], " \t");
+                    const stripped = std.mem.trimEnd(u8, trimmed[0..abs_pos], " \t");
                     return .{ .text = stripped, .ref_number = num };
                 }
             }

--- a/src/ui/components/markdown_renderer.zig
+++ b/src/ui/components/markdown_renderer.zig
@@ -234,7 +234,7 @@ pub fn freeLines(allocator: std.mem.Allocator, lines: *std.ArrayList(RenderLine)
         allocator.free(line.plain_text);
     }
     lines.deinit(allocator);
-    lines.* = .{};
+    lines.* = .empty;
 }
 
 fn freeTableCells(allocator: std.mem.Allocator, table_cells: []TableCell) void {
@@ -380,7 +380,7 @@ fn flushCurrentLine(
 
     const plain = try joinRunText(allocator, current.items);
     const runs = try current.toOwnedSlice(allocator);
-    current.* = .{};
+    current.* = .empty;
 
     try lines.append(allocator, .{
         .kind = .text,

--- a/src/ui/components/pr_dropdown.zig
+++ b/src/ui/components/pr_dropdown.zig
@@ -21,6 +21,7 @@ const FetchResult = model.FetchResult;
 
 const FetchContext = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
     cwd: []const u8,
     mutex: std.Thread.Mutex = .{},
     result: ?FetchResult = null,
@@ -50,6 +51,7 @@ const FetchJob = struct {
 
 pub const PRDropdownComponent = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
     overlay: ExpandingOverlay = ExpandingOverlay.init(3, button_margin, button_size_small, button_size_large, button_animation_duration_ms),
     first_frame: FirstFrameGuard = .{},
 
@@ -94,9 +96,9 @@ pub const PRDropdownComponent = struct {
     /// Time before a successful fetch is considered stale and re-fetched on open.
     const fetch_ttl_ms: i64 = 30_000;
 
-    pub fn create(allocator: std.mem.Allocator) !UiComponent {
+    pub fn create(allocator: std.mem.Allocator, io: std.Io) !UiComponent {
         const comp = try allocator.create(PRDropdownComponent);
-        comp.* = .{ .allocator = allocator };
+        comp.* = .{ .allocator = allocator, .io = io };
         return UiComponent{
             .ptr = comp,
             .vtable = &vtable,
@@ -475,17 +477,17 @@ pub const PRDropdownComponent = struct {
         var new_is_github_repo = false;
 
         if (new_cwd) |cwd| {
-            new_repo_root = repo.findRepoRoot(self.allocator, cwd) catch |err| blk: {
+            new_repo_root = repo.findRepoRoot(self.allocator, self.io, cwd) catch |err| blk: {
                 log.warn("failed to find repository for {s}: {}", .{ cwd, err });
                 break :blk null;
             };
             if (new_repo_root) |root| {
-                new_is_github_repo = repo.detectGithubOrigin(self.allocator, root) catch |err| blk: {
+                new_is_github_repo = repo.detectGithubOrigin(self.allocator, self.io, root) catch |err| blk: {
                     log.warn("failed to inspect GitHub origin for {s}: {}", .{ root, err });
                     break :blk false;
                 };
                 if (new_is_github_repo) {
-                    new_branch = repo.readCurrentBranch(self.allocator, root) catch |err| blk: {
+                    new_branch = repo.readCurrentBranch(self.allocator, self.io, root) catch |err| blk: {
                         log.warn("failed to read branch for {s}: {}", .{ root, err });
                         break :blk null;
                     };
@@ -533,7 +535,7 @@ pub const PRDropdownComponent = struct {
 
     fn refreshCurrentBranch(self: *PRDropdownComponent) void {
         const root = self.repo_root orelse return;
-        const new_branch = repo.readCurrentBranch(self.allocator, root) catch |err| {
+        const new_branch = repo.readCurrentBranch(self.allocator, self.io, root) catch |err| {
             log.warn("failed to refresh branch for {s}: {}", .{ root, err });
             return;
         };
@@ -570,6 +572,7 @@ pub const PRDropdownComponent = struct {
         };
         ctx.* = .{
             .allocator = self.allocator,
+            .io = self.io,
             .cwd = cwd_copy,
         };
 
@@ -591,7 +594,7 @@ pub const PRDropdownComponent = struct {
     }
 
     fn fetchThreadMain(ctx: *FetchContext) void {
-        const result = fetch.runGhPrList(ctx.allocator, ctx.cwd);
+        const result = fetch.runGhPrList(ctx.allocator, ctx.io, ctx.cwd);
         ctx.mutex.lock();
         ctx.result = result;
         ctx.mutex.unlock();

--- a/src/ui/components/pr_dropdown.zig
+++ b/src/ui/components/pr_dropdown.zig
@@ -23,7 +23,7 @@ const FetchContext = struct {
     allocator: std.mem.Allocator,
     io: std.Io,
     cwd: []const u8,
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = .init,
     result: ?FetchResult = null,
     done: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
@@ -36,8 +36,8 @@ const FetchContext = struct {
     }
 
     fn takeResult(self: *FetchContext) ?FetchResult {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
         const result = self.result;
         self.result = null;
         return result;
@@ -595,9 +595,9 @@ pub const PRDropdownComponent = struct {
 
     fn fetchThreadMain(ctx: *FetchContext) void {
         const result = fetch.runGhPrList(ctx.allocator, ctx.io, ctx.cwd);
-        ctx.mutex.lock();
+        ctx.mutex.lockUncancelable(ctx.io);
         ctx.result = result;
-        ctx.mutex.unlock();
+        ctx.mutex.unlock(ctx.io);
         ctx.done.store(true, .release);
     }
 

--- a/src/ui/components/pr_dropdown.zig
+++ b/src/ui/components/pr_dropdown.zig
@@ -63,7 +63,7 @@ pub const PRDropdownComponent = struct {
     current_pr_number: ?u32 = null,
 
     // Fetched PRs (owned by this component)
-    prs: std.ArrayList(PullRequest) = .{},
+    prs: std.ArrayList(PullRequest) = .empty,
     fetch_status: FetchStatus = .idle,
     fetch_error: ?[]const u8 = null,
     last_fetch_ms: i64 = 0,
@@ -74,7 +74,7 @@ pub const PRDropdownComponent = struct {
     fetch_jobs: std.ArrayList(FetchJob) = .empty,
 
     // Filter / selection
-    filtered_indices: std.ArrayList(usize) = .{},
+    filtered_indices: std.ArrayList(usize) = .empty,
     selected_index: usize = 0,
     hovered_entry: ?usize = null,
     search_query: text_edit.TextInput = .{ .separators = text_edit.path_separators, .accepts = text_edit.isSingleLineChar },

--- a/src/ui/components/pr_dropdown_fetch.zig
+++ b/src/ui/components/pr_dropdown_fetch.zig
@@ -10,13 +10,13 @@ const GhOutputPreview = struct {
     consumed: usize,
 };
 
-pub fn runGhPrList(allocator: std.mem.Allocator, cwd: []const u8) model.FetchResult {
+pub fn runGhPrList(allocator: std.mem.Allocator, io: std.Io, cwd: []const u8) model.FetchResult {
     const argv = [_][]const u8{
         "gh",      "pr",     "list",
         "--state", "open",   "--limit",
         "30",      "--json", "number,title,headRefName",
     };
-    const result = proc.run(allocator, .{
+    const result = proc.run(allocator, io, .{
         .argv = &argv,
         .cwd = cwd,
     }) catch |err| {

--- a/src/ui/components/pr_dropdown_repo.zig
+++ b/src/ui/components/pr_dropdown_repo.zig
@@ -3,7 +3,6 @@ const std = @import("std");
 /// Walk upward from `cwd` looking for a `.git` directory (or `.git` file for worktrees).
 /// Returns a newly-allocated absolute path to the directory containing `.git`.
 pub fn findRepoRoot(allocator: std.mem.Allocator, io: std.Io, cwd: []const u8) !?[]u8 {
-    _ = io;
     var current = try allocator.dupe(u8, cwd);
     errdefer allocator.free(current);
 
@@ -12,13 +11,13 @@ pub fn findRepoRoot(allocator: std.mem.Allocator, io: std.Io, cwd: []const u8) !
         defer allocator.free(dot_git);
 
         var found = false;
-        if (std.fs.openDirAbsolute(dot_git, .{})) |dir_const| {
+        if (std.Io.Dir.openDirAbsolute(io, dot_git, .{})) |dir_const| {
             var dir = dir_const;
-            dir.close();
+            dir.close(io);
             found = true;
         } else |_| {
-            if (std.fs.openFileAbsolute(dot_git, .{})) |file| {
-                file.close();
+            if (std.Io.Dir.openFileAbsolute(io, dot_git, .{})) |file| {
+                file.close(io);
                 found = true;
             } else |_| {}
         }
@@ -44,33 +43,32 @@ pub fn detectGithubOrigin(allocator: std.mem.Allocator, io: std.Io, repo_root: [
     const cfg_path = try resolveConfigPath(allocator, io, repo_root);
     defer allocator.free(cfg_path);
 
-    var file = std.fs.openFileAbsolute(cfg_path, .{}) catch |err| switch (err) {
+    const file = std.Io.Dir.openFileAbsolute(io, cfg_path, .{}) catch |err| switch (err) {
         error.FileNotFound => return false,
         else => return err,
     };
-    defer file.close();
-    const bytes = try file.readToEndAlloc(allocator, 256 * 1024);
+    defer file.close(io);
+    const bytes = try std.Io.Dir.cwd().readFileAlloc(io, cfg_path, allocator, .limited(256 * 1024));
     defer allocator.free(bytes);
 
     return originUrlIsGithub(bytes);
 }
 
 fn resolveConfigPath(allocator: std.mem.Allocator, io: std.Io, repo_root: []const u8) ![]u8 {
-    _ = io;
     const dot_git = try std.fs.path.join(allocator, &.{ repo_root, ".git" });
     defer allocator.free(dot_git);
 
-    if (std.fs.openDirAbsolute(dot_git, .{})) |dir_const| {
+    if (std.Io.Dir.openDirAbsolute(io, dot_git, .{})) |dir_const| {
         var dir = dir_const;
-        dir.close();
+        dir.close(io);
         return std.fs.path.join(allocator, &.{ dot_git, "config" });
     } else |_| {}
 
-    var file = std.fs.openFileAbsolute(dot_git, .{}) catch {
+    const file = std.Io.Dir.openFileAbsolute(io, dot_git, .{}) catch {
         return std.fs.path.join(allocator, &.{ dot_git, "config" });
     };
-    defer file.close();
-    const bytes = try file.readToEndAlloc(allocator, 4096);
+    defer file.close(io);
+    const bytes = try std.Io.Dir.cwd().readFileAlloc(io, dot_git, allocator, .limited(4096));
     defer allocator.free(bytes);
     const trimmed = std.mem.trim(u8, bytes, " \t\r\n");
     if (!std.mem.startsWith(u8, trimmed, "gitdir:")) {
@@ -87,9 +85,9 @@ fn resolveConfigPath(allocator: std.mem.Allocator, io: std.Io, repo_root: []cons
     // at `<main>/.git/config`. Read `commondir` to find the main gitdir.
     const commondir_path = try std.fs.path.join(allocator, &.{ gitdir_abs, "commondir" });
     defer allocator.free(commondir_path);
-    if (std.fs.openFileAbsolute(commondir_path, .{})) |cf| {
-        defer cf.close();
-        const cb = try cf.readToEndAlloc(allocator, 4096);
+    if (std.Io.Dir.openFileAbsolute(io, commondir_path, .{})) |cf| {
+        defer cf.close(io);
+        const cb = try std.Io.Dir.cwd().readFileAlloc(io, commondir_path, allocator, .limited(4096));
         defer allocator.free(cb);
         const ct = std.mem.trim(u8, cb, " \t\r\n");
         if (ct.len > 0) {
@@ -148,12 +146,12 @@ pub fn readCurrentBranch(allocator: std.mem.Allocator, io: std.Io, repo_root: []
     const head_path = try resolveHeadPath(allocator, io, repo_root);
     defer allocator.free(head_path);
 
-    var file = std.fs.openFileAbsolute(head_path, .{}) catch |err| switch (err) {
+    const file = std.Io.Dir.openFileAbsolute(io, head_path, .{}) catch |err| switch (err) {
         error.FileNotFound => return null,
         else => return err,
     };
-    defer file.close();
-    const bytes = try file.readToEndAlloc(allocator, 4096);
+    defer file.close(io);
+    const bytes = try std.Io.Dir.cwd().readFileAlloc(io, head_path, allocator, .limited(4096));
     defer allocator.free(bytes);
     const trimmed = std.mem.trim(u8, bytes, " \t\r\n");
     const prefix = "ref: refs/heads/";
@@ -164,21 +162,20 @@ pub fn readCurrentBranch(allocator: std.mem.Allocator, io: std.Io, repo_root: []
 }
 
 fn resolveHeadPath(allocator: std.mem.Allocator, io: std.Io, repo_root: []const u8) ![]u8 {
-    _ = io;
     const dot_git = try std.fs.path.join(allocator, &.{ repo_root, ".git" });
     defer allocator.free(dot_git);
 
-    if (std.fs.openDirAbsolute(dot_git, .{})) |dir_const| {
+    if (std.Io.Dir.openDirAbsolute(io, dot_git, .{})) |dir_const| {
         var dir = dir_const;
-        dir.close();
+        dir.close(io);
         return std.fs.path.join(allocator, &.{ dot_git, "HEAD" });
     } else |_| {}
 
-    var file = std.fs.openFileAbsolute(dot_git, .{}) catch {
+    const file = std.Io.Dir.openFileAbsolute(io, dot_git, .{}) catch {
         return std.fs.path.join(allocator, &.{ dot_git, "HEAD" });
     };
-    defer file.close();
-    const bytes = try file.readToEndAlloc(allocator, 4096);
+    defer file.close(io);
+    const bytes = try std.Io.Dir.cwd().readFileAlloc(io, dot_git, allocator, .limited(4096));
     defer allocator.free(bytes);
     const trimmed = std.mem.trim(u8, bytes, " \t\r\n");
     if (!std.mem.startsWith(u8, trimmed, "gitdir:")) {

--- a/src/ui/components/pr_dropdown_repo.zig
+++ b/src/ui/components/pr_dropdown_repo.zig
@@ -2,7 +2,8 @@ const std = @import("std");
 
 /// Walk upward from `cwd` looking for a `.git` directory (or `.git` file for worktrees).
 /// Returns a newly-allocated absolute path to the directory containing `.git`.
-pub fn findRepoRoot(allocator: std.mem.Allocator, cwd: []const u8) !?[]u8 {
+pub fn findRepoRoot(allocator: std.mem.Allocator, io: std.Io, cwd: []const u8) !?[]u8 {
+    _ = io;
     var current = try allocator.dupe(u8, cwd);
     errdefer allocator.free(current);
 
@@ -39,8 +40,8 @@ pub fn findRepoRoot(allocator: std.mem.Allocator, cwd: []const u8) !?[]u8 {
 
 /// Look at the git config and decide whether `[remote "origin"]` points at github.com.
 /// Resolves `.git` files (worktrees) so it finds the main repo's config.
-pub fn detectGithubOrigin(allocator: std.mem.Allocator, repo_root: []const u8) !bool {
-    const cfg_path = try resolveConfigPath(allocator, repo_root);
+pub fn detectGithubOrigin(allocator: std.mem.Allocator, io: std.Io, repo_root: []const u8) !bool {
+    const cfg_path = try resolveConfigPath(allocator, io, repo_root);
     defer allocator.free(cfg_path);
 
     var file = std.fs.openFileAbsolute(cfg_path, .{}) catch |err| switch (err) {
@@ -54,7 +55,8 @@ pub fn detectGithubOrigin(allocator: std.mem.Allocator, repo_root: []const u8) !
     return originUrlIsGithub(bytes);
 }
 
-fn resolveConfigPath(allocator: std.mem.Allocator, repo_root: []const u8) ![]u8 {
+fn resolveConfigPath(allocator: std.mem.Allocator, io: std.Io, repo_root: []const u8) ![]u8 {
+    _ = io;
     const dot_git = try std.fs.path.join(allocator, &.{ repo_root, ".git" });
     defer allocator.free(dot_git);
 
@@ -142,8 +144,8 @@ fn urlPointsToGithub(url: []const u8) bool {
 
 /// Read HEAD and return the current branch name (or null if detached HEAD).
 /// Handles both regular repos and worktrees.
-pub fn readCurrentBranch(allocator: std.mem.Allocator, repo_root: []const u8) !?[]u8 {
-    const head_path = try resolveHeadPath(allocator, repo_root);
+pub fn readCurrentBranch(allocator: std.mem.Allocator, io: std.Io, repo_root: []const u8) !?[]u8 {
+    const head_path = try resolveHeadPath(allocator, io, repo_root);
     defer allocator.free(head_path);
 
     var file = std.fs.openFileAbsolute(head_path, .{}) catch |err| switch (err) {
@@ -161,7 +163,8 @@ pub fn readCurrentBranch(allocator: std.mem.Allocator, repo_root: []const u8) !?
     return try allocator.dupe(u8, branch);
 }
 
-fn resolveHeadPath(allocator: std.mem.Allocator, repo_root: []const u8) ![]u8 {
+fn resolveHeadPath(allocator: std.mem.Allocator, io: std.Io, repo_root: []const u8) ![]u8 {
+    _ = io;
     const dot_git = try std.fs.path.join(allocator, &.{ repo_root, ".git" });
     defer allocator.free(dot_git);
 

--- a/src/ui/components/reader_overlay.zig
+++ b/src/ui/components/reader_overlay.zig
@@ -70,14 +70,14 @@ pub const ReaderOverlayComponent = struct {
     pinned_to_bottom: bool = true,
 
     raw_text: ?[]u8 = null,
-    blocks: std.ArrayList(markdown_parser.DisplayBlock) = .{},
-    lines: std.ArrayList(markdown_renderer.RenderLine) = .{},
+    blocks: std.ArrayList(markdown_parser.DisplayBlock) = .empty,
+    lines: std.ArrayList(markdown_renderer.RenderLine) = .empty,
 
     search_active: bool = false,
     search: text_edit.TextInput = .{ .separators = text_edit.prose_separators, .accepts = text_edit.isSingleLineChar },
-    matches: std.ArrayList(SearchMatch) = .{},
+    matches: std.ArrayList(SearchMatch) = .empty,
     selected_match: ?usize = null,
-    link_hits: std.ArrayList(LinkHit) = .{},
+    link_hits: std.ArrayList(LinkHit) = .empty,
     hovered_link: ?usize = null,
     jump_button_hovered: bool = false,
 
@@ -165,8 +165,8 @@ pub const ReaderOverlayComponent = struct {
         self.clearLinkHits();
         markdown_parser.freeBlocks(self.allocator, &self.blocks);
         markdown_renderer.freeLines(self.allocator, &self.lines);
-        self.blocks = .{};
-        self.lines = .{};
+        self.blocks = .empty;
+        self.lines = .empty;
         self.last_render_epoch = 0;
     }
 
@@ -190,7 +190,7 @@ pub const ReaderOverlayComponent = struct {
         markdown_parser.freeBlocks(self.allocator, &self.blocks);
         self.blocks = markdown_parser.parse(self.allocator, extracted) catch |err| {
             log.warn("failed to parse markdown from terminal output: {}", .{err});
-            self.blocks = .{};
+            self.blocks = .empty;
             return;
         };
 
@@ -206,7 +206,7 @@ pub const ReaderOverlayComponent = struct {
         markdown_renderer.freeLines(self.allocator, &self.lines);
         self.lines = markdown_renderer.buildLines(self.allocator, self.blocks.items, self.wrap_cols) catch |err| {
             log.warn("failed to build markdown layout: {}", .{err});
-            self.lines = .{};
+            self.lines = .empty;
             return;
         };
 

--- a/src/ui/components/recent_folders_overlay.zig
+++ b/src/ui/components/recent_folders_overlay.zig
@@ -25,8 +25,8 @@ pub const RecentFoldersOverlayComponent = struct {
     first_frame: FirstFrameGuard = .{},
     badge: GlyphBadge = .{ .text = "⌘O" },
 
-    all_folders: std.ArrayList(Folder) = .{},
-    filtered_indices: std.ArrayList(usize) = .{},
+    all_folders: std.ArrayList(Folder) = .empty,
+    filtered_indices: std.ArrayList(usize) = .empty,
     selected_index: usize = 0,
     hovered_entry: ?usize = null,
     escape_pressed: bool = false,

--- a/src/ui/components/session_interaction.zig
+++ b/src/ui/components/session_interaction.zig
@@ -978,14 +978,14 @@ fn isWordCharacter(codepoint: u21) bool {
 /// on non-text cells.
 fn cellCodepoint(cell: anytype) u21 {
     return if (cell.content_tag == .codepoint or cell.content_tag == .codepoint_grapheme)
-        cell.content.codepoint
+        if (comptime @TypeOf(cell.content.codepoint) == u21) cell.content.codepoint else cell.content.codepoint.data
     else
         0;
 }
 
 fn selectWord(session: *SessionState, view: *SessionViewState, pin: ghostty_vt.Pin) void {
     const terminal = &(session.terminal orelse return);
-    const page = &pin.node.data;
+    const page = pin.node.page();
     const max_col: u16 = @intCast(page.size.cols - 1);
 
     const click_coords = pinToCoords(terminal, pin, view.is_viewing_scrollback) orelse return;
@@ -1052,7 +1052,7 @@ fn selectWord(session: *SessionState, view: *SessionViewState, pin: ghostty_vt.P
 
 fn selectLine(session: *SessionState, view: *SessionViewState, pin: ghostty_vt.Pin) void {
     const terminal = &(session.terminal orelse return);
-    const page = &pin.node.data;
+    const page = pin.node.page();
     const max_col: u16 = @intCast(page.size.cols - 1);
 
     const click_y = (pinToCoords(terminal, pin, view.is_viewing_scrollback) orelse return).y;
@@ -1087,7 +1087,7 @@ const LinkMatch = struct {
 };
 
 fn getLinkMatchAtPin(allocator: std.mem.Allocator, terminal: *ghostty_vt.Terminal, pin: ghostty_vt.Pin, is_viewing_scrollback: bool) ?LinkMatch {
-    const page = &pin.node.data;
+    const page = pin.node.page();
     const row_and_cell = pin.rowAndCell();
     const cell = row_and_cell.cell;
 

--- a/src/ui/components/story_overlay.zig
+++ b/src/ui/components/story_overlay.zig
@@ -42,6 +42,7 @@ const AnchorPosition = struct {
 
 pub const StoryOverlayComponent = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
     overlay: FullscreenOverlay = .{},
     scrollbar_state: scrollbar.State = .{},
 
@@ -73,10 +74,11 @@ pub const StoryOverlayComponent = struct {
     const marker_width: c_int = 20;
     const code_indent: c_int = 8;
 
-    pub fn init(allocator: std.mem.Allocator) !*StoryOverlayComponent {
+    pub fn init(allocator: std.mem.Allocator, io: std.Io) !*StoryOverlayComponent {
         const comp = try allocator.create(StoryOverlayComponent);
         comp.* = .{
             .allocator = allocator,
+            .io = io,
             .pointer_cursor = c.SDL_CreateSystemCursor(c.SDL_SYSTEM_CURSOR_POINTER),
             .arrow_cursor = c.SDL_CreateSystemCursor(c.SDL_SYSTEM_CURSOR_DEFAULT),
         };

--- a/src/ui/components/story_overlay.zig
+++ b/src/ui/components/story_overlay.zig
@@ -47,22 +47,22 @@ pub const StoryOverlayComponent = struct {
     scrollbar_state: scrollbar.State = .{},
 
     raw_content: ?[]u8 = null,
-    blocks: std.ArrayList(markdown_parser.DisplayBlock) = .{},
-    lines: std.ArrayList(markdown_renderer.RenderLine) = .{},
+    blocks: std.ArrayList(markdown_parser.DisplayBlock) = .empty,
+    lines: std.ArrayList(markdown_renderer.RenderLine) = .empty,
     file_path: ?[]u8 = null,
 
     wrap_cols: usize = 0,
 
-    anchor_positions: std.ArrayList(AnchorPosition) = .{},
+    anchor_positions: std.ArrayList(AnchorPosition) = .empty,
     hovered_anchor: ?u8 = null,
     hover_start_ms: i64 = 0,
 
     search_active: bool = false,
     search: text_edit.TextInput = .{ .separators = text_edit.prose_separators, .accepts = text_edit.isSingleLineChar },
-    matches: std.ArrayList(SearchMatch) = .{},
+    matches: std.ArrayList(SearchMatch) = .empty,
     selected_match: ?usize = null,
 
-    link_hits: std.ArrayList(LinkHit) = .{},
+    link_hits: std.ArrayList(LinkHit) = .empty,
     hovered_link: ?usize = null,
 
     pointer_cursor: ?*c.SDL_Cursor = null,
@@ -147,7 +147,7 @@ pub const StoryOverlayComponent = struct {
         markdown_parser.freeBlocks(self.allocator, &self.blocks);
         self.blocks = markdown_parser.parseStory(self.allocator, self.raw_content orelse "") catch |err| {
             log.warn("failed to parse story markdown: {}", .{err});
-            self.blocks = .{};
+            self.blocks = .empty;
             return;
         };
 
@@ -160,7 +160,7 @@ pub const StoryOverlayComponent = struct {
         const effective_wrap = if (self.wrap_cols > 0) self.wrap_cols else 120;
         self.lines = markdown_renderer.buildLines(self.allocator, self.blocks.items, effective_wrap) catch |err| {
             log.warn("failed to build story layout: {}", .{err});
-            self.lines = .{};
+            self.lines = .empty;
             return;
         };
         self.rebuildSearchMatches();

--- a/src/ui/components/story_overlay.zig
+++ b/src/ui/components/story_overlay.zig
@@ -131,14 +131,13 @@ pub const StoryOverlayComponent = struct {
     }
 
     fn readFile(self: *StoryOverlayComponent, path: []const u8) ?[]u8 {
-        const file = std.fs.openFileAbsolute(path, .{}) catch |err| {
+        const file = std.Io.Dir.openFileAbsolute(self.io, path, .{}) catch |err| {
             log.warn("failed to open story file {s}: {}", .{ path, err });
             return null;
         };
-        defer file.close();
+        defer file.close(self.io);
 
-        const max_size: usize = 4 * 1024 * 1024;
-        return file.readToEndAlloc(self.allocator, max_size) catch |err| {
+        return std.Io.Dir.cwd().readFileAlloc(self.io, path, self.allocator, .limited(4 * 1024 * 1024)) catch |err| {
             log.warn("failed to read story file {s}: {}", .{ path, err });
             return null;
         };

--- a/src/ui/components/worktree_overlay.zig
+++ b/src/ui/components/worktree_overlay.zig
@@ -23,7 +23,7 @@ pub const WorktreeOverlayComponent = struct {
     first_frame: FirstFrameGuard = .{},
     badge: GlyphBadge = .{ .text = "⌘T" },
 
-    worktrees: std.ArrayList(Worktree) = .{},
+    worktrees: std.ArrayList(Worktree) = .empty,
     last_cwd: ?[]const u8 = null,
     display_base: ?[]const u8 = null,
     needs_refresh: bool = true,
@@ -633,7 +633,7 @@ pub const WorktreeOverlayComponent = struct {
 
     fn makeDisplayPath(self: *WorktreeOverlayComponent, base: []const u8, abs: []const u8) ![]const u8 {
         if (std.mem.startsWith(u8, abs, base)) {
-            const rel = std.fs.path.relative(self.allocator, base, abs) catch {
+            const rel = std.fs.path.relative(self.allocator, ".", null, base, abs) catch {
                 return self.allocator.dupe(u8, abs);
             };
             if (rel.len == 0) return self.allocator.dupe(u8, repository_root_label);

--- a/src/ui/components/worktree_overlay.zig
+++ b/src/ui/components/worktree_overlay.zig
@@ -18,6 +18,7 @@ const log = std.log.scoped(.worktree_overlay);
 
 pub const WorktreeOverlayComponent = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
     overlay: ExpandingOverlay = ExpandingOverlay.init(2, button_margin, button_size_small, button_size_large, button_animation_duration_ms),
     first_frame: FirstFrameGuard = .{},
     badge: GlyphBadge = .{ .text = "⌘T" },
@@ -104,9 +105,9 @@ pub const WorktreeOverlayComponent = struct {
         font_generation: u64,
     };
 
-    pub fn create(allocator: std.mem.Allocator) !UiComponent {
+    pub fn create(allocator: std.mem.Allocator, io: std.Io) !UiComponent {
         const comp = try allocator.create(WorktreeOverlayComponent);
-        comp.* = .{ .allocator = allocator };
+        comp.* = .{ .allocator = allocator, .io = io };
         return UiComponent{
             .ptr = comp,
             .vtable = &vtable,

--- a/src/ui/components/worktree_overlay.zig
+++ b/src/ui/components/worktree_overlay.zig
@@ -1464,13 +1464,13 @@ pub const WorktreeOverlayComponent = struct {
         };
         defer self.allocator.free(worktrees_dir_buf);
 
-        var dir = std.fs.openDirAbsolute(worktrees_dir_buf, .{ .iterate = true }) catch {
+        var dir = std.Io.Dir.openDirAbsolute(self.io, worktrees_dir_buf, .{ .iterate = true }) catch {
             return self.worktrees.items.len > 0;
         };
-        defer dir.close();
+        defer dir.close(self.io);
 
         var iterator = dir.iterate();
-        while (iterator.next() catch |err| blk: {
+        while (iterator.next(self.io) catch |err| blk: {
             log.warn("failed to iterate directory: {}", .{err});
             break :blk null;
         }) |entry| {
@@ -1508,9 +1508,7 @@ pub const WorktreeOverlayComponent = struct {
     }
 
     fn readTrimmedFile(self: *WorktreeOverlayComponent, path: []const u8) ![]const u8 {
-        const file = try std.fs.openFileAbsolute(path, .{});
-        defer file.close();
-        const contents = try file.readToEndAlloc(self.allocator, 4096);
+        const contents = try std.Io.Dir.cwd().readFileAlloc(self.io, path, self.allocator, .limited(4096));
         defer self.allocator.free(contents);
         const trimmed = std.mem.trim(u8, contents, " \t\r\n");
         return self.allocator.dupe(u8, trimmed);
@@ -1527,17 +1525,17 @@ pub const WorktreeOverlayComponent = struct {
             };
             defer self.allocator.free(candidate);
 
-            if (std.fs.openDirAbsolute(candidate, .{})) |dir| {
+            if (std.Io.Dir.openDirAbsolute(self.io, candidate, .{})) |dir| {
                 var owned_dir = dir;
-                owned_dir.close();
+                owned_dir.close(self.io);
                 const gitdir = try self.allocator.dupe(u8, candidate);
                 const commondir = try self.resolveCommonDir(gitdir);
                 self.allocator.free(current);
                 return GitContext{ .gitdir = gitdir, .commondir = commondir, .allocator = self.allocator };
             } else |_| {
                 // .git file case
-                if (std.fs.openFileAbsolute(candidate, .{})) |file| {
-                    defer file.close();
+                if (std.Io.Dir.openFileAbsolute(self.io, candidate, .{})) |file| {
+                    defer file.close(self.io);
                     const gitdir_line = self.readTrimmedFile(candidate) catch |err| {
                         log.warn("failed to read .git file: {}", .{err});
                         break;

--- a/src/ui/root.zig
+++ b/src/ui/root.zig
@@ -17,7 +17,7 @@ pub const UiRoot = struct {
     pub fn init(allocator: std.mem.Allocator) UiRoot {
         return .{
             .allocator = allocator,
-            .components = .{},
+            .components = .empty,
             .actions = types.UiActionQueue.init(allocator),
             .assets = .{},
         };

--- a/src/ui/types.zig
+++ b/src/ui/types.zig
@@ -129,7 +129,7 @@ pub const UiAssets = struct {
 
 pub const UiActionQueue = struct {
     allocator: std.mem.Allocator,
-    list: std.ArrayList(UiAction) = .{},
+    list: std.ArrayList(UiAction) = .empty,
 
     pub fn init(allocator: std.mem.Allocator) UiActionQueue {
         return .{ .allocator = allocator };

--- a/src/vt_stream.zig
+++ b/src/vt_stream.zig
@@ -407,6 +407,7 @@ test "stream answers OSC 10 and OSC 11 color queries" {
     defer std.posix.close(pipe_fds[1]);
 
     var shell = shell_mod.Shell{
+        .io = std.testing.io,
         .pty = .{
             .master = pipe_fds[1],
             .slave = pipe_fds[0],
@@ -442,6 +443,7 @@ test "stream answers synchronized output mode report queries" {
     defer std.posix.close(pipe_fds[1]);
 
     var shell = shell_mod.Shell{
+        .io = std.testing.io,
         .pty = .{
             .master = pipe_fds[1],
             .slave = pipe_fds[0],
@@ -479,6 +481,7 @@ test "stream answers unknown mode report queries" {
     defer std.posix.close(pipe_fds[1]);
 
     var shell = shell_mod.Shell{
+        .io = std.testing.io,
         .pty = .{
             .master = pipe_fds[1],
             .slave = pipe_fds[0],
@@ -530,6 +533,7 @@ test "stream answers OSC 4 palette queries with the current terminal palette" {
     defer std.posix.close(pipe_fds[1]);
 
     var shell = shell_mod.Shell{
+        .io = std.testing.io,
         .pty = .{
             .master = pipe_fds[1],
             .slave = pipe_fds[0],
@@ -561,6 +565,7 @@ test "stream processes OSC 8 hyperlinks via nextSlice without error" {
     defer std.posix.close(pipe_fds[1]);
 
     var shell = shell_mod.Shell{
+        .io = std.testing.io,
         .pty = .{
             .master = pipe_fds[1],
             .slave = pipe_fds[0],

--- a/src/vt_stream.zig
+++ b/src/vt_stream.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const ghostty_vt = @import("ghostty-vt");
 const shell_mod = @import("shell.zig");
+const posix_util = @import("posix_util.zig");
 
 const log = std.log.scoped(.vt_stream);
 
@@ -32,6 +33,16 @@ pub const Handler = struct {
         self: *Handler,
         comptime action: ghostty_vt.StreamAction.Tag,
         value: ghostty_vt.StreamAction.Value(action),
+    ) void {
+        self.vtFallible(action, value) catch |err| {
+            log.warn("error handling VT action action={} err={}", .{ action, err });
+        };
+    }
+
+    fn vtFallible(
+        self: *Handler,
+        comptime action: ghostty_vt.StreamAction.Tag,
+        value: ghostty_vt.StreamAction.Value(action),
     ) !void {
         switch (action) {
             .device_attributes => try self.handleDeviceAttributes(value),
@@ -41,7 +52,7 @@ pub const Handler = struct {
             .request_mode => try self.handleRequestMode(value.mode),
             .request_mode_unknown => try self.handleRequestModeUnknown(value.mode, value.ansi),
             .set_mode => {
-                try self.delegateVt(action, value);
+                self.delegateVt(action, value);
                 // DEC mode 2048 (in-band size reports): apps that enable this
                 // expect a size report whenever the terminal is resized AND an
                 // initial report when the mode is first enabled. Matches
@@ -52,78 +63,40 @@ pub const Handler = struct {
             },
             .kitty_keyboard_push => {
                 log.debug("kitty_keyboard_push: flags={d}", .{value.flags.int()});
-                try self.delegateVt(action, value);
+                self.delegateVt(action, value);
                 log.debug("kitty_keyboard: current={d}", .{self.terminal.screens.active.kitty_keyboard.current().int()});
             },
             .kitty_keyboard_pop => {
                 log.debug("kitty_keyboard_pop: n={d}", .{value});
-                try self.delegateVt(action, value);
+                self.delegateVt(action, value);
                 log.debug("kitty_keyboard: current={d}", .{self.terminal.screens.active.kitty_keyboard.current().int()});
             },
             .kitty_keyboard_set => {
                 log.debug("kitty_keyboard_set: flags={d}", .{value.flags.int()});
-                try self.delegateVt(action, value);
+                self.delegateVt(action, value);
                 log.debug("kitty_keyboard: current={d}", .{self.terminal.screens.active.kitty_keyboard.current().int()});
             },
             .kitty_keyboard_set_or => {
                 log.debug("kitty_keyboard_set_or: flags={d}", .{value.flags.int()});
-                try self.delegateVt(action, value);
+                self.delegateVt(action, value);
                 log.debug("kitty_keyboard: current={d}", .{self.terminal.screens.active.kitty_keyboard.current().int()});
             },
             .kitty_keyboard_set_not => {
                 log.debug("kitty_keyboard_set_not: flags={d}", .{value.flags.int()});
-                try self.delegateVt(action, value);
+                self.delegateVt(action, value);
                 log.debug("kitty_keyboard: current={d}", .{self.terminal.screens.active.kitty_keyboard.current().int()});
             },
-            else => try self.delegateVt(action, value),
+            else => self.delegateVt(action, value),
         }
     }
 
-    /// Errors the built-in readonly handler can surface, other than the OSC 8
-    /// hyperlink capacity errors that delegateVt always contains. Declared
-    /// explicitly (rather than inferred) because `vt` is comptime-generic over
-    /// the action tag: each action instantiates a differently-shaped inferred
-    /// error union, and only some of them actually include the hyperlink
-    /// errors. An inferred return type here would force every switch arm in
-    /// `vt` below to reference literals that are members of the local error
-    /// union, which fails to compile for actions that can't produce them.
-    const DelegateVtError = error{
-        DivisionByZero,
-        GraphemeAllocOutOfMemory,
-        GraphemeMapOutOfMemory,
-        NeedsRehash,
-        OutOfMemory,
-        OutOfSpace,
-        StringAllocOutOfMemory,
-        StyleSetNeedsRehash,
-        StyleSetOutOfMemory,
-    };
-
-    /// Delegates to the built-in readonly handler, containing OSC 8 hyperlink
-    /// capacity errors so a single exhausted hyperlink table doesn't abort
-    /// parsing of the rest of the PTY output. All other errors propagate.
+    /// Delegates to the built-in readonly handler.
     fn delegateVt(
         self: *Handler,
         comptime action: ghostty_vt.StreamAction.Tag,
         value: ghostty_vt.StreamAction.Value(action),
-    ) DelegateVtError!void {
-        self.readonly.vt(action, value) catch |err| {
-            // Match against anyerror since the hyperlink error names aren't
-            // members of every action's own inferred error set.
-            switch (@as(anyerror, err)) {
-                error.HyperlinkSetOutOfMemory,
-                error.HyperlinkSetNeedsRehash,
-                error.HyperlinkMapOutOfMemory,
-                => {
-                    log.warn("OSC 8 hyperlink capacity exhausted, hyperlink dropped: {}", .{err});
-                    return;
-                },
-                else => {},
-            }
-            // Safe: the hyperlink errors were already handled above, so err
-            // is guaranteed to be a member of DelegateVtError here.
-            return @errorCast(err);
-        };
+    ) void {
+        self.readonly.vt(action, value);
     }
 
     fn handleDeviceAttributes(self: *Handler, req: ghostty_vt.DeviceAttributeReq) !void {
@@ -390,7 +363,7 @@ test "formatOscColorQueryResponse formats dynamic queries with the input termina
 test "stream answers OSC 10 and OSC 11 color queries" {
     const allocator = std.testing.allocator;
 
-    var terminal = try ghostty_vt.Terminal.init(allocator, .{
+    var terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{
         .cols = 80,
         .rows = 24,
         .colors = .{
@@ -402,9 +375,10 @@ test "stream answers OSC 10 and OSC 11 color queries" {
     });
     defer terminal.deinit(allocator);
 
-    const pipe_fds = try std.posix.pipe();
-    defer std.posix.close(pipe_fds[0]);
-    defer std.posix.close(pipe_fds[1]);
+    var pipe_fds: [2]std.posix.fd_t = undefined;
+    try posix_util.pipe(&pipe_fds);
+    defer _ = std.c.close(pipe_fds[0]);
+    defer _ = std.c.close(pipe_fds[1]);
 
     var shell = shell_mod.Shell{
         .io = std.testing.io,
@@ -420,11 +394,11 @@ test "stream answers OSC 10 and OSC 11 color queries" {
 
     var buf: [128]u8 = undefined;
 
-    try stream.nextSlice("\x1b]10;?\x07");
+    stream.nextSlice("\x1b]10;?\x07");
     const fg_len = try std.posix.read(pipe_fds[0], &buf);
     try std.testing.expectEqualSlices(u8, "\x1b]10;rgb:abab/cdcd/efef\x07", buf[0..fg_len]);
 
-    try stream.nextSlice("\x1b]11;?\x1b\\");
+    stream.nextSlice("\x1b]11;?\x1b\\");
     const bg_len = try std.posix.read(pipe_fds[0], &buf);
     try std.testing.expectEqualSlices(u8, "\x1b]11;rgb:1212/3434/5656\x1b\\", buf[0..bg_len]);
 }
@@ -432,15 +406,16 @@ test "stream answers OSC 10 and OSC 11 color queries" {
 test "stream answers synchronized output mode report queries" {
     const allocator = std.testing.allocator;
 
-    var terminal = try ghostty_vt.Terminal.init(allocator, .{
+    var terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{
         .cols = 80,
         .rows = 24,
     });
     defer terminal.deinit(allocator);
 
-    const pipe_fds = try std.posix.pipe();
-    defer std.posix.close(pipe_fds[0]);
-    defer std.posix.close(pipe_fds[1]);
+    var pipe_fds: [2]std.posix.fd_t = undefined;
+    try posix_util.pipe(&pipe_fds);
+    defer _ = std.c.close(pipe_fds[0]);
+    defer _ = std.c.close(pipe_fds[1]);
 
     var shell = shell_mod.Shell{
         .io = std.testing.io,
@@ -456,13 +431,13 @@ test "stream answers synchronized output mode report queries" {
 
     var buf: [128]u8 = undefined;
 
-    try stream.nextSlice("\x1b[?2026$p");
+    stream.nextSlice("\x1b[?2026$p");
     const disabled_len = try std.posix.read(pipe_fds[0], &buf);
     try std.testing.expectEqualSlices(u8, "\x1b[?2026;2$y", buf[0..disabled_len]);
 
     terminal.modes.set(.synchronized_output, true);
 
-    try stream.nextSlice("\x1b[?2026$p");
+    stream.nextSlice("\x1b[?2026$p");
     const enabled_len = try std.posix.read(pipe_fds[0], &buf);
     try std.testing.expectEqualSlices(u8, "\x1b[?2026;1$y", buf[0..enabled_len]);
 }
@@ -470,15 +445,16 @@ test "stream answers synchronized output mode report queries" {
 test "stream answers unknown mode report queries" {
     const allocator = std.testing.allocator;
 
-    var terminal = try ghostty_vt.Terminal.init(allocator, .{
+    var terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{
         .cols = 80,
         .rows = 24,
     });
     defer terminal.deinit(allocator);
 
-    const pipe_fds = try std.posix.pipe();
-    defer std.posix.close(pipe_fds[0]);
-    defer std.posix.close(pipe_fds[1]);
+    var pipe_fds: [2]std.posix.fd_t = undefined;
+    try posix_util.pipe(&pipe_fds);
+    defer _ = std.c.close(pipe_fds[0]);
+    defer _ = std.c.close(pipe_fds[1]);
 
     var shell = shell_mod.Shell{
         .io = std.testing.io,
@@ -494,7 +470,7 @@ test "stream answers unknown mode report queries" {
 
     var buf: [128]u8 = undefined;
 
-    try stream.nextSlice("\x1b[?9999$p");
+    stream.nextSlice("\x1b[?9999$p");
     const private_len = try std.posix.read(pipe_fds[0], &buf);
     try std.testing.expectEqualSlices(u8, "\x1b[?9999;0$y", buf[0..private_len]);
 
@@ -502,11 +478,11 @@ test "stream answers unknown mode report queries" {
     // form (`$p`) is dropped by the parser before reaching the handler, so no
     // response is written. Verify via a non-blocking read instead of hanging
     // on a reply that can never arrive.
-    const flags = try std.posix.fcntl(pipe_fds[0], std.posix.F.GETFL, 0);
+    const flags = try posix_util.fcntl(pipe_fds[0], std.posix.F.GETFL, 0);
     var o_flags: std.posix.O = @bitCast(@as(u32, @intCast(flags)));
     o_flags.NONBLOCK = true;
-    _ = try std.posix.fcntl(pipe_fds[0], std.posix.F.SETFL, @as(u32, @bitCast(o_flags)));
-    try stream.nextSlice("\x1b[9999$p");
+    _ = try posix_util.fcntl(pipe_fds[0], std.posix.F.SETFL, @as(u32, @bitCast(o_flags)));
+    stream.nextSlice("\x1b[9999$p");
     try std.testing.expectError(error.WouldBlock, std.posix.read(pipe_fds[0], &buf));
 }
 
@@ -516,7 +492,7 @@ test "stream answers OSC 4 palette queries with the current terminal palette" {
     var palette = ghostty_vt.color.default;
     palette[17] = .{ .r = 0x12, .g = 0x34, .b = 0x56 };
 
-    var terminal = try ghostty_vt.Terminal.init(allocator, .{
+    var terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{
         .cols = 80,
         .rows = 24,
         .colors = .{
@@ -528,9 +504,10 @@ test "stream answers OSC 4 palette queries with the current terminal palette" {
     });
     defer terminal.deinit(allocator);
 
-    const pipe_fds = try std.posix.pipe();
-    defer std.posix.close(pipe_fds[0]);
-    defer std.posix.close(pipe_fds[1]);
+    var pipe_fds: [2]std.posix.fd_t = undefined;
+    try posix_util.pipe(&pipe_fds);
+    defer _ = std.c.close(pipe_fds[0]);
+    defer _ = std.c.close(pipe_fds[1]);
 
     var shell = shell_mod.Shell{
         .io = std.testing.io,
@@ -546,7 +523,7 @@ test "stream answers OSC 4 palette queries with the current terminal palette" {
 
     var buf: [128]u8 = undefined;
 
-    try stream.nextSlice("\x1b]4;17;?\x07");
+    stream.nextSlice("\x1b]4;17;?\x07");
     const len = try std.posix.read(pipe_fds[0], &buf);
     try std.testing.expectEqualSlices(u8, "\x1b]4;17;rgb:1212/3434/5656\x07", buf[0..len]);
 }
@@ -554,15 +531,16 @@ test "stream answers OSC 4 palette queries with the current terminal palette" {
 test "stream processes OSC 8 hyperlinks via nextSlice without error" {
     const allocator = std.testing.allocator;
 
-    var terminal = try ghostty_vt.Terminal.init(allocator, .{
+    var terminal = try ghostty_vt.Terminal.init(std.testing.io, allocator, .{
         .cols = 80,
         .rows = 24,
     });
     defer terminal.deinit(allocator);
 
-    const pipe_fds = try std.posix.pipe();
-    defer std.posix.close(pipe_fds[0]);
-    defer std.posix.close(pipe_fds[1]);
+    var pipe_fds: [2]std.posix.fd_t = undefined;
+    try posix_util.pipe(&pipe_fds);
+    defer _ = std.c.close(pipe_fds[0]);
+    defer _ = std.c.close(pipe_fds[1]);
 
     var shell = shell_mod.Shell{
         .io = std.testing.io,
@@ -579,7 +557,7 @@ test "stream processes OSC 8 hyperlinks via nextSlice without error" {
     // Delegated (non-explicit) VT actions such as hyperlink start/end and
     // print route through Handler.delegateVt; this exercises that path end
     // to end via the SIMD-capable nextSlice entry point.
-    try stream.nextSlice("\x1b]8;;http://example.com\x1b\\link text\x1b]8;;\x1b\\");
+    stream.nextSlice("\x1b]8;;http://example.com\x1b\\link text\x1b]8;;\x1b\\");
 
     try std.testing.expectEqual(@as(usize, 9), terminal.screens.active.cursor.x);
 }
@@ -591,5 +569,5 @@ pub fn initStream(
     terminal: *ghostty_vt.Terminal,
     shell: *shell_mod.Shell,
 ) StreamType {
-    return StreamType.initAlloc(alloc, Handler.init(terminal, shell));
+    return StreamType.init(.{ .allocator = alloc, .handler = Handler.init(terminal, shell) });
 }

--- a/src/vt_stream.zig
+++ b/src/vt_stream.zig
@@ -16,6 +16,7 @@ pub const Handler = struct {
     terminal: *ghostty_vt.Terminal,
     shell: *shell_mod.Shell,
     readonly: ReadonlyHandler,
+    semantic_failure: bool = false,
 
     pub fn init(terminal: *ghostty_vt.Terminal, shell: *shell_mod.Shell) Handler {
         return .{
@@ -35,8 +36,21 @@ pub const Handler = struct {
         value: ghostty_vt.StreamAction.Value(action),
     ) void {
         self.vtFallible(action, value) catch |err| {
-            log.warn("error handling VT action action={} err={}", .{ action, err });
+            switch (@as(anyerror, err)) {
+                error.HyperlinkSetOutOfMemory,
+                error.HyperlinkSetNeedsRehash,
+                error.HyperlinkMapOutOfMemory,
+                => log.warn("OSC 8 hyperlink capacity exhausted, hyperlink dropped: {}", .{err}),
+                else => {
+                    self.semantic_failure = true;
+                    log.warn("error handling VT action action={} err={}", .{ action, err });
+                },
+            }
         };
+    }
+
+    pub fn hasSemanticFailure(self: *const Handler) bool {
+        return self.semantic_failure or self.readonly.semantic_failure;
     }
 
     fn vtFallible(

--- a/src/vt_stream.zig
+++ b/src/vt_stream.zig
@@ -36,20 +36,16 @@ pub const Handler = struct {
         value: ghostty_vt.StreamAction.Value(action),
     ) void {
         self.vtFallible(action, value) catch |err| {
-            switch (@as(anyerror, err)) {
-                error.HyperlinkSetOutOfMemory,
-                error.HyperlinkSetNeedsRehash,
-                error.HyperlinkMapOutOfMemory,
-                => log.warn("OSC 8 hyperlink capacity exhausted, hyperlink dropped: {}", .{err}),
-                else => {
-                    self.semantic_failure = true;
-                    log.warn("error handling VT action action={} err={}", .{ action, err });
-                },
-            }
+            self.semantic_failure = true;
+            log.warn("error handling VT action action={} err={}", .{ action, err });
         };
     }
 
     pub fn hasSemanticFailure(self: *const Handler) bool {
+        // Ghostty's delegated handler exposes only this undifferentiated flag.
+        // Treat every delegated failure as fatal, including OSC 8 capacity
+        // exhaustion, because the current Ghostty API cannot distinguish it
+        // from terminal-state allocation failures.
         return self.semantic_failure or self.readonly.semantic_failure;
     }
 


### PR DESCRIPTION
## Issue

Architect must move from Zig 0.15.2 to Zig 0.16.0, including the dependency pins and build-script APIs that gate the migration.

## Solution

This PR spans Tasks 6-15 of the Zig 0.16.0 migration plan. Task 6 flips the flake toolchain pin and minimum Zig version, updates the four verified dependency hashes, renames the build graph environment map, and migrates build.zig SDK probing to std.Io and std.process.run.

## Context

CI is EXPECTED TO FAIL from this commit through Task 12, by design, because the codebase cannot build on both toolchains simultaneously mid-flip. The true green gate is Task 13. The remaining commits on this branch will complete Tasks 7-15 before this PR is merged.

## Test plan

- PASS: direct Zig 0.16.0 zig build --help
- PASS: build script format check with Zig 0.16.0
- EXPECTED FAIL: direct Zig 0.16.0 zig build baseline, with 6 source error diagnostics captured in .tmp/flip-errors.txt
- PASS: dependency resolution reached Architect source without ghostty, libxev, toml, or zwanzig dependency diagnostics
- DO NOT expect CI to be green until Task 13; do not poll CI for green at this intermediate task
