### PR TITLE
Resolve gh for GUI launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Common settings include font family, theme colors, grid font scale, and logging 
 * **Font not found**: ensure the font is installed and set `font.family` in `config.toml`. The app falls back to `SFNSMono` on macOS.
 * **Missing symbol glyphs**: fallbacks try the bundled Symbols Nerd Font, then `Arial Unicode MS`, then `STIXTwoMath` (if available) before emoji.
 * **Emoji alignment**: single-codepoint emoji are centered using glyph metrics; if they appear off, try a different primary font or font size.
+* **Pull request list says to install `gh`**: Architect checks the inherited `PATH` and the standard Homebrew locations `/opt/homebrew/bin/gh` and `/usr/local/bin/gh`. If `gh` is installed elsewhere, make its executable path available to the app or use a standard Homebrew installation.
 * **Reset configuration**: delete `~/.config/architect/config.toml` and `~/.config/architect/persistence.toml`.
 * **Crash after closing a terminal**: update to the latest build; older builds could crash after terminal close events on macOS.
 * **Known limitations**: emoji fallback is macOS-only; keybindings are currently fixed.

--- a/src/ui/components/pr_dropdown_fetch.zig
+++ b/src/ui/components/pr_dropdown_fetch.zig
@@ -166,11 +166,14 @@ test "gh resolver finds a known location when PATH omits it" {
     file.close(io);
     const directory = try tmp.dir.realPathFileAlloc(io, ".", allocator);
     defer allocator.free(directory);
+    try tmp.dir.createDir(io, "empty-path", .default_dir);
+    const path_directory = try tmp.dir.realPathFileAlloc(io, "empty-path", allocator);
+    defer allocator.free(path_directory);
     const expected = try std.fs.path.join(allocator, &.{ directory, "gh" });
     defer allocator.free(expected);
     const known_paths = [_][]const u8{expected};
 
-    const resolved = try resolveExecutablePath(allocator, io, "/usr/bin:/bin", "gh", &known_paths);
+    const resolved = try resolveExecutablePath(allocator, io, path_directory, "gh", &known_paths);
     try std.testing.expect(resolved != null);
     defer allocator.free(resolved.?);
     try std.testing.expectEqualStrings(expected, resolved.?);

--- a/src/ui/components/pr_dropdown_fetch.zig
+++ b/src/ui/components/pr_dropdown_fetch.zig
@@ -7,7 +7,7 @@ const proc = @import("../../proc.zig");
 const log = std.log.scoped(.pr_dropdown);
 pub const gh_output_log_preview_limit: usize = 2 * 1024;
 
-const ResolveExecutableError = std.Io.Dir.AccessError || std.mem.Allocator.Error;
+const ResolveExecutableError = std.Io.Dir.AccessError || std.Io.Dir.RealPathFileAllocError;
 const known_gh_paths: []const []const u8 = if (builtin.os.tag == .macos)
     &.{ "/opt/homebrew/bin/gh", "/usr/local/bin/gh" }
 else
@@ -110,9 +110,10 @@ fn resolveExecutablePath(
 
         const candidate = try std.fs.path.join(allocator, &.{ directory, name });
         if (std.Io.Dir.cwd().access(io, candidate, .{ .execute = true })) |_| {
-            return candidate;
+            defer allocator.free(candidate);
+            return try canonicalizeExecutablePath(allocator, io, candidate);
         } else |err| switch (err) {
-            error.FileNotFound => allocator.free(candidate),
+            error.FileNotFound, error.AccessDenied, error.PermissionDenied => allocator.free(candidate),
             else => {
                 allocator.free(candidate);
                 return err;
@@ -122,13 +123,23 @@ fn resolveExecutablePath(
 
     for (known_paths) |candidate| {
         std.Io.Dir.cwd().access(io, candidate, .{ .execute = true }) catch |err| switch (err) {
-            error.FileNotFound => continue,
+            error.FileNotFound, error.AccessDenied, error.PermissionDenied => continue,
             else => return err,
         };
-        return @as(?[]u8, try allocator.dupe(u8, candidate));
+        return @as(?[]u8, try canonicalizeExecutablePath(allocator, io, candidate));
     }
 
     return null;
+}
+
+fn canonicalizeExecutablePath(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    candidate: []const u8,
+) ResolveExecutableError![]u8 {
+    const canonical = try std.Io.Dir.cwd().realPathFileAlloc(io, candidate, allocator);
+    defer allocator.free(canonical);
+    return try allocator.dupe(u8, canonical);
 }
 
 test "gh resolver finds an executable in PATH" {
@@ -150,6 +161,33 @@ test "gh resolver finds an executable in PATH" {
     const resolved = try resolveExecutablePath(allocator, io, directory, "gh", &.{});
     try std.testing.expect(resolved != null);
     defer allocator.free(resolved.?);
+    try std.testing.expectEqualStrings(expected, resolved.?);
+}
+
+test "gh resolver canonicalizes relative PATH entries" {
+    const allocator = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile(io, "gh", .{ .permissions = .fromMode(0o755) });
+    file.close(io);
+    const directory = try tmp.dir.realPathFileAlloc(io, ".", allocator);
+    defer allocator.free(directory);
+    const current_directory = try std.Io.Dir.cwd().realPathFileAlloc(io, ".", allocator);
+    defer allocator.free(current_directory);
+    const relative_directory = try std.fs.path.relative(allocator, current_directory, null, current_directory, directory);
+    defer allocator.free(relative_directory);
+    const expected = try std.fs.path.join(allocator, &.{ directory, "gh" });
+    defer allocator.free(expected);
+
+    const resolved = try resolveExecutablePath(allocator, io, relative_directory, "gh", &.{});
+    try std.testing.expect(resolved != null);
+    defer allocator.free(resolved.?);
+    try std.testing.expect(std.fs.path.isAbsolute(resolved.?));
     try std.testing.expectEqualStrings(expected, resolved.?);
 }
 
@@ -196,6 +234,45 @@ test "gh resolver reports no executable when PATH and known locations are empty"
 
     const resolved = try resolveExecutablePath(allocator, io, "", "gh", &known_paths);
     try std.testing.expectEqual(@as(?[]u8, null), resolved);
+}
+
+test "gh resolver skips inaccessible PATH and known candidates" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var path_tmp = std.testing.tmpDir(.{});
+    defer path_tmp.cleanup();
+    var path_file = try path_tmp.dir.createFile(io, "gh", .{ .permissions = .fromMode(0o644) });
+    path_file.close(io);
+    const path_directory = try path_tmp.dir.realPathFileAlloc(io, ".", allocator);
+    defer allocator.free(path_directory);
+    const inaccessible_path = try std.fs.path.join(allocator, &.{ path_directory, "gh" });
+    defer allocator.free(inaccessible_path);
+
+    var fallback_tmp = std.testing.tmpDir(.{});
+    defer fallback_tmp.cleanup();
+    var fallback_file = try fallback_tmp.dir.createFile(io, "gh", .{ .permissions = .fromMode(0o755) });
+    fallback_file.close(io);
+    const fallback_directory = try fallback_tmp.dir.realPathFileAlloc(io, ".", allocator);
+    defer allocator.free(fallback_directory);
+    const fallback_path = try std.fs.path.join(allocator, &.{ fallback_directory, "gh" });
+    defer allocator.free(fallback_path);
+    const fallback_only = [_][]const u8{fallback_path};
+
+    const from_path = try resolveExecutablePath(allocator, io, path_directory, "gh", &fallback_only);
+    try std.testing.expect(from_path != null);
+    defer allocator.free(from_path.?);
+    try std.testing.expectEqualStrings(fallback_path, from_path.?);
+
+    const known_paths = [_][]const u8{ inaccessible_path, fallback_path };
+    const from_known_paths = try resolveExecutablePath(allocator, io, "", "gh", &known_paths);
+    try std.testing.expect(from_known_paths != null);
+    defer allocator.free(from_known_paths.?);
+    try std.testing.expectEqualStrings(fallback_path, from_known_paths.?);
 }
 
 fn logGhOutputPreview(comptime stream_name: []const u8, bytes: []const u8) void {

--- a/src/ui/components/pr_dropdown_fetch.zig
+++ b/src/ui/components/pr_dropdown_fetch.zig
@@ -109,19 +109,13 @@ fn resolveExecutablePath(
         if (directory.len == 0) continue;
 
         const candidate = try std.fs.path.join(allocator, &.{ directory, name });
+        defer allocator.free(candidate);
         if (std.Io.Dir.cwd().access(io, candidate, .{ .execute = true })) |_| {
-            if (!try isRegularFile(io, candidate)) {
-                allocator.free(candidate);
-                continue;
-            }
-            defer allocator.free(candidate);
+            if (!try isRegularFile(io, candidate)) continue;
             return try canonicalizeExecutablePath(allocator, io, candidate);
         } else |err| switch (err) {
-            error.FileNotFound, error.AccessDenied, error.PermissionDenied => allocator.free(candidate),
-            else => {
-                allocator.free(candidate);
-                return err;
-            },
+            error.FileNotFound, error.AccessDenied, error.PermissionDenied => {},
+            else => return err,
         }
     }
 

--- a/src/ui/components/pr_dropdown_fetch.zig
+++ b/src/ui/components/pr_dropdown_fetch.zig
@@ -7,7 +7,7 @@ const proc = @import("../../proc.zig");
 const log = std.log.scoped(.pr_dropdown);
 pub const gh_output_log_preview_limit: usize = 2 * 1024;
 
-const ResolveExecutableError = std.Io.Dir.AccessError || std.Io.Dir.RealPathFileAllocError;
+const ResolveExecutableError = std.Io.Dir.AccessError || std.Io.Dir.StatFileError || std.Io.Dir.RealPathFileAllocError;
 const known_gh_paths: []const []const u8 = if (builtin.os.tag == .macos)
     &.{ "/opt/homebrew/bin/gh", "/usr/local/bin/gh" }
 else
@@ -110,6 +110,10 @@ fn resolveExecutablePath(
 
         const candidate = try std.fs.path.join(allocator, &.{ directory, name });
         if (std.Io.Dir.cwd().access(io, candidate, .{ .execute = true })) |_| {
+            if (!try isRegularFile(io, candidate)) {
+                allocator.free(candidate);
+                continue;
+            }
             defer allocator.free(candidate);
             return try canonicalizeExecutablePath(allocator, io, candidate);
         } else |err| switch (err) {
@@ -126,10 +130,19 @@ fn resolveExecutablePath(
             error.FileNotFound, error.AccessDenied, error.PermissionDenied => continue,
             else => return err,
         };
+        if (!try isRegularFile(io, candidate)) continue;
         return @as(?[]u8, try canonicalizeExecutablePath(allocator, io, candidate));
     }
 
     return null;
+}
+
+fn isRegularFile(io: std.Io, candidate: []const u8) ResolveExecutableError!bool {
+    const stat = std.Io.Dir.cwd().statFile(io, candidate, .{ .follow_symlinks = true }) catch |err| switch (err) {
+        error.FileNotFound, error.AccessDenied, error.PermissionDenied => return false,
+        else => return err,
+    };
+    return stat.kind == .file;
 }
 
 fn canonicalizeExecutablePath(
@@ -269,6 +282,42 @@ test "gh resolver skips inaccessible PATH and known candidates" {
     try std.testing.expectEqualStrings(fallback_path, from_path.?);
 
     const known_paths = [_][]const u8{ inaccessible_path, fallback_path };
+    const from_known_paths = try resolveExecutablePath(allocator, io, "", "gh", &known_paths);
+    try std.testing.expect(from_known_paths != null);
+    defer allocator.free(from_known_paths.?);
+    try std.testing.expectEqualStrings(fallback_path, from_known_paths.?);
+}
+
+test "gh resolver skips directory PATH and known candidates" {
+    const allocator = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var path_tmp = std.testing.tmpDir(.{});
+    defer path_tmp.cleanup();
+    try path_tmp.dir.createDir(io, "gh", .default_dir);
+    const path_directory = try path_tmp.dir.realPathFileAlloc(io, ".", allocator);
+    defer allocator.free(path_directory);
+    const directory_path = try std.fs.path.join(allocator, &.{ path_directory, "gh" });
+    defer allocator.free(directory_path);
+
+    var fallback_tmp = std.testing.tmpDir(.{});
+    defer fallback_tmp.cleanup();
+    var fallback_file = try fallback_tmp.dir.createFile(io, "gh", .{ .permissions = .fromMode(0o755) });
+    fallback_file.close(io);
+    const fallback_directory = try fallback_tmp.dir.realPathFileAlloc(io, ".", allocator);
+    defer allocator.free(fallback_directory);
+    const fallback_path = try std.fs.path.join(allocator, &.{ fallback_directory, "gh" });
+    defer allocator.free(fallback_path);
+    const fallback_only = [_][]const u8{fallback_path};
+
+    const from_path = try resolveExecutablePath(allocator, io, path_directory, "gh", &fallback_only);
+    try std.testing.expect(from_path != null);
+    defer allocator.free(from_path.?);
+    try std.testing.expectEqualStrings(fallback_path, from_path.?);
+
+    const known_paths = [_][]const u8{ directory_path, fallback_path };
     const from_known_paths = try resolveExecutablePath(allocator, io, "", "gh", &known_paths);
     try std.testing.expect(from_known_paths != null);
     defer allocator.free(from_known_paths.?);

--- a/src/ui/components/pr_dropdown_fetch.zig
+++ b/src/ui/components/pr_dropdown_fetch.zig
@@ -1,9 +1,17 @@
 const std = @import("std");
+const builtin = @import("builtin");
+const env = @import("../../env.zig");
 const model = @import("pr_dropdown_model.zig");
 const proc = @import("../../proc.zig");
 
 const log = std.log.scoped(.pr_dropdown);
 pub const gh_output_log_preview_limit: usize = 2 * 1024;
+
+const ResolveExecutableError = std.Io.Dir.AccessError || std.mem.Allocator.Error;
+const known_gh_paths: []const []const u8 = if (builtin.os.tag == .macos)
+    &.{ "/opt/homebrew/bin/gh", "/usr/local/bin/gh" }
+else
+    &.{};
 
 const GhOutputPreview = struct {
     len: usize,
@@ -11,8 +19,23 @@ const GhOutputPreview = struct {
 };
 
 pub fn runGhPrList(allocator: std.mem.Allocator, io: std.Io, cwd: []const u8) model.FetchResult {
+    const gh_path = resolveGhPath(allocator, io) catch |err| {
+        log.err("failed to locate gh while listing pull requests: cwd={s} error={s}", .{ cwd, @errorName(err) });
+        return buildFetchError(allocator, "Failed to locate gh: {s}", .{@errorName(err)});
+    } orelse {
+        log.err("gh CLI not found in PATH or known locations while listing pull requests: cwd={s}", .{cwd});
+        return model.FetchResult{
+            .status = .gh_missing,
+            .prs = &[_]model.PullRequest{},
+            .error_message = null,
+        };
+    };
+    defer allocator.free(gh_path);
+
+    log.debug("using gh CLI at {s} while listing pull requests: cwd={s}", .{ gh_path, cwd });
+
     const argv = [_][]const u8{
-        "gh",      "pr",     "list",
+        gh_path,   "pr",     "list",
         "--state", "open",   "--limit",
         "30",      "--json", "number,title,headRefName",
     };
@@ -21,7 +44,7 @@ pub fn runGhPrList(allocator: std.mem.Allocator, io: std.Io, cwd: []const u8) mo
         .cwd = cwd,
     }) catch |err| {
         if (err == error.FileNotFound) {
-            log.err("gh CLI not found while listing pull requests: cwd={s}", .{cwd});
+            log.err("gh CLI disappeared while listing pull requests: path={s} cwd={s}", .{ gh_path, cwd });
             return model.FetchResult{
                 .status = .gh_missing,
                 .prs = &[_]model.PullRequest{},
@@ -61,6 +84,115 @@ pub fn runGhPrList(allocator: std.mem.Allocator, io: std.Io, cwd: []const u8) mo
         logGhOutputPreview("stdout", result.stdout);
     }
     return fetch_result;
+}
+
+fn resolveGhPath(allocator: std.mem.Allocator, io: std.Io) ResolveExecutableError!?[]u8 {
+    const path_env = env.get("PATH");
+    return resolveExecutablePath(
+        allocator,
+        io,
+        if (path_env) |path| std.mem.sliceTo(path, 0) else "",
+        "gh",
+        known_gh_paths,
+    );
+}
+
+fn resolveExecutablePath(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    path_env: []const u8,
+    name: []const u8,
+    known_paths: []const []const u8,
+) ResolveExecutableError!?[]u8 {
+    var path_it = std.mem.splitScalar(u8, path_env, ':');
+    while (path_it.next()) |directory| {
+        if (directory.len == 0) continue;
+
+        const candidate = try std.fs.path.join(allocator, &.{ directory, name });
+        if (std.Io.Dir.cwd().access(io, candidate, .{ .execute = true })) |_| {
+            return candidate;
+        } else |err| switch (err) {
+            error.FileNotFound => allocator.free(candidate),
+            else => {
+                allocator.free(candidate);
+                return err;
+            },
+        }
+    }
+
+    for (known_paths) |candidate| {
+        std.Io.Dir.cwd().access(io, candidate, .{ .execute = true }) catch |err| switch (err) {
+            error.FileNotFound => continue,
+            else => return err,
+        };
+        return @as(?[]u8, try allocator.dupe(u8, candidate));
+    }
+
+    return null;
+}
+
+test "gh resolver finds an executable in PATH" {
+    const allocator = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile(io, "gh", .{ .permissions = .fromMode(0o755) });
+    file.close(io);
+    const directory = try tmp.dir.realPathFileAlloc(io, ".", allocator);
+    defer allocator.free(directory);
+    const expected = try std.fs.path.join(allocator, &.{ directory, "gh" });
+    defer allocator.free(expected);
+
+    const resolved = try resolveExecutablePath(allocator, io, directory, "gh", &.{});
+    try std.testing.expect(resolved != null);
+    defer allocator.free(resolved.?);
+    try std.testing.expectEqualStrings(expected, resolved.?);
+}
+
+test "gh resolver finds a known location when PATH omits it" {
+    const allocator = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile(io, "gh", .{ .permissions = .fromMode(0o755) });
+    file.close(io);
+    const directory = try tmp.dir.realPathFileAlloc(io, ".", allocator);
+    defer allocator.free(directory);
+    const expected = try std.fs.path.join(allocator, &.{ directory, "gh" });
+    defer allocator.free(expected);
+    const known_paths = [_][]const u8{expected};
+
+    const resolved = try resolveExecutablePath(allocator, io, "/usr/bin:/bin", "gh", &known_paths);
+    try std.testing.expect(resolved != null);
+    defer allocator.free(resolved.?);
+    try std.testing.expectEqualStrings(expected, resolved.?);
+}
+
+test "gh resolver reports no executable when PATH and known locations are empty" {
+    const allocator = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const directory = try tmp.dir.realPathFileAlloc(io, ".", allocator);
+    defer allocator.free(directory);
+    const missing = try std.fs.path.join(allocator, &.{ directory, "missing-gh" });
+    defer allocator.free(missing);
+    const known_paths = [_][]const u8{missing};
+
+    const resolved = try resolveExecutablePath(allocator, io, "", "gh", &known_paths);
+    try std.testing.expectEqual(@as(?[]u8, null), resolved);
 }
 
 fn logGhOutputPreview(comptime stream_name: []const u8, bytes: []const u8) void {


### PR DESCRIPTION
## Issue

When Architect is launched as a macOS GUI application, launchd provides a minimal `PATH`. A Homebrew-installed `gh` is therefore not found by the PR dropdown, which incorrectly displays the instruction to install GitHub CLI.

## Solution

Resolve `gh` from the inherited `PATH`, then check the standard macOS Homebrew locations `/opt/homebrew/bin/gh` and `/usr/local/bin/gh`. Pass the resolved absolute path to the PR-list subprocess while preserving the existing missing-executable handling.

The resolver is covered by tests, and the README documents the supported locations. Terminal-launched behavior and PR checkout handling remain unchanged.

## Context

This is a temporary compatibility fix until the planned built-in GitHub API client replaces the `gh` dependency.

## Test plan

- [ ] Launch Architect from Finder or the Dock, with `gh` installed by Homebrew, and verify that the PR dropdown lists open pull requests.
