### PR TITLE
fix(homebrew): provide SDL headers to Zig translation

### DIFF
--- a/Formula/architect.rb
+++ b/Formula/architect.rb
@@ -6,12 +6,17 @@ class Architect < Formula
   license "MIT"
 
   depends_on "pkg-config" => :build
-  depends_on "zig@0.16" => :build
   depends_on xcode: :build
+  depends_on "zig@0.16" => :build
   depends_on "sdl3"
   depends_on "sdl3_ttf"
 
   def install
+    # addTranslateC does not discover Homebrew dependency headers through the
+    # linker search path, so provide the include roots explicitly.
+    ENV["SDL3_INCLUDE_PATH"] = formula_opt_include("sdl3").to_s
+    ENV["SDL3_TTF_INCLUDE_PATH"] = formula_opt_include("sdl3_ttf").to_s
+
     # Zig 0.16.0 cannot translate Apple headers against the arm64e-only SDK
     # shipped with recent macOS toolchains. Source the helper in the same
     # shell as the build so its SDK selection reaches every compiler step.
@@ -25,7 +30,6 @@ class Architect < Formula
     contents = app_path/"Contents"
     macos = contents/"MacOS"
     resources = contents/"Resources"
-    share = contents/"share/architect"
 
     macos.mkpath
     resources.mkpath

--- a/docs/development.md
+++ b/docs/development.md
@@ -77,8 +77,10 @@ SDL3 and the platform C APIs are translated at build time with Zig's built-in
 `addTranslateC` steps using the small header shims under `src/c/`. When SDL is
 provided outside the compiler's default search paths, `SDL3_INCLUDE_PATH` and
 `SDL3_TTF_INCLUDE_PATH` supply the include paths to both translation and
-compilation. On macOS, framework headers use the SDK path discovered from
-`SDKROOT`, `DEVELOPER_DIR`, or `xcrun`, in that order.
+compilation. The Homebrew formula sets these variables from the installed SDL
+formula prefixes before starting the build. On macOS, framework headers use
+the SDK path discovered from `SDKROOT`, `DEVELOPER_DIR`, or `xcrun`, in that
+order.
 
 ## Tests and Formatting
 


### PR DESCRIPTION
## Issue

Homebrew source installation fails after the Zig 0.16 C translation migration because `addTranslateC` cannot find the SDL3 headers in Homebrew's dependency prefixes.

## Solution

The formula exports the stable include roots for SDL3 and SDL3_ttf before invoking Zig. The existing build configuration then applies those paths to both C translation and compilation. The development documentation now records this packaging requirement.

## Context

The fix complements the existing macOS SDK workaround used by the Homebrew formula.
