### PR TITLE
chore: clean up leftover Zig 0.15 references after the 0.16 migration

### DIFF
--- a/.air/cloud/startup.sh
+++ b/.air/cloud/startup.sh
@@ -139,7 +139,7 @@ build_sdl SDL_ttf "$sdl_ttf_version" "https://github.com/libsdl-org/SDL_ttf/arch
 
 export SDL3_INCLUDE_PATH="$sdl_prefix/include"
 export SDL3_TTF_INCLUDE_PATH="$sdl_prefix/include"
-# Zig 0.15's HTTP client cannot reliably use AIR Cloud's injected proxy, while
+# Zig's HTTP client cannot reliably use AIR Cloud's injected proxy, while
 # direct HTTPS works. Clear it after all curl/git provisioning has finished.
 unset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy
 touch "$profile"

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ zig-cache/
 zig-out/
 .zig-cache/
 .cache/
+zig-pkg/
 
 # zwanzig linter cache
 .zwanzig-cache/

--- a/Formula/architect.rb
+++ b/Formula/architect.rb
@@ -6,7 +6,7 @@ class Architect < Formula
   license "MIT"
 
   depends_on "pkg-config" => :build
-  depends_on "zig@0.15" => :build
+  depends_on "zig@0.16" => :build
   depends_on xcode: :build
   depends_on "sdl3"
   depends_on "sdl3_ttf"


### PR DESCRIPTION
## Issue

The Zig 0.16.0 migration (#376) landed and was merged, but a few things
outside the source tree still referenced the old 0.15 toolchain or lacked
housekeeping for a new build artifact:

- `Formula/architect.rb` still declared `depends_on "zig@0.15" => :build`,
  which would install the wrong compiler for anyone using the Homebrew
  formula going forward.
- `.air/cloud/startup.sh` had a comment blaming a proxy workaround on
  "Zig 0.15's HTTP client", which is now a stale/inaccurate version claim.
- Zig 0.16's local package fetch cache (`zig-pkg/`) has no `.gitignore`
  entry, so it shows up as untracked clutter after every build.

## Solution

- Bump the Homebrew formula to `depends_on "zig@0.16" => :build`. Homebrew's
  `zig@0.16` is currently an alias to the mainline `zig` formula (stable
  0.16.0), mirroring how `zig@0.15` was pinned before.
- Reword the startup script comment to drop the specific version claim,
  since there's no evidence the underlying proxy issue is tied to a
  particular Zig release — the actual `unset HTTP_PROXY ...` mitigation is
  left untouched.
- Add `zig-pkg/` to `.gitignore` next to the other Zig cache directories
  (`.zig-cache/`, `zig-cache/`, `.cache/`). Confirmed it's a deterministic,
  regenerable build cache (deleting it and rebuilding recreates it) rather
  than anything that should be committed.

## Context

Follow-up to #376 (Zig 0.16.0 migration), found while doing post-merge
wrap-up verification on a real macOS host.

## Test plan

- [ ] `brew install --build-from-source ./Formula/architect.rb` (or
      equivalent local formula audit) to confirm it resolves `zig@0.16`
      correctly.
