### PR TITLE
fix(metrics-overlay): request frames only when the sample interval elapsed

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,6 +140,8 @@ When enabled, press `Cmd+Shift+M` to toggle the metrics overlay in the bottom-ri
 - **Deferred/s and Skipped epochs/s**: Output-render deferrals and invisible output updates per second
 - **Cache full/s and partial/s**: Full and partial session-cache refreshes per second
 
+The overlay requests a frame only when its one-second sample is due, so opening it does not change the presented frame rate it reports (before this fix it forced vsync-rate presents).
+
 Metrics collection has zero overhead when disabled (no allocations, null pointer checks compile away).
 
 ### Logging Configuration

--- a/src/main.zig
+++ b/src/main.zig
@@ -71,6 +71,7 @@ test {
     _ = @import("ui/components/expanding_overlay.zig");
     _ = @import("ui/components/markdown_parser.zig");
     _ = @import("ui/components/markdown_renderer.zig");
+    _ = @import("ui/components/metrics_overlay.zig");
     _ = @import("ui/components/quit_blocking_overlay.zig");
     _ = @import("ui/components/recent_folders_overlay.zig");
     _ = @import("ui/components/pr_dropdown.zig");

--- a/src/ui/components/metrics_overlay.zig
+++ b/src/ui/components/metrics_overlay.zig
@@ -80,9 +80,15 @@ pub const MetricsOverlayComponent = struct {
 
     fn update(_: *anyopaque, _: *const types.UiHost, _: *types.UiActionQueue) void {}
 
-    fn wantsFrame(self_ptr: *anyopaque, _: *const types.UiHost) bool {
+    fn sampleDue(now_ms: i64, last_sample_ms: i64) bool {
+        return now_ms - last_sample_ms >= sample_interval_ms;
+    }
+
+    fn wantsFrame(self_ptr: *anyopaque, host: *const types.UiHost) bool {
         const self: *MetricsOverlayComponent = @ptrCast(@alignCast(self_ptr));
-        return self.first_frame.wantsFrame() or self.visible;
+        // The frame loop's 1 s idle ceiling wakes us to observe a due sample.
+        return self.first_frame.wantsFrame() or
+            (self.visible and sampleDue(host.now_ms, self.last_sample_ms));
     }
 
     fn render(self_ptr: *anyopaque, host: *const types.UiHost, renderer: *c.SDL_Renderer, assets: *types.UiAssets) void {
@@ -92,7 +98,7 @@ pub const MetricsOverlayComponent = struct {
         const metrics_ptr = metrics_mod.global orelse return;
 
         var needs_commit = false;
-        if (host.now_ms - self.last_sample_ms >= sample_interval_ms) {
+        if (sampleDue(host.now_ms, self.last_sample_ms)) {
             self.cached_elapsed_ms = metrics_ptr.sampleRates(host.now_ms);
             self.last_sample_ms = host.now_ms;
             self.dirty = true;
@@ -322,3 +328,19 @@ pub const MetricsOverlayComponent = struct {
         .wantsFrame = wantsFrame,
     };
 };
+
+test "metrics overlay samples only when its interval is due" {
+    const last_sample_ms: i64 = 1_000;
+    try std.testing.expect(!MetricsOverlayComponent.sampleDue(
+        last_sample_ms + MetricsOverlayComponent.sample_interval_ms - 1,
+        last_sample_ms,
+    ));
+    try std.testing.expect(MetricsOverlayComponent.sampleDue(
+        last_sample_ms + MetricsOverlayComponent.sample_interval_ms,
+        last_sample_ms,
+    ));
+    try std.testing.expect(MetricsOverlayComponent.sampleDue(
+        MetricsOverlayComponent.sample_interval_ms,
+        0,
+    ));
+}


### PR DESCRIPTION
## Issue

The metrics overlay forces vsync-rate presents while open and distorts its own Present/s reading.

## Solution

MetricsOverlayComponent now shares a pure sampleDue helper between wantsFrame and render. It preserves FirstFrameGuard's immediate transition frame, but requests further frames only when the one-second sample interval has elapsed. The test registry includes the new helper test, and configuration docs explain the demand behavior.

## Context

Measured today: Loop/s 120 / Present/s 120 with the overlay open versus <= 30 without it. src/app/frame_schedule.zig treats ui_wants_frame as continuous demand, so the overlay's former always-true wantsFrame forced vsync-paced presents and distorted the rates it displayed.

## Test plan

Manual macOS check: open the overlay over an idle shell, confirm it still refreshes every second and Present/s reads ~1; open it over an unattended spinner session and confirm Present/s stays <= ~30.